### PR TITLE
perf: Optimize SqlBuildingBuffer allocation and throughput (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Improved `SqlBuildingBuffer` memory efficiency and throughput. (#45)
 
 ## [0.2.0-beta.3] - 2026-06-07
 ### Added

--- a/README.md
+++ b/README.md
@@ -294,15 +294,15 @@ To illustrate this, we benchmarked our `ArrayPool<T>`-based internal string buil
 
 | Method                               |            Mean |     Allocated |
 | :----------------------------------- | --------------: | ------------: |
-| StringBuilder_DapperDynamicParams    |      206.5 ns   |     1.38 KB   |
-| DapperQbNet_NoParams                 |    2,700.3 ns   |     7.47 KB   |
-| DapperSqlBuilder_DapperDynamicParams |    1,333.3 ns   |     5.12 KB   |
-| InterpolatedSql_SpecificParams       |    1,568.4 ns   |     5.17 KB   |
-| SqExpress_NoParams                   |    2,091.0 ns   |     4.56 KB   |
-| Sqlify_SpecificParams                |    1,001.6 ns   |     3.13 KB   |
-| SqlKata_SpecificParams               |   29,072.0 ns   |    40.54 KB   |
-| **SqlArtisan_SpecificParams**        |  **1,433.0 ns** |   **2.66 KB** |
-| **SqlArtisan_DapperDynamicParams**   |  **1,568.5 ns** |   **3.23 KB** |
+| StringBuilder_DapperDynamicParams    |      208.2 ns   |     1.38 KB   |
+| DapperQbNet_NoParams                 |    2,699.1 ns   |     7.47 KB   |
+| DapperSqlBuilder_DapperDynamicParams |    1,317.4 ns   |     5.12 KB   |
+| InterpolatedSql_SpecificParams       |    1,599.4 ns   |     5.17 KB   |
+| SqExpress_NoParams                   |    2,263.3 ns   |     4.65 KB   |
+| Sqlify_SpecificParams                |      987.5 ns   |     3.13 KB   |
+| SqlKata_SpecificParams               |   29,736.3 ns   |    40.54 KB   |
+| **SqlArtisan_SpecificParams**        |  **1,344.6 ns** |   **2.46 KB** |
+| **SqlArtisan_DapperDynamicParams**   |  **1,444.3 ns** |   **3.02 KB** |
 
 ### Disclaimer
 

--- a/src/SqlArtisan/Internal/SqlBuilder/DbmsDialect/DbmsDialectFactory.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/DbmsDialect/DbmsDialectFactory.cs
@@ -2,15 +2,23 @@ namespace SqlArtisan.Internal;
 
 internal static class DbmsDialectFactory
 {
+    // Dialects are stateless, so a single cached instance per DBMS is shared
+    // across all builds to avoid allocating one on every Build() call.
+    private static readonly MySqlDialect s_mySql = new();
+    private static readonly OracleDialect s_oracle = new();
+    private static readonly PostgreSqlDialect s_postgreSql = new();
+    private static readonly SqliteDialect s_sqlite = new();
+    private static readonly SqlServerDialect s_sqlServer = new();
+
     internal static IDbmsDialect Create(Dbms dbmsType)
     {
         return dbmsType switch
         {
-            Dbms.MySql => new MySqlDialect(),
-            Dbms.Oracle => new OracleDialect(),
-            Dbms.PostgreSql => new PostgreSqlDialect(),
-            Dbms.Sqlite => new SqliteDialect(),
-            Dbms.SqlServer => new SqlServerDialect(),
+            Dbms.MySql => s_mySql,
+            Dbms.Oracle => s_oracle,
+            Dbms.PostgreSql => s_postgreSql,
+            Dbms.Sqlite => s_sqlite,
+            Dbms.SqlServer => s_sqlServer,
             _ => throw new ArgumentOutOfRangeException(nameof(dbmsType), dbmsType, "Unsupported DBMS.")
         };
     }

--- a/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
@@ -1,6 +1,5 @@
 using System.Buffers;
 using System.Data;
-using System.Text;
 
 namespace SqlArtisan.Internal;
 
@@ -20,15 +19,21 @@ internal sealed class SqlBuildingBuffer : IDisposable
         _position = 0;
     }
 
-    ~SqlBuildingBuffer()
-    {
-        Dispose(false);
-    }
-
     public void Dispose()
     {
-        Dispose(true);
-        GC.SuppressFinalize(this);
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (_buffer != null)
+        {
+            ArrayPool<char>.Shared.Return(_buffer);
+            _buffer = null!;
+        }
+
+        _parameters = null!;
+        _disposed = true;
     }
 
     internal SqlBuildingBuffer Append(SqlPart part)
@@ -96,7 +101,7 @@ internal sealed class SqlBuildingBuffer : IDisposable
 
     internal SqlBuildingBuffer AppendSpace()
     {
-        Append(" ");
+        Append(' ');
         return this;
     }
 
@@ -146,28 +151,25 @@ internal sealed class SqlBuildingBuffer : IDisposable
             return this;
         }
 
-        StringBuilder builder = new();
-
         for (int i = 0; i < text.Length; i++)
         {
             char c = text[i];
 
             if (i > 0 && char.IsUpper(c))
             {
-                builder.Append('_');
+                Append('_');
             }
 
-            builder.Append(char.ToUpper(c));
+            Append(char.ToUpperInvariant(c));
         }
 
-        Append(builder.ToString());
         return this;
     }
 
     internal SqlBuildingBuffer CloseParenthesis(SqlPart? part = null)
     {
         part?.Format(this);
-        Append(")");
+        Append(')');
         return this;
     }
 
