### PR TITLE
feat: Add support for LIMIT / OFFSET / FETCH pagination (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added support for pagination: `Limit`/`Offset` (PostgreSQL/MySQL/SQLite) and `OffsetRows`/`FetchFirst`/`FetchNext` (Oracle 12c+/SQL Server 2012+). (#49)
+
 ### Changed
 - Improved `SqlBuildingBuffer` memory efficiency and throughput. (#45)
 - Documented the design philosophy and non-goals, and surfaced dialect-specific features in the README and via XML doc comments. (#47)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ So you can focus on the query logic, not the boilerplate. That’s why SqlArtisa
     - [GROUP BY and HAVING Clause](#group-by-and-having-clause)
     - [Set Operators](#set-operators): `UNION [ALL]`, `EXCEPT [ALL]`, `MINUS [ALL]`, `INTERSECT [ALL]`
     - [FOR UPDATE Clause](#for-update-clause)
-    - [Pagination (LIMIT / OFFSET / FETCH)](#pagination-limit--offset--fetch)
+    - [Pagination](#pagination): `LIMIT`, `OFFSET`, `FETCH`
   - [DELETE Statement](#delete-statement)
   - [UPDATE Statement](#update-statement)
   - [INSERT Statement](#insert-statement): **Standard**, **SET-like**, `INSERT SELECT`
@@ -613,7 +613,7 @@ SqlStatement sql =
 
 ---
 
-#### Pagination (LIMIT / OFFSET / FETCH)
+#### Pagination
 
 Row limiting is dialect-divergent, so SqlArtisan exposes two faithful families and you choose the one for your target database (see [Design Philosophy](#design-philosophy)).
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ So you can focus on the query logic, not the boilerplate. That’s why SqlArtisa
     - [GROUP BY and HAVING Clause](#group-by-and-having-clause)
     - [Set Operators](#set-operators): `UNION [ALL]`, `EXCEPT [ALL]`, `MINUS [ALL]`, `INTERSECT [ALL]`
     - [FOR UPDATE Clause](#for-update-clause)
+    - [Pagination (LIMIT / OFFSET / FETCH)](#pagination-limit--offset--fetch)
   - [DELETE Statement](#delete-statement)
   - [UPDATE Statement](#update-statement)
   - [INSERT Statement](#insert-statement): **Standard**, **SET-like**, `INSERT SELECT`
@@ -609,6 +610,56 @@ SqlStatement sql =
 - `Nowait` for `NOWAIT`
 - `SkipLocked` for `SKIP LOCKED`
 - `Wait()` for `WAIT`
+
+---
+
+#### Pagination (LIMIT / OFFSET / FETCH)
+
+Row limiting is dialect-divergent, so SqlArtisan exposes two faithful families and you choose the one for your target database (see [Design Philosophy](#design-philosophy)).
+
+##### LIMIT family (PostgreSQL / MySQL / SQLite)
+
+```csharp
+TestTable t = new();
+SqlStatement sql =
+    Select(t.Code)
+    .From(t)
+    .OrderBy(t.Code)
+    .Limit(10)
+    .Offset(20)
+    .Build();
+
+// SELECT code
+// FROM test_table
+// ORDER BY code
+// LIMIT :0 OFFSET :1
+```
+
+`Limit()` and `Offset()` can be used together or independently.
+
+##### OFFSET/FETCH family (Oracle 12c+ / SQL Server 2012+)
+
+```csharp
+TestTable t = new();
+SqlStatement sql =
+    Select(t.Code)
+    .From(t)
+    .OrderBy(t.Code)
+    .OffsetRows(20)
+    .FetchNext(10)
+    .Build(Dbms.Oracle);
+
+// SELECT code
+// FROM test_table
+// ORDER BY code
+// OFFSET :0 ROWS FETCH NEXT :1 ROWS ONLY
+```
+
+- Use `FetchFirst(n)` for `FETCH FIRST n ROWS ONLY` (no offset).
+- Use `OffsetRows(m)` alone for `OFFSET m ROWS`.
+- This form requires `ORDER BY` on SQL Server, and is available on Oracle 12c+ / SQL Server 2012+.
+
+The row counts are parameterized like other literals, so the bind-parameter prefix follows the target dialect (`:` / `@` / `?`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ SqlStatement sql =
 // LIMIT :0 OFFSET :1
 ```
 
-`Limit()` and `Offset()` can be used together or independently.
+`Limit()` and `Offset()` can be combined as `LIMIT n OFFSET m`. Note that a standalone `Offset()` (without `Limit()`) is only valid on PostgreSQL; MySQL and SQLite require `OFFSET` to be paired with `LIMIT`.
 
 ##### OFFSET/FETCH family (Oracle 12c+ / SQL Server 2012+)
 
@@ -655,9 +655,9 @@ SqlStatement sql =
 // OFFSET :0 ROWS FETCH NEXT :1 ROWS ONLY
 ```
 
-- Use `FetchFirst(n)` for `FETCH FIRST n ROWS ONLY` (no offset).
 - Use `OffsetRows(m)` alone for `OFFSET m ROWS`.
-- This form requires `ORDER BY` on SQL Server, and is available on Oracle 12c+ / SQL Server 2012+.
+- Use `FetchFirst(n)` for `FETCH FIRST n ROWS ONLY` (no offset). This standalone form is valid on **Oracle** (and PostgreSQL); **SQL Server requires an `OFFSET`**, so on SQL Server use `OffsetRows(0).FetchNext(n)` instead.
+- This clause requires `ORDER BY` on SQL Server, and is available on Oracle 12c+ / SQL Server 2012+.
 
 The row counts are parameterized like other literals, so the bind-parameter prefix follows the target dialect (`:` / `@` / `?`).
 

--- a/src/SqlArtisan/Internal/SqlBuilder/Select/ILimitOffsetBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Select/ILimitOffsetBuilder.cs
@@ -1,0 +1,10 @@
+namespace SqlArtisan.Internal;
+
+public interface ILimitOffsetBuilder : ISqlBuilder
+{
+    /// <summary>
+    /// Appends <c>OFFSET m</c> after <c>LIMIT n</c>. Dialect-specific
+    /// (PostgreSQL / MySQL / SQLite).
+    /// </summary>
+    ISqlBuilder Offset(int start);
+}

--- a/src/SqlArtisan/Internal/SqlBuilder/Select/IOffsetFetchBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Select/IOffsetFetchBuilder.cs
@@ -1,0 +1,10 @@
+namespace SqlArtisan.Internal;
+
+public interface IOffsetFetchBuilder : ISqlBuilder
+{
+    /// <summary>
+    /// Appends <c>FETCH NEXT n ROWS ONLY</c> after <c>OFFSET m ROWS</c>.
+    /// Dialect-specific (Oracle 12c+ / SQL Server 2012+).
+    /// </summary>
+    ISqlBuilder FetchNext(int count);
+}

--- a/src/SqlArtisan/Internal/SqlBuilder/Select/IPagination.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Select/IPagination.cs
@@ -1,0 +1,28 @@
+namespace SqlArtisan.Internal;
+
+public interface IPagination
+{
+    /// <summary>
+    /// Appends <c>LIMIT n</c>. Dialect-specific (PostgreSQL / MySQL / SQLite).
+    /// For Oracle 12c+ / SQL Server 2012+ use <see cref="FetchFirst(int)"/>.
+    /// </summary>
+    ILimitOffsetBuilder Limit(int count);
+
+    /// <summary>
+    /// Appends <c>OFFSET m</c>. Dialect-specific (PostgreSQL / MySQL / SQLite).
+    /// For Oracle 12c+ / SQL Server 2012+ use <see cref="OffsetRows(int)"/>.
+    /// </summary>
+    ISqlBuilder Offset(int start);
+
+    /// <summary>
+    /// Appends <c>OFFSET m ROWS</c>. Dialect-specific (Oracle 12c+ / SQL Server 2012+).
+    /// For PostgreSQL / MySQL / SQLite use <see cref="Offset(int)"/>.
+    /// </summary>
+    IOffsetFetchBuilder OffsetRows(int start);
+
+    /// <summary>
+    /// Appends <c>FETCH FIRST n ROWS ONLY</c>. Dialect-specific (Oracle 12c+ /
+    /// SQL Server 2012+). For PostgreSQL / MySQL / SQLite use <see cref="Limit(int)"/>.
+    /// </summary>
+    ISqlBuilder FetchFirst(int count);
+}

--- a/src/SqlArtisan/Internal/SqlBuilder/Select/IPagination.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Select/IPagination.cs
@@ -9,8 +9,10 @@ public interface IPagination
     ILimitOffsetBuilder Limit(int count);
 
     /// <summary>
-    /// Appends <c>OFFSET m</c>. Dialect-specific (PostgreSQL / MySQL / SQLite).
-    /// For Oracle 12c+ / SQL Server 2012+ use <see cref="OffsetRows(int)"/>.
+    /// Appends <c>OFFSET m</c>. As a standalone clause this is valid on PostgreSQL;
+    /// MySQL and SQLite require <c>OFFSET</c> to be combined with <see cref="Limit(int)"/>
+    /// (<c>LIMIT n OFFSET m</c>). For Oracle 12c+ / SQL Server 2012+ use
+    /// <see cref="OffsetRows(int)"/>.
     /// </summary>
     ISqlBuilder Offset(int start);
 
@@ -21,8 +23,11 @@ public interface IPagination
     IOffsetFetchBuilder OffsetRows(int start);
 
     /// <summary>
-    /// Appends <c>FETCH FIRST n ROWS ONLY</c>. Dialect-specific (Oracle 12c+ /
-    /// SQL Server 2012+). For PostgreSQL / MySQL / SQLite use <see cref="Limit(int)"/>.
+    /// Appends <c>FETCH FIRST n ROWS ONLY</c> with no offset. Valid standalone on
+    /// Oracle 12c+ (and PostgreSQL). SQL Server requires an <c>OFFSET</c>, so there
+    /// use <see cref="OffsetRows(int)"/> followed by
+    /// <see cref="IOffsetFetchBuilder.FetchNext(int)"/>. For PostgreSQL / MySQL /
+    /// SQLite, <see cref="Limit(int)"/> is the more common form.
     /// </summary>
     ISqlBuilder FetchFirst(int count);
 }

--- a/src/SqlArtisan/Internal/SqlBuilder/Select/ISelectBuilderFrom.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Select/ISelectBuilderFrom.cs
@@ -1,6 +1,6 @@
 ﻿namespace SqlArtisan.Internal;
 
-public interface ISelectBuilderFrom : ISqlBuilder, ISetOperator, IForUpdate, ISubquery
+public interface ISelectBuilderFrom : ISqlBuilder, ISetOperator, IForUpdate, ISubquery, IPagination
 {
     // Subsequent SQL is the same as the FROM clause.
     ISelectBuilderFrom CrossJoin(TableReference table);

--- a/src/SqlArtisan/Internal/SqlBuilder/Select/ISelectBuilderGroupBy.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Select/ISelectBuilderGroupBy.cs
@@ -1,6 +1,6 @@
 ﻿namespace SqlArtisan.Internal;
 
-public interface ISelectBuilderGroupBy : ISqlBuilder, ISetOperator, ISubquery
+public interface ISelectBuilderGroupBy : ISqlBuilder, ISetOperator, ISubquery, IPagination
 {
     ISelectBuilderHaving Having(SqlCondition condition);
 

--- a/src/SqlArtisan/Internal/SqlBuilder/Select/ISelectBuilderHaving.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Select/ISelectBuilderHaving.cs
@@ -1,5 +1,5 @@
 ﻿namespace SqlArtisan.Internal;
 
-public interface ISelectBuilderHaving : ISqlBuilder, ISetOperator, ISubquery
+public interface ISelectBuilderHaving : ISqlBuilder, ISetOperator, ISubquery, IPagination
 {
 }

--- a/src/SqlArtisan/Internal/SqlBuilder/Select/ISelectBuilderOrderBy.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Select/ISelectBuilderOrderBy.cs
@@ -1,5 +1,5 @@
 ﻿namespace SqlArtisan.Internal;
 
-public interface ISelectBuilderOrderBy : ISqlBuilder, IForUpdate, ISubquery
+public interface ISelectBuilderOrderBy : ISqlBuilder, IForUpdate, ISubquery, IPagination
 {
 }

--- a/src/SqlArtisan/Internal/SqlBuilder/Select/ISelectBuilderWhere.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Select/ISelectBuilderWhere.cs
@@ -1,6 +1,6 @@
 ﻿namespace SqlArtisan.Internal;
 
-public interface ISelectBuilderWhere : ISqlBuilder, ISetOperator, IForUpdate, ISubquery
+public interface ISelectBuilderWhere : ISqlBuilder, ISetOperator, IForUpdate, ISubquery, IPagination
 {
     ISelectBuilderGroupBy GroupBy(params object[] groupByItems);
 

--- a/src/SqlArtisan/Internal/SqlBuilder/Select/SelectBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Select/SelectBuilder.cs
@@ -11,7 +11,9 @@ internal class SelectBuilder(params SqlPart[] rootParts) :
     ISelectBuilderJoin,
     ISelectBuilderOrderBy,
     ISelectBuilderSelect,
-    ISelectBuilderWhere
+    ISelectBuilderWhere,
+    ILimitOffsetBuilder,
+    IOffsetFetchBuilder
 {
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public ISelectBuilderSetOperator Except
@@ -112,6 +114,36 @@ internal class SelectBuilder(params SqlPart[] rootParts) :
         LockBehaviorBase? lockBehavior = null)
     {
         AddPart(new ForUpdateClause(ofClause, lockBehavior));
+        return this;
+    }
+
+    public ILimitOffsetBuilder Limit(int count)
+    {
+        AddPart(new LimitClause(count));
+        return this;
+    }
+
+    public ISqlBuilder Offset(int start)
+    {
+        AddPart(new OffsetClause(start));
+        return this;
+    }
+
+    public IOffsetFetchBuilder OffsetRows(int start)
+    {
+        AddPart(new OffsetRowsClause(start));
+        return this;
+    }
+
+    public ISqlBuilder FetchFirst(int count)
+    {
+        AddPart(new FetchClause(count, first: true));
+        return this;
+    }
+
+    public ISqlBuilder FetchNext(int count)
+    {
+        AddPart(new FetchClause(count, first: false));
         return this;
     }
 

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Pagination/FetchClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Pagination/FetchClause.cs
@@ -1,0 +1,18 @@
+namespace SqlArtisan.Internal;
+
+internal sealed class FetchClause : SqlPart
+{
+    private readonly BindValue _count;
+    private readonly bool _first;
+
+    internal FetchClause(int count, bool first)
+    {
+        _count = new BindValue(count);
+        _first = first;
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append($"{Keywords.Fetch} {(_first ? Keywords.First : Keywords.Next)} ")
+        .Append(_count)
+        .Append($" {Keywords.Rows} {Keywords.Only}");
+}

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Pagination/LimitClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Pagination/LimitClause.cs
@@ -1,0 +1,15 @@
+namespace SqlArtisan.Internal;
+
+internal sealed class LimitClause : SqlPart
+{
+    private readonly BindValue _count;
+
+    internal LimitClause(int count)
+    {
+        _count = new BindValue(count);
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append($"{Keywords.Limit} ")
+        .Append(_count);
+}

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Pagination/OffsetClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Pagination/OffsetClause.cs
@@ -1,0 +1,15 @@
+namespace SqlArtisan.Internal;
+
+internal sealed class OffsetClause : SqlPart
+{
+    private readonly BindValue _start;
+
+    internal OffsetClause(int start)
+    {
+        _start = new BindValue(start);
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append($"{Keywords.Offset} ")
+        .Append(_start);
+}

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Pagination/OffsetRowsClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Pagination/OffsetRowsClause.cs
@@ -1,0 +1,16 @@
+namespace SqlArtisan.Internal;
+
+internal sealed class OffsetRowsClause : SqlPart
+{
+    private readonly BindValue _start;
+
+    internal OffsetRowsClause(int start)
+    {
+        _start = new BindValue(start);
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append($"{Keywords.Offset} ")
+        .Append(_start)
+        .Append($" {Keywords.Rows}");
+}

--- a/src/SqlArtisan/Internal/SqlPart/Keywords.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Keywords.cs
@@ -35,6 +35,8 @@ internal static class Keywords
     internal const string Except = "EXCEPT";
     internal const string Exists = "EXISTS";
     internal const string Extract = "EXTRACT";
+    internal const string Fetch = "FETCH";
+    internal const string First = "FIRST";
     internal const string For = "FOR";
     internal const string From = "FROM";
     internal const string Full = "FULL";
@@ -55,6 +57,7 @@ internal static class Keywords
     internal const string Length = "LENGTH";
     internal const string Lengthb = "LENGTHB";
     internal const string Like = "LIKE";
+    internal const string Limit = "LIMIT";
     internal const string Locked = "LOCKED";
     internal const string Lower = "LOWER";
     internal const string Lpad = "LPAD";
@@ -73,7 +76,9 @@ internal static class Keywords
     internal const string NullsLast = "NULLS LAST";
     internal const string Nvl = "NVL";
     internal const string Of = "OF";
+    internal const string Offset = "OFFSET";
     internal const string On = "ON";
+    internal const string Only = "ONLY";
     internal const string Or = "OR";
     internal const string Order = "ORDER";
     internal const string Over = "OVER";
@@ -89,6 +94,7 @@ internal static class Keywords
     internal const string Returning = "RETURNING";
     internal const string Right = "RIGHT";
     internal const string RowNumber = "ROW_NUMBER";
+    internal const string Rows = "ROWS";
     internal const string Rpad = "RPAD";
     internal const string Rtrim = "RTRIM";
     internal const string Select = "SELECT";

--- a/tests/SqlArtisan.Tests/PaginationTests.cs
+++ b/tests/SqlArtisan.Tests/PaginationTests.cs
@@ -1,0 +1,188 @@
+using System.Text;
+using static SqlArtisan.Sql;
+
+namespace SqlArtisan.Tests;
+
+public class PaginationTests
+{
+    private readonly TestTable _t = new();
+
+    // ── LIMIT family (PostgreSQL / MySQL / SQLite) ────────────────────
+
+    [Fact]
+    public void Limit_CorrectSql()
+    {
+        SqlStatement sql =
+            Select(_t.Code)
+            .From(_t)
+            .OrderBy(_t.Code)
+            .Limit(10)
+            .Build();
+
+        StringBuilder expected = new();
+        expected.Append("SELECT code ");
+        expected.Append("FROM test_table ");
+        expected.Append("ORDER BY code ");
+        expected.Append("LIMIT :0");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
+    public void Offset_CorrectSql()
+    {
+        SqlStatement sql =
+            Select(_t.Code)
+            .From(_t)
+            .OrderBy(_t.Code)
+            .Offset(20)
+            .Build();
+
+        StringBuilder expected = new();
+        expected.Append("SELECT code ");
+        expected.Append("FROM test_table ");
+        expected.Append("ORDER BY code ");
+        expected.Append("OFFSET :0");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
+    public void LimitOffset_CorrectSql()
+    {
+        SqlStatement sql =
+            Select(_t.Code)
+            .From(_t)
+            .OrderBy(_t.Code)
+            .Limit(10)
+            .Offset(20)
+            .Build();
+
+        StringBuilder expected = new();
+        expected.Append("SELECT code ");
+        expected.Append("FROM test_table ");
+        expected.Append("ORDER BY code ");
+        expected.Append("LIMIT :0 OFFSET :1");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
+    public void Limit_WithoutOrderBy_CorrectSql()
+    {
+        SqlStatement sql =
+            Select(_t.Code)
+            .From(_t)
+            .Limit(10)
+            .Build();
+
+        StringBuilder expected = new();
+        expected.Append("SELECT code ");
+        expected.Append("FROM test_table ");
+        expected.Append("LIMIT :0");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
+    public void Limit_AfterWhere_ParametersInOrder()
+    {
+        SqlStatement sql =
+            Select(_t.Code)
+            .From(_t)
+            .Where(_t.Code > 0)
+            .OrderBy(_t.Code)
+            .Limit(10)
+            .Offset(20)
+            .Build();
+
+        StringBuilder expected = new();
+        expected.Append("SELECT code ");
+        expected.Append("FROM test_table ");
+        expected.Append("WHERE code > :0 ");
+        expected.Append("ORDER BY code ");
+        expected.Append("LIMIT :1 OFFSET :2");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    // ── OFFSET/FETCH family (Oracle 12c+ / SQL Server 2012+) ──────────
+
+    [Fact]
+    public void FetchFirst_CorrectSql()
+    {
+        SqlStatement sql =
+            Select(_t.Code)
+            .From(_t)
+            .OrderBy(_t.Code)
+            .FetchFirst(10)
+            .Build();
+
+        StringBuilder expected = new();
+        expected.Append("SELECT code ");
+        expected.Append("FROM test_table ");
+        expected.Append("ORDER BY code ");
+        expected.Append("FETCH FIRST :0 ROWS ONLY");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
+    public void OffsetRows_CorrectSql()
+    {
+        SqlStatement sql =
+            Select(_t.Code)
+            .From(_t)
+            .OrderBy(_t.Code)
+            .OffsetRows(20)
+            .Build();
+
+        StringBuilder expected = new();
+        expected.Append("SELECT code ");
+        expected.Append("FROM test_table ");
+        expected.Append("ORDER BY code ");
+        expected.Append("OFFSET :0 ROWS");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
+    public void OffsetRowsFetchNext_CorrectSql()
+    {
+        SqlStatement sql =
+            Select(_t.Code)
+            .From(_t)
+            .OrderBy(_t.Code)
+            .OffsetRows(20)
+            .FetchNext(10)
+            .Build();
+
+        StringBuilder expected = new();
+        expected.Append("SELECT code ");
+        expected.Append("FROM test_table ");
+        expected.Append("ORDER BY code ");
+        expected.Append("OFFSET :0 ROWS FETCH NEXT :1 ROWS ONLY");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
+    public void FetchFirst_UsesDialectParameterMarker()
+    {
+        SqlStatement sql =
+            Select(_t.Code)
+            .From(_t)
+            .OrderBy(_t.Code)
+            .OffsetRows(20)
+            .FetchNext(10)
+            .Build(Dbms.SqlServer);
+
+        StringBuilder expected = new();
+        expected.Append("SELECT code ");
+        expected.Append("FROM test_table ");
+        expected.Append("ORDER BY code ");
+        expected.Append("OFFSET @0 ROWS FETCH NEXT @1 ROWS ONLY");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+}

--- a/tests/SqlArtisan.Tests/PaginationTests.cs
+++ b/tests/SqlArtisan.Tests/PaginationTests.cs
@@ -10,7 +10,7 @@ public class PaginationTests
     // ── LIMIT family (PostgreSQL / MySQL / SQLite) ────────────────────
 
     [Fact]
-    public void Limit_CorrectSql()
+    public void Limit_WithOrderBy_CorrectSql()
     {
         SqlStatement sql =
             Select(_t.Code)
@@ -29,7 +29,7 @@ public class PaginationTests
     }
 
     [Fact]
-    public void Offset_CorrectSql()
+    public void Offset_WithOrderBy_CorrectSql()
     {
         SqlStatement sql =
             Select(_t.Code)
@@ -48,7 +48,7 @@ public class PaginationTests
     }
 
     [Fact]
-    public void LimitOffset_CorrectSql()
+    public void LimitOffset_WithOrderBy_CorrectSql()
     {
         SqlStatement sql =
             Select(_t.Code)
@@ -109,7 +109,7 @@ public class PaginationTests
     // ── OFFSET/FETCH family (Oracle 12c+ / SQL Server 2012+) ──────────
 
     [Fact]
-    public void FetchFirst_CorrectSql()
+    public void FetchFirst_WithOrderBy_CorrectSql()
     {
         SqlStatement sql =
             Select(_t.Code)
@@ -128,7 +128,7 @@ public class PaginationTests
     }
 
     [Fact]
-    public void OffsetRows_CorrectSql()
+    public void OffsetRows_WithOrderBy_CorrectSql()
     {
         SqlStatement sql =
             Select(_t.Code)
@@ -147,7 +147,7 @@ public class PaginationTests
     }
 
     [Fact]
-    public void OffsetRowsFetchNext_CorrectSql()
+    public void OffsetRowsFetchNext_WithOrderBy_CorrectSql()
     {
         SqlStatement sql =
             Select(_t.Code)
@@ -167,7 +167,7 @@ public class PaginationTests
     }
 
     [Fact]
-    public void FetchFirst_UsesDialectParameterMarker()
+    public void OffsetRowsFetchNext_OnSqlServer_UsesDialectParameterMarker()
     {
         SqlStatement sql =
             Select(_t.Code)


### PR DESCRIPTION
Closes #49

## Summary

Adds pagination (row limiting / offsetting) to the SELECT builder. Per SqlArtisan's design philosophy, pagination is exposed as **dialect-faithful APIs**: the method you choose determines the emitted SQL, and the `Dbms` build target only affects lexical concerns (the bind-parameter marker).

## API

LIMIT family (PostgreSQL / MySQL / SQLite):

```csharp
.Limit(10)              // LIMIT :0
.Offset(20)             // OFFSET :0
.Limit(10).Offset(20)   // LIMIT :0 OFFSET :1
```

OFFSET/FETCH family (Oracle 12c+ / SQL Server 2012+):

```csharp
.FetchFirst(10)               // FETCH FIRST :0 ROWS ONLY
.OffsetRows(20)               // OFFSET :0 ROWS
.OffsetRows(20).FetchNext(10) // OFFSET :0 ROWS FETCH NEXT :1 ROWS ONLY
```

- Exposed on the FROM / WHERE / GROUP BY / HAVING / ORDER BY stages, so `LIMIT` without `ORDER BY` is supported where valid.
- Row counts are parameterized like other literals, so the marker follows the dialect (`:` / `@` / `?`).
- The fluent return types prevent invalid chains (e.g. `FetchNext` is only reachable after `OffsetRows`).

## Notes / out of scope

- `FETCH FIRST n ROWS WITH TIES` is deferred (possible follow-up).
- No dialect compatibility validation — SqlArtisan informs (docs/XML/IntelliSense), it does not gate (see #47).

## Testing

- Added `PaginationTests` (LIMIT family, OFFSET/FETCH family, no-ORDER-BY, parameter ordering, dialect marker).
- Full suite: 292 tests passing; Release build clean (0 warnings, 0 errors).
- README (new Pagination section + ToC) and CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
