### PR TITLE
feat: Add support for multi-row INSERT ... VALUES (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added support for pagination: `Limit`/`Offset` (PostgreSQL/MySQL/SQLite) and `OffsetRows`/`FetchFirst`/`FetchNext` (Oracle 12c+/SQL Server 2012+). (#49)
 - Added support for the ANSI `CAST(expr AS type)` expression. (#52)
+- Added support for multi-row `INSERT ... VALUES` by chaining `Values()`. (#54)
 
 ### Changed
 - Improved `SqlBuildingBuffer` memory efficiency and throughput. (#45)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ So you can focus on the query logic, not the boilerplate. That’s why SqlArtisa
     - [Pagination](#pagination): `LIMIT`, `OFFSET`, `FETCH`
   - [DELETE Statement](#delete-statement)
   - [UPDATE Statement](#update-statement)
-  - [INSERT Statement](#insert-statement): **Standard**, **SET-like**, `INSERT SELECT`
+  - [INSERT Statement](#insert-statement): **Standard**, **Multiple Rows**, **SET-like**, `INSERT SELECT`
   - [WITH Clause (Common Table Expressions)](#with-clause-common-table-expressions): `WITH`, `WITH RECURSIVE`, **CTEs with DML**
   - [RETURNING Clause](#returning-clause): `RETURNING`, `RETURNING INTO` (Oracle)
   - [Expressions](#expressions)
@@ -715,6 +715,29 @@ SqlStatement sql =
 // VALUES
 // (:0, :1, CURRENT_TIMESTAMP)
 ```
+
+---
+
+#### Multiple Rows
+
+Chain `Values()` to insert multiple rows in a single statement.
+
+```csharp
+UsersTable u = new();
+SqlStatement sql =
+    InsertInto(u, u.Id, u.Name)
+    .Values(1, "Alice")
+    .Values(2, "Bob")
+    .Values(3, "Carol")
+    .Build();
+
+// INSERT INTO users
+// (id, name)
+// VALUES
+// (:0, :1), (:2, :3), (:4, :5)
+```
+
+**Note:** Multi-row `VALUES` is supported by PostgreSQL, MySQL, SQLite, and SQL Server (2008+). Oracle does not support multi-row `VALUES`; it uses `INSERT ALL` instead.
 
 ---
 

--- a/src/SqlArtisan/Internal/SqlBuilder/Insert/IInsertBuilderValues.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Insert/IInsertBuilderValues.cs
@@ -1,4 +1,4 @@
-namespace SqlArtisan.Internal;
+﻿namespace SqlArtisan.Internal;
 
 public interface IInsertBuilderValues : ISqlBuilder, IReturning
 {

--- a/src/SqlArtisan/Internal/SqlBuilder/Insert/IInsertBuilderValues.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Insert/IInsertBuilderValues.cs
@@ -1,5 +1,11 @@
-﻿namespace SqlArtisan.Internal;
+namespace SqlArtisan.Internal;
 
 public interface IInsertBuilderValues : ISqlBuilder, IReturning
 {
+    /// <summary>
+    /// Appends another row to the <c>VALUES</c> clause, producing a multi-row
+    /// insert (<c>VALUES (...), (...)</c>). Supported by PostgreSQL, MySQL, SQLite,
+    /// and SQL Server; Oracle does not support multi-row <c>VALUES</c>.
+    /// </summary>
+    IInsertBuilderValues Values(params object[] values);
 }

--- a/src/SqlArtisan/Internal/SqlBuilder/Insert/InsertBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Insert/InsertBuilder.cs
@@ -7,6 +7,8 @@ internal sealed class InsertBuilder(params SqlPart[] rootParts) :
     IInsertBuilderTable,
     IInsertBuilderValues
 {
+    private InsertValuesClause? _valuesClause;
+
     public IReturningBuilder Returning(params object[] expressions) =>
         ReturningBuilder.Create(this, expressions);
 
@@ -18,7 +20,16 @@ internal sealed class InsertBuilder(params SqlPart[] rootParts) :
 
     public IInsertBuilderValues Values(params object[] values)
     {
-        AddPart(InsertValuesClause.Parse(values));
+        if (_valuesClause is null)
+        {
+            _valuesClause = InsertValuesClause.Parse(values);
+            AddPart(_valuesClause);
+        }
+        else
+        {
+            _valuesClause.AddRow(values);
+        }
+
         return this;
     }
 

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Insert/InsertValuesClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Insert/InsertValuesClause.cs
@@ -1,20 +1,35 @@
-﻿namespace SqlArtisan.Internal;
+namespace SqlArtisan.Internal;
 
 internal sealed class InsertValuesClause : SqlPart
 {
-    private readonly SqlExpression[] _values;
+    private readonly List<SqlExpression[]> _rows;
 
-    private InsertValuesClause(SqlExpression[] values)
+    private InsertValuesClause(SqlExpression[] firstRow)
     {
-        _values = values;
+        _rows = [firstRow];
     }
 
     internal static InsertValuesClause Parse(object[] values) =>
         new(InsertValueResolver.Resolve(values));
 
-    internal override void Format(SqlBuildingBuffer buffer) => buffer
-        .Append($"{Keywords.Values} ")
-        .OpenParenthesis()
-        .AppendCsv(_values)
-        .CloseParenthesis();
+    internal void AddRow(object[] values) =>
+        _rows.Add(InsertValueResolver.Resolve(values));
+
+    internal override void Format(SqlBuildingBuffer buffer)
+    {
+        buffer.Append($"{Keywords.Values} ");
+
+        for (int i = 0; i < _rows.Count; i++)
+        {
+            if (i > 0)
+            {
+                buffer.Append(", ");
+            }
+
+            buffer
+                .OpenParenthesis()
+                .AppendCsv(_rows[i])
+                .CloseParenthesis();
+        }
+    }
 }

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Insert/InsertValuesClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Insert/InsertValuesClause.cs
@@ -1,4 +1,4 @@
-namespace SqlArtisan.Internal;
+﻿namespace SqlArtisan.Internal;
 
 internal sealed class InsertValuesClause : SqlPart
 {

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Insert/InsertValuesClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Insert/InsertValuesClause.cs
@@ -12,8 +12,19 @@ internal sealed class InsertValuesClause : SqlPart
     internal static InsertValuesClause Parse(object[] values) =>
         new(InsertValueResolver.Resolve(values));
 
-    internal void AddRow(object[] values) =>
-        _rows.Add(InsertValueResolver.Resolve(values));
+    internal void AddRow(object[] values)
+    {
+        SqlExpression[] row = InsertValueResolver.Resolve(values);
+
+        if (row.Length != _rows[0].Length)
+        {
+            throw new ArgumentException(
+                "All rows in a multi-row INSERT must have the same number of values. " +
+                $"The first row has {_rows[0].Length}, but this row has {row.Length}.");
+        }
+
+        _rows.Add(row);
+    }
 
     internal override void Format(SqlBuildingBuffer buffer)
     {

--- a/tests/SqlArtisan.Tests/MultiRowInsertTests.cs
+++ b/tests/SqlArtisan.Tests/MultiRowInsertTests.cs
@@ -1,0 +1,87 @@
+using System.Text;
+using static SqlArtisan.Sql;
+
+namespace SqlArtisan.Tests;
+
+public class MultiRowInsertTests
+{
+    private readonly TestTable _t = new();
+
+    [Fact]
+    public void Values_TwoRows_CorrectSql()
+    {
+        // Arrange
+        StringBuilder expected = new();
+        expected.Append("INSERT INTO test_table (code, name) ");
+        expected.Append("VALUES (:0, :1), (:2, :3)");
+
+        // Act
+        SqlStatement sql =
+            InsertInto(_t, _t.Code, _t.Name)
+            .Values(1, "a")
+            .Values(2, "b")
+            .Build();
+
+        // Assert
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
+    public void Values_ThreeRows_CorrectSql()
+    {
+        // Arrange
+        StringBuilder expected = new();
+        expected.Append("INSERT INTO test_table (code, name) ");
+        expected.Append("VALUES (:0, :1), (:2, :3), (:4, :5)");
+
+        // Act
+        SqlStatement sql =
+            InsertInto(_t, _t.Code, _t.Name)
+            .Values(1, "a")
+            .Values(2, "b")
+            .Values(3, "c")
+            .Build();
+
+        // Assert
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
+    public void Values_SingleRow_CorrectSql()
+    {
+        // Arrange
+        StringBuilder expected = new();
+        expected.Append("INSERT INTO test_table (code, name) ");
+        expected.Append("VALUES (:0, :1)");
+
+        // Act
+        SqlStatement sql =
+            InsertInto(_t, _t.Code, _t.Name)
+            .Values(1, "a")
+            .Build();
+
+        // Assert
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
+    public void Values_MultiRowWithReturning_CorrectSql()
+    {
+        // Arrange
+        StringBuilder expected = new();
+        expected.Append("INSERT INTO test_table (code, name) ");
+        expected.Append("VALUES (:0, :1), (:2, :3) ");
+        expected.Append("RETURNING code, name");
+
+        // Act
+        SqlStatement sql =
+            InsertInto(_t, _t.Code, _t.Name)
+            .Values(1, "a")
+            .Values(2, "b")
+            .Returning(_t.Code, _t.Name)
+            .Build();
+
+        // Assert
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+}

--- a/tests/SqlArtisan.Tests/MultiRowInsertTests.cs
+++ b/tests/SqlArtisan.Tests/MultiRowInsertTests.cs
@@ -84,4 +84,13 @@ public class MultiRowInsertTests
         // Assert
         Assert.Equal(expected.ToString(), sql.Text);
     }
+
+    [Fact]
+    public void Values_MismatchedRowLength_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            InsertInto(_t, _t.Code, _t.Name)
+            .Values(1, "a")
+            .Values(2));
+    }
 }

--- a/tests/SqlArtisan.Tests/MultiRowInsertTests.cs
+++ b/tests/SqlArtisan.Tests/MultiRowInsertTests.cs
@@ -8,6 +8,24 @@ public class MultiRowInsertTests
     private readonly TestTable _t = new();
 
     [Fact]
+    public void Values_SingleRow_CorrectSql()
+    {
+        // Arrange
+        StringBuilder expected = new();
+        expected.Append("INSERT INTO test_table (code, name) ");
+        expected.Append("VALUES (:0, :1)");
+
+        // Act
+        SqlStatement sql =
+            InsertInto(_t, _t.Code, _t.Name)
+            .Values(1, "a")
+            .Build();
+
+        // Assert
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
     public void Values_TwoRows_CorrectSql()
     {
         // Arrange
@@ -40,24 +58,6 @@ public class MultiRowInsertTests
             .Values(1, "a")
             .Values(2, "b")
             .Values(3, "c")
-            .Build();
-
-        // Assert
-        Assert.Equal(expected.ToString(), sql.Text);
-    }
-
-    [Fact]
-    public void Values_SingleRow_CorrectSql()
-    {
-        // Arrange
-        StringBuilder expected = new();
-        expected.Append("INSERT INTO test_table (code, name) ");
-        expected.Append("VALUES (:0, :1)");
-
-        // Act
-        SqlStatement sql =
-            InsertInto(_t, _t.Code, _t.Name)
-            .Values(1, "a")
             .Build();
 
         // Assert


### PR DESCRIPTION
Closes #54

## Summary

Adds multi-row `INSERT ... VALUES` — a Tier-1 gap for 1.0. Rows are added by chaining `Values(...)`:

```csharp
InsertInto(t, t.Code, t.Name)
    .Values(1, "a")
    .Values(2, "b")
    .Values(3, "c")
    .Build();

// INSERT INTO test_table (code, name)
// VALUES (:0, :1), (:2, :3), (:4, :5)
```

## Implementation

- `IInsertBuilderValues` gains a chainable `Values(...)`.
- `InsertValuesClause` now holds a list of rows and renders them comma-separated (one `VALUES` keyword, multiple tuples).
- `InsertBuilder` keeps a reference to the values clause so the first `Values()` creates it and subsequent calls append rows.
- The single-row form (`Values(1, "a")`) is unchanged and fully backward compatible.

## Dialect note

Multi-row `VALUES (...), (...)` is supported by PostgreSQL, MySQL, SQLite, and SQL Server (2008+). **Oracle does not support multi-row `VALUES`** (it uses `INSERT ALL`). Consistent with the design philosophy, SqlArtisan emits the standard form and documents this caveat rather than gating on dialect.

## Testing

- Added `MultiRowInsertTests` (two rows, three rows, single-row regression, multi-row + RETURNING), in Arrange-Act-Assert style.
- Full suite: 300 tests passing; Release build clean (0 warnings, 0 errors).
- README (new "Multiple Rows" section + ToC) and CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
