### PR TITLE
feat: Add support for CAST(expr AS type) (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Added support for pagination: `Limit`/`Offset` (PostgreSQL/MySQL/SQLite) and `OffsetRows`/`FetchFirst`/`FetchNext` (Oracle 12c+/SQL Server 2012+). (#49)
+- Added support for the ANSI `CAST(expr AS type)` expression. (#52)
 
 ### Changed
 - Improved `SqlBuildingBuffer` memory efficiency and throughput. (#45)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ So you can focus on the query logic, not the boilerplate. That’s why SqlArtisa
     - [Arithmetic Operators](#arithmetic-operators): `+`, `-`, `*`, `/`, `%`
     - [Conditions](#conditions): **Logical**, **Comparison**, `NULL`, `LIKE`, `REGEXP_LIKE`, `BETWEEN`, `IN`, `EXISTS`, **Dynamic Conditions**
     - [CASE Expressions](#case-expressions): **Simple CASE**, **Searched CASE**
+    - [CAST](#cast)
     - [Window Functions](#window-functions)
     - [Sequence](#sequence): `CURRVAL`, `NEXTVAL`, `NEXT VALUE FOR`
 - [Additional Query Details](#additional-query-details)
@@ -1176,6 +1177,25 @@ SqlStatement sql =
 // END "AgeGroup"
 // FROM users
 ```
+
+---
+
+#### CAST
+
+The ANSI `CAST(expr AS type)` expression converts a value to another type. It is supported with the same syntax on every dialect.
+
+```csharp
+UsersTable u = new();
+SqlStatement sql =
+    Select(Cast(u.Id, "VARCHAR(10)").As("id_text"))
+    .From(u)
+    .Build();
+
+// SELECT CAST(id AS VARCHAR(10)) "id_text"
+// FROM users
+```
+
+The target type is emitted verbatim, so write the exact SQL data type for your target database (for example `VARCHAR2(10)` on Oracle, `NVARCHAR(10)` on SQL Server). Consistent with the [Design Philosophy](#design-philosophy), SqlArtisan does not abstract or translate dialect-specific type names.
 
 ---
 

--- a/src/SqlArtisan/Internal/SqlPart/Expression/CastExpression.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/CastExpression.cs
@@ -1,0 +1,21 @@
+namespace SqlArtisan.Internal;
+
+public sealed class CastExpression : SqlExpression
+{
+    private readonly SqlExpression _expr;
+    private readonly string _type;
+
+    internal CastExpression(SqlExpression expr, string type)
+    {
+        _expr = expr;
+        _type = type;
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append(Keywords.Cast)
+        .OpenParenthesis()
+        .Append(_expr)
+        .EncloseInSpaces(Keywords.As)
+        .Append(_type)
+        .CloseParenthesis();
+}

--- a/src/SqlArtisan/Internal/SqlPart/Keywords.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Keywords.cs
@@ -14,6 +14,7 @@ internal static class Keywords
     internal const string Both = "BOTH";
     internal const string By = "BY";
     internal const string Case = "CASE";
+    internal const string Cast = "CAST";
     internal const string Coalesce = "COALESCE";
     internal const string Concat = "CONCAT";
     internal const string Count = "COUNT";

--- a/src/SqlArtisan/Sql/Sql.C.cs
+++ b/src/SqlArtisan/Sql/Sql.C.cs
@@ -376,6 +376,14 @@ public static partial class Sql
             whenClauses,
             elseExpr);
 
+    /// <summary>
+    /// The ANSI <c>CAST(expr AS type)</c> expression. The target <paramref name="type"/>
+    /// is emitted verbatim, so supply the exact SQL data type for your target database
+    /// (for example <c>"VARCHAR2(10)"</c> on Oracle, <c>"NVARCHAR(10)"</c> on SQL Server).
+    /// </summary>
+    public static CastExpression Cast(object expr, string type) =>
+        new(Resolve(expr), type);
+
     public static CoalesceFunction Coalesce(
         object primary,
         object secondary,

--- a/tests/SqlArtisan.Tests/CastTests.cs
+++ b/tests/SqlArtisan.Tests/CastTests.cs
@@ -1,0 +1,73 @@
+using static SqlArtisan.Sql;
+
+namespace SqlArtisan.Tests;
+
+public class CastTests
+{
+    private readonly TestTable _t = new();
+
+    [Fact]
+    public void Cast_Column_CorrectSql()
+    {
+        // Arrange
+        string expected = "SELECT CAST(code AS VARCHAR(10)) FROM test_table";
+
+        // Act
+        SqlStatement sql =
+            Select(Cast(_t.Code, "VARCHAR(10)"))
+            .From(_t)
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void Cast_Literal_CorrectSql()
+    {
+        // Arrange
+        string expected = "SELECT CAST(:0 AS INTEGER) FROM test_table";
+
+        // Act
+        SqlStatement sql =
+            Select(Cast("123", "INTEGER"))
+            .From(_t)
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void Cast_WithAlias_CorrectSql()
+    {
+        // Arrange
+        string expected = "SELECT CAST(code AS VARCHAR(10)) \"code_str\" FROM test_table";
+
+        // Act
+        SqlStatement sql =
+            Select(Cast(_t.Code, "VARCHAR(10)").As("code_str"))
+            .From(_t)
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void Cast_InWhere_CorrectSql()
+    {
+        // Arrange
+        string expected = "SELECT name FROM test_table WHERE CAST(code AS VARCHAR(10)) = :0";
+
+        // Act
+        SqlStatement sql =
+            Select(_t.Name)
+            .From(_t)
+            .Where(Cast(_t.Code, "VARCHAR(10)") == "5")
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+}


### PR DESCRIPTION
Closes #52

## Summary

Adds the ANSI `CAST(expr AS type)` expression — a Tier-1 type-conversion gap for 1.0. `CAST` has identical syntax across PostgreSQL, MySQL, SQLite, Oracle, and SQL Server.

## API

```csharp
Cast(t.Code, "VARCHAR(10)")                 // CAST(code AS VARCHAR(10))
Cast("123", "INTEGER")                       // CAST(:0 AS INTEGER)
Cast(u.Id, "VARCHAR(10)").As("id_text")      // CAST(id AS VARCHAR(10)) "id_text"
```

- The expression is resolved like any other input (column, literal → bind parameter, function, arithmetic).
- `CastExpression` is a `SqlExpression`, so it composes anywhere an expression is allowed (SELECT list, WHERE, ORDER BY, aliasing, nesting).
- The target **type is emitted verbatim**: write your database's exact SQL data type (`VARCHAR2(10)` on Oracle, `NVARCHAR(10)` on SQL Server, …). Dialect-specific type names are not abstracted, consistent with the design philosophy.

## Out of scope: `CONVERT`

`CONVERT` is intentionally excluded — it is dialect-divergent in both syntax and semantics (SQL Server `CONVERT(type, expr, style)`, MySQL `CONVERT(expr, type)`, Oracle/PostgreSQL character-set conversion). A future `CONVERT` would be exposed as distinct dialect-faithful methods, tracked separately.

## Testing

- Added `CastTests` (column, literal, alias, WHERE), written in the Arrange-Act-Assert style.
- Full suite: 296 tests passing; Release build clean (0 warnings, 0 errors).
- README (new CAST section + ToC) and CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