@@ -181,23 +183,23 @@ internal sealed class SqlBuildingBuffer : IDisposable
 
     internal SqlBuildingBuffer EncloseInParentheses(SqlPart part)
     {
-        Append("(");
+        Append('(');
         part.Format(this);
-        Append(")");
+        Append(')');
         return this;
     }
 
     internal SqlBuildingBuffer EncloseInSpaces(string value)
     {
-        Append(" ");
+        Append(' ');
         Append(value);
-        Append(" ");
+        Append(' ');
         return this;
     }
 
     internal SqlBuildingBuffer OpenParenthesis(SqlPart? part = null)
     {
-        Append("(");
+        Append('(');
         part?.Format(this);
         return this;
     }
@@ -271,31 +273,13 @@ internal sealed class SqlBuildingBuffer : IDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        // Pass a copy of _parameter to ensure
-        // the original reference is not retained by the caller.
+        // Transfer ownership of the parameter dictionary to the SqlStatement.
+        // The buffer relinquishes its reference so the caller's instance is
+        // never mutated after this point (Dispose only returns the char buffer).
         string sql = new(_buffer, 0, _position);
-        Dictionary<string, BindValue> parametersCopy = new(_parameters);
-        return new(sql, parametersCopy);
-    }
-
-    private void Dispose(bool disposing)
-    {
-        if (!_disposed)
-        {
-            if (disposing)
-            {
-                if (_buffer != null)
-                {
-                    ArrayPool<char>.Shared.Return(_buffer);
-                    _buffer = null!;
-                }
-
-                _parameters.Clear();
-                _parameters = null!;
-            }
-
-            _disposed = true;
-        }
+        Dictionary<string, BindValue> parameters = _parameters;
+        _parameters = null!;
+        return new(sql, parameters);
     }
 
     private void AppendSelectItem(SqlPart selectItem)
@@ -308,6 +292,13 @@ internal sealed class SqlBuildingBuffer : IDisposable
         {
             selectItem.Format(this);
         }
+    }
+
+    private SqlBuildingBuffer Append(char value)
+    {
+        EnsureCapacity(1);
+        _buffer[_position++] = value;
+        return this;
     }
 
     private SqlBuildingBuffer Append(ReadOnlySpan<char> value)

--- a/tests/SqlArtisan.Benchmark/Program.cs
+++ b/tests/SqlArtisan.Benchmark/Program.cs
@@ -1,4 +1,5 @@
 ﻿using BenchmarkDotNet.Running;
-using SqlArtisan.Benchmark;
 
-BenchmarkRunner.Run<SqlBuilderBenchmarks>();
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);

--- a/tests/SqlArtisan.Benchmark/SqlArtisan.Benchmark.csproj
+++ b/tests/SqlArtisan.Benchmark/SqlArtisan.Benchmark.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="Dapper.Qb.Net" Version="0.20.5" />
     <PackageReference Include="Dapper.SqlBuilder" Version="2.1.66" />
