### PR TITLE
test: Standardize test method names to MethodUnderTest_Condition_Expected

### DIFF
--- a/tests/SqlArtisan.Tests/ArithmeticTests.cs
+++ b/tests/SqlArtisan.Tests/ArithmeticTests.cs
@@ -27,7 +27,7 @@ public class ArithmeticTests
         Assert.Equal("SELECT (\"t\".code % :0)", Select(_t.Code % 2).Build().Text);
 
     [Fact]
-    public void SubtractionAndAddition_nesting_CorrectSql() =>
+    public void SubtractionAndAddition_Nesting_CorrectSql() =>
         Assert.Equal(
             "SELECT ((\"t\".created_at - \"t\".created_at) + :0)",
             Select((_t.CreatedAt - _t.CreatedAt) + 1).Build().Text);

--- a/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.A.cs
+++ b/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.A.cs
@@ -50,7 +50,7 @@ public partial class FunctionTests
     }
 
     [Fact]
-    public void Avg_Distinct_NumericValue_CorrectSql()
+    public void Avg_DistinctNumericValue_CorrectSql()
     {
         SqlStatement sql =
             Select(Avg(Distinct, _t.Code))

--- a/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.C.cs
+++ b/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.C.cs
@@ -48,7 +48,7 @@ public partial class FunctionTests
     }
 
     [Fact]
-    public void Count_Distinct_ColumnValue_CorrectSql()
+    public void Count_DistinctColumnValue_CorrectSql()
     {
         SqlStatement sql =
             Select(Count(Distinct, _t.Code))

--- a/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.S.cs
+++ b/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.S.cs
@@ -76,7 +76,7 @@ public partial class FunctionTests
     }
 
     [Fact]
