### PR TITLE
chore: Bump version to 0.2.0-beta.3 for NuGet publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [0.2.0-beta.3] - 2026-06-07
 ### Added
 - Added overloads to the `Decode` method to remove the array requirement. (#39)
 - Added support for RETURNING clause. (#41)

--- a/src/SqlArtisan/SqlArtisan.csproj
+++ b/src/SqlArtisan/SqlArtisan.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
 
     <VersionPrefix>0.2.0</VersionPrefix>
-    <VersionSuffix>beta.2</VersionSuffix>
+    <VersionSuffix>beta.3</VersionSuffix>
     <Copyright>Copyright (c) h.tacayama 2025</Copyright>
 
     <Authors>h.tacayama</Authors>


### PR DESCRIPTION
## Summary

Bumps the package version from `0.2.0-beta.2` to `0.2.0-beta.3` in preparation for NuGet publication.

This release includes the changes that had accumulated under `[Unreleased]`:

- Added overloads to the `Decode` method to remove the array requirement. (#39)
- Added support for the `RETURNING` clause. (#41)

## Changes

- `src/SqlArtisan/SqlArtisan.csproj`: `VersionSuffix` `beta.2` → `beta.3`
- `CHANGELOG.md`: moved the `[Unreleased]` entries into a new `[0.2.0-beta.3] - 2026-06-07` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