-    <PackageReference Include="InterpolatedSql" Version="2.4.0" />
-    <PackageReference Include="SqExpress" Version="1.1.1" />
+    <PackageReference Include="InterpolatedSql" Version="2.5.1" />
+    <PackageReference Include="SqExpress" Version="1.2.0" />
     <PackageReference Include="Sqlify" Version="0.3.14" />
     <PackageReference Include="SqlKata" Version="4.0.1" />
   </ItemGroup>

--- a/tests/SqlArtisan.Benchmark/SqlBuildingBufferBenchmark.cs
+++ b/tests/SqlArtisan.Benchmark/SqlBuildingBufferBenchmark.cs
@@ -1,0 +1,38 @@
+using BenchmarkDotNet.Attributes;
+using SqlArtisan.Benchmark.SqlArtisanTable;
+using static SqlArtisan.Sql;
+
+namespace SqlArtisan.Benchmark;
+
+// Isolates the SqlBuildingBuffer/format path: the SqlPart tree is built once in
+// [GlobalSetup], and only .Build() (dialect creation + buffer formatting + string
+// + parameter dictionary) is measured in the loop.
+[MemoryDiagnoser]
+public class SqlBuildingBufferBenchmark
+{
+    private ISqlBuilder _builder = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Users u = new("u");
+        Orders o = new("o");
+
+        _builder =
+            Select(
+                u.Id.As("user_id"),
+                u.Name.As("user_name"),
+                Count(o.Id).As("order_count"))
+            .From(u)
+            .InnerJoin(o)
+            .On(u.Id == o.UserId)
+            .Where(
+                o.OrderDate >= new DateTime(2024, 1, 1)
+                & o.OrderDate < new DateTime(2025, 1, 1))
+            .GroupBy(u.Id, u.Name)
+            .OrderBy(Count(o.Id).As("order_count").Desc);
+    }
+
+    [Benchmark]
+    public SqlStatement Build() => _builder.Build();
+}


### PR DESCRIPTION
Closes #45

## Summary

Optimizes `SqlBuildingBuffer`, which sits on the hot path of every `Build()` call, for both allocation and throughput.

## Changes

- **Remove the no-op finalizer + simplify `Dispose`** — the finalizer never returned the pooled buffer; it only added GC finalization overhead.
- **`ToSqlStatement`: transfer ownership of the parameter dictionary** instead of copying it.
- **Add an `Append(char)` overload** for the frequent single-char appends (`(`, `)`, space).
- **`AppendUpperSnakeCase`: write directly into the pooled buffer** instead of allocating a `StringBuilder` + `ToString()`; use `ToUpperInvariant` (correctness + speed).
- **Cache stateless DBMS dialect instances** instead of allocating one per `Build()`.

## Tooling

- Add an isolated micro-benchmark (`SqlBuildingBufferBenchmark`) that builds the `SqlPart` tree once in `[GlobalSetup]` and measures only the `.Build()` (format) path.
- Switch the benchmark entry point to `BenchmarkSwitcher` so benchmarks can be selected via `--filter`.
- Update the comparison packages to their latest importable versions (BenchmarkDotNet 0.15.8, InterpolatedSql 2.5.1, SqExpress 1.2.0) for a fair comparison.

## Benchmark results

Isolated format path (default job, `[MemoryDiagnoser]`):

| | Mean | Allocated |
|---|---:|---:|
| Before | 1,125 ns | 1,137 B |
| After | 888.8 ns | 896 B |
| Change | **-21.0%** | **-21.2%** |

Full build vs. other builders (ShortRun, same machine/run, updated packages):

| Method | Mean | Allocated |
|---|---:|---:|
| StringBuilder (baseline) | 208.2 ns | 1.38 KB |
| Sqlify | 987.5 ns | 3.13 KB |
| DapperSqlBuilder | 1,317.4 ns | 5.12 KB |
| **SqlArtisan_SpecificParams** | **1,344.6 ns** | **2.46 KB** |
| **SqlArtisan_DapperDynamicParams** | **1,444.3 ns** | **3.02 KB** |
| InterpolatedSql | 1,599.4 ns | 5.17 KB |
| SqExpress | 2,263.3 ns | 4.65 KB |
| DapperQbNet | 2,699.1 ns | 7.47 KB |
| SqlKata | 29,736.3 ns | 40.54 KB |

(SqlArtisan_SpecificParams improved from a prior 1,433.0 ns / 2.66 KB.)

## Testing

- Full suite: 283 tests passing
- Release build clean (0 warnings, 0 errors)
- README benchmark table and CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