-    public void Sum_Distinct_NumericValue_CorrectSql()
+    public void Sum_DistinctNumericValue_CorrectSql()
     {
         SqlStatement sql =
             Select(Sum(Distinct, _t.Code))

--- a/tests/SqlArtisan.Tests/ReturningTests.cs
+++ b/tests/SqlArtisan.Tests/ReturningTests.cs
@@ -248,7 +248,7 @@ public class ReturningTests
     // ── output parameters ─────────────────────────────────────────────
 
     [Fact]
-    public void ReturningInto_RegistersOutputParameters()
+    public void ReturningInto_OnDelete_RegistersOutputParameters()
     {
         SqlStatement sql =
             DeleteFrom(_t)
@@ -264,7 +264,7 @@ public class ReturningTests
     }
 
     [Fact]
-    public void ReturningInto_UsesDialectParameterMarker()
+    public void ReturningInto_OnSqlServer_UsesDialectParameterMarker()
     {
         SqlStatement sql =
             DeleteFrom(_t)

--- a/tests/SqlArtisan.Tests/WindowFunctionTests/WindowCumeDistTests.cs
+++ b/tests/SqlArtisan.Tests/WindowFunctionTests/WindowCumeDistTests.cs
@@ -8,7 +8,7 @@ public partial class WindowCumeDistTests
     private readonly TestTable _t = new("t");
 
     [Fact]
-    public void CumeDist_Over_PartitionByOrderBy_CorrectSql()
+    public void CumeDist_OverPartitionByOrderBy_CorrectSql()
     {
         SqlStatement sql =
             Select(
@@ -34,7 +34,7 @@ public partial class WindowCumeDistTests
     }
 
     [Fact]
-    public void CumeDist_Over_OrderBy_CorrectSql()
+    public void CumeDist_OverOrderBy_CorrectSql()
     {
         SqlStatement sql =
             Select(

--- a/tests/SqlArtisan.Tests/WindowFunctionTests/WindowDenseRankTests.cs
+++ b/tests/SqlArtisan.Tests/WindowFunctionTests/WindowDenseRankTests.cs
@@ -8,7 +8,7 @@ public partial class WindowDenseRankTests
     private readonly TestTable _t = new("t");
 
     [Fact]
-    public void DenseRank_Over_PartitionByOrderBy_CorrectSql()
+    public void DenseRank_OverPartitionByOrderBy_CorrectSql()
     {
         SqlStatement sql =
             Select(
@@ -34,7 +34,7 @@ public partial class WindowDenseRankTests
     }
 
     [Fact]
-    public void DenseRank_Over_OrderBy_CorrectSql()
+    public void DenseRank_OverOrderBy_CorrectSql()
     {
         SqlStatement sql =
             Select(DenseRank().Over(OrderBy(_t.Code, _t.Name)))

--- a/tests/SqlArtisan.Tests/WindowFunctionTests/WindowPercentRankTests.cs
+++ b/tests/SqlArtisan.Tests/WindowFunctionTests/WindowPercentRankTests.cs
@@ -8,7 +8,7 @@ public partial class WindowPercentRankTests
     private readonly TestTable _t = new("t");
 
     [Fact]
-    public void PercentRank_Over_PartitionByOrderBy_CorrectSql()
+    public void PercentRank_OverPartitionByOrderBy_CorrectSql()
     {
         SqlStatement sql =
             Select(
@@ -34,7 +34,7 @@ public partial class WindowPercentRankTests
     }
 
     [Fact]
-    public void PercentRank_Over_OrderBy_CorrectSql()
+    public void PercentRank_OverOrderBy_CorrectSql()
     {
         SqlStatement sql =
             Select(

--- a/tests/SqlArtisan.Tests/WindowFunctionTests/WindowRankTests.cs
+++ b/tests/SqlArtisan.Tests/WindowFunctionTests/WindowRankTests.cs
@@ -8,7 +8,7 @@ public partial class WindowRankTests
     private readonly TestTable _t = new("t");
 
     [Fact]
-    public void Rank_Over_PartitionByOrderBy_CorrectSql()
+    public void Rank_OverPartitionByOrderBy_CorrectSql()
     {
         SqlStatement sql =
             Select(
@@ -34,7 +34,7 @@ public partial class WindowRankTests
     }
 
     [Fact]
-    public void Rank_Over_OrderBy_CorrectSql()
+    public void Rank_OverOrderBy_CorrectSql()
     {
         SqlStatement sql =
             Select(

--- a/tests/SqlArtisan.Tests/WindowFunctionTests/WindowRowNumberTests.cs
+++ b/tests/SqlArtisan.Tests/WindowFunctionTests/WindowRowNumberTests.cs
@@ -8,7 +8,7 @@ public partial class WindowRowNumberTests
     private readonly TestTable _t = new("t");
 
     [Fact]
-    public void RowNumber_Over_PartitionByOrderBy_CorrectSql()
+    public void RowNumber_OverPartitionByOrderBy_CorrectSql()
     {
         SqlStatement sql =
             Select(
@@ -34,7 +34,7 @@ public partial class WindowRowNumberTests
     }
 
     [Fact]
-    public void RowNumber_Over_OrderBy_CorrectSql()
+    public void RowNumber_OverOrderBy_CorrectSql()
     {
         SqlStatement sql =
             Select(RowNumber().Over(OrderBy(_t.Code, _t.Name)))


### PR DESCRIPTION
## Summary

Standardizes test method names to the `MethodUnderTest_Condition_ExpectedResult` (strictly three-part) convention. Most of the suite already followed it; this fixes the remaining deviations. Test-only change; no production code touched.

## Changes

- **Missing condition (two-part → three-part):**
  - `ReturningInto_RegistersOutputParameters` → `ReturningInto_OnDelete_RegistersOutputParameters`
  - `ReturningInto_UsesDialectParameterMarker` → `ReturningInto_OnSqlServer_UsesDialectParameterMarker`
- **Extra segment (four-part → three-part):**
  - Window-function tests: `*_Over_PartitionByOrderBy_*` / `*_Over_OrderBy_*` → `*_OverPartitionByOrderBy_*` / `*_OverOrderBy_*` (RowNumber, Rank, DenseRank, CumeDist, PercentRank)
  - DISTINCT aggregate tests: `Sum_Distinct_NumericValue_*`, `Count_Distinct_ColumnValue_*`, `Avg_Distinct_NumericValue_*` → `*_DistinctNumericValue_*` / `*_DistinctColumnValue_*`
- **Casing:** `SubtractionAndAddition_nesting_CorrectSql` → `SubtractionAndAddition_Nesting_CorrectSql`

## Testing

- Full suite: 283 tests passing (names only; behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
