### PR TITLE
feat: Add support for window frames (ROWS / RANGE) (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for the ANSI `CAST(expr AS type)` expression. (#52)
 - Added support for multi-row `INSERT ... VALUES` by chaining `Values()`. (#54)
 - Added support for aggregate window functions (`Sum`/`Count`/`Avg`/`Max`/`Min` with `Over(...)`). (#56)
+- Added support for window frames (`ROWS` / `RANGE`) via `Rows(...)` / `Range(...)`. (#58)
 
 ### Changed
 - Improved `SqlBuildingBuffer` memory efficiency and throughput. (#45)

--- a/README.md
+++ b/README.md
@@ -1271,6 +1271,29 @@ SqlStatement sql =
 
 **Note:** Most databases do not allow `DISTINCT` in a windowed aggregate (e.g. `SUM(DISTINCT x) OVER (...)`), so avoid combining a distinct aggregate with `Over(...)`.
 
+###### Window Frames (ROWS / RANGE)
+
+Attach a frame to an ordered window with `Rows(...)` / `Range(...)` for moving or cumulative calculations.
+
+```csharp
+UsersTable u = new();
+SqlStatement sql =
+    Select(
+        u.Id,
+        Avg(u.Amount).Over(OrderBy(u.Date).Rows(Preceding(4))).As("moving_avg"))
+    .From(u)
+    .Build();
+
+// SELECT id,
+// AVG(amount) OVER (ORDER BY date ROWS 4 PRECEDING) "moving_avg"
+// FROM users
+```
+
+- Bounds: `UnboundedPreceding`, `CurrentRow`, `UnboundedFollowing`, `Preceding(n)`, `Following(n)`.
+- A single bound uses `Rows(bound)` / `Range(bound)` (e.g. `Rows(UnboundedPreceding)`); `RowsBetween(start, end)` / `RangeBetween(start, end)` produce `ROWS/RANGE BETWEEN ... AND ...`.
+- A frame requires `ORDER BY`, so `Rows(...)` / `Range(...)` are available only after `OrderBy(...)` (optionally with `PartitionBy(...)`).
+- Requires PostgreSQL, Oracle, MySQL 8.0+, SQLite 3.25+, or SQL Server 2012+.
+
 ---
 
 #### Sequence

--- a/src/SqlArtisan/Internal/SqlPart/Clause/OrderBy/OrderByClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/OrderBy/OrderByClause.cs
@@ -10,19 +10,6 @@ public sealed class OrderByClause : SqlPart
     }
 
     /// <summary>
-    /// Adds a <c>ROWS bound</c> window frame to this ordering (for use within <c>OVER</c>).
-    /// </summary>
-    public WindowFrameClause Rows(FrameBound bound) =>
-        new(this, new WindowFrame(Keywords.Rows, bound));
-
-    /// <summary>
-    /// Adds a <c>ROWS BETWEEN start AND end</c> window frame to this ordering
-    /// (for use within <c>OVER</c>).
-    /// </summary>
-    public WindowFrameClause RowsBetween(FrameBound start, FrameBound end) =>
-        new(this, new WindowFrame(Keywords.Rows, new FrameBetween(start, end)));
-
-    /// <summary>
     /// Adds a <c>RANGE bound</c> window frame to this ordering (for use within <c>OVER</c>).
     /// </summary>
     public WindowFrameClause Range(FrameBound bound) =>
@@ -34,6 +21,19 @@ public sealed class OrderByClause : SqlPart
     /// </summary>
     public WindowFrameClause RangeBetween(FrameBound start, FrameBound end) =>
         new(this, new WindowFrame(Keywords.Range, new FrameBetween(start, end)));
+
+    /// <summary>
+    /// Adds a <c>ROWS bound</c> window frame to this ordering (for use within <c>OVER</c>).
+    /// </summary>
+    public WindowFrameClause Rows(FrameBound bound) =>
+        new(this, new WindowFrame(Keywords.Rows, bound));
+
+    /// <summary>
+    /// Adds a <c>ROWS BETWEEN start AND end</c> window frame to this ordering
+    /// (for use within <c>OVER</c>).
+    /// </summary>
+    public WindowFrameClause RowsBetween(FrameBound start, FrameBound end) =>
+        new(this, new WindowFrame(Keywords.Rows, new FrameBetween(start, end)));
 
     internal static OrderByClause Parse(object[] orderByItems) =>
         new(OrderByItemResolver.Resolve(orderByItems));

--- a/src/SqlArtisan/Internal/SqlPart/Clause/OrderBy/OrderByClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/OrderBy/OrderByClause.cs
@@ -9,6 +9,32 @@ public sealed class OrderByClause : SqlPart
         _orderByItems = orderByItems;
     }
 
+    /// <summary>
+    /// Adds a <c>ROWS bound</c> window frame to this ordering (for use within <c>OVER</c>).
+    /// </summary>
+    public WindowFrameClause Rows(FrameBound bound) =>
+        new(this, new WindowFrame(Keywords.Rows, bound));
+
+    /// <summary>
+    /// Adds a <c>ROWS BETWEEN start AND end</c> window frame to this ordering
+    /// (for use within <c>OVER</c>).
+    /// </summary>
+    public WindowFrameClause RowsBetween(FrameBound start, FrameBound end) =>
+        new(this, new WindowFrame(Keywords.Rows, new FrameBetween(start, end)));
+
+    /// <summary>
+    /// Adds a <c>RANGE bound</c> window frame to this ordering (for use within <c>OVER</c>).
+    /// </summary>
+    public WindowFrameClause Range(FrameBound bound) =>
+        new(this, new WindowFrame(Keywords.Range, bound));
+
+    /// <summary>
+    /// Adds a <c>RANGE BETWEEN start AND end</c> window frame to this ordering
+    /// (for use within <c>OVER</c>).
+    /// </summary>
+    public WindowFrameClause RangeBetween(FrameBound start, FrameBound end) =>
+        new(this, new WindowFrame(Keywords.Range, new FrameBetween(start, end)));
+
     internal static OrderByClause Parse(object[] orderByItems) =>
         new(OrderByItemResolver.Resolve(orderByItems));
 

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Over/FrameBetween.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Over/FrameBetween.cs
@@ -1,0 +1,23 @@
+﻿namespace SqlArtisan.Internal;
+
+/// <summary>
+/// A <c>BETWEEN start AND end</c> window-frame extent.
+/// </summary>
+internal sealed class FrameBetween : SqlPart
+{
+    private readonly FrameBound _start;
+    private readonly FrameBound _end;
+
+    internal FrameBetween(FrameBound start, FrameBound end)
+    {
+        _start = start;
+        _end = end;
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append(Keywords.Between)
+        .AppendSpace()
+        .Append(_start)
+        .EncloseInSpaces(Keywords.And)
+        .Append(_end);
+}

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Over/FrameBound.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Over/FrameBound.cs
@@ -1,0 +1,33 @@
+﻿namespace SqlArtisan.Internal;
+
+/// <summary>
+/// A single window-frame bound, such as <c>UNBOUNDED PRECEDING</c>,
+/// <c>CURRENT ROW</c>, or <c>n PRECEDING</c>.
+/// </summary>
+public sealed class FrameBound : SqlPart
+{
+    private readonly string _text;
+
+    private FrameBound(string text)
+    {
+        _text = text;
+    }
+
+    internal static FrameBound UnboundedPreceding() =>
+        new($"{Keywords.Unbounded} {Keywords.Preceding}");
+
+    internal static FrameBound CurrentRow() =>
+        new($"{Keywords.Current} {Keywords.Row}");
+
+    internal static FrameBound UnboundedFollowing() =>
+        new($"{Keywords.Unbounded} {Keywords.Following}");
+
+    internal static FrameBound Preceding(int offset) =>
+        new($"{offset} {Keywords.Preceding}");
+
+    internal static FrameBound Following(int offset) =>
+        new($"{offset} {Keywords.Following}");
+
+    internal override void Format(SqlBuildingBuffer buffer) =>
+        buffer.Append(_text);
+}

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Over/FrameBound.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Over/FrameBound.cs
@@ -16,17 +16,17 @@ public sealed class FrameBound : SqlPart
     internal static FrameBound UnboundedPreceding() =>
         new($"{Keywords.Unbounded} {Keywords.Preceding}");
 
-    internal static FrameBound CurrentRow() =>
-        new($"{Keywords.Current} {Keywords.Row}");
-
-    internal static FrameBound UnboundedFollowing() =>
-        new($"{Keywords.Unbounded} {Keywords.Following}");
-
     internal static FrameBound Preceding(int offset) =>
         new($"{offset} {Keywords.Preceding}");
 
+    internal static FrameBound CurrentRow() =>
+        new($"{Keywords.Current} {Keywords.Row}");
+
     internal static FrameBound Following(int offset) =>
         new($"{offset} {Keywords.Following}");
+
+    internal static FrameBound UnboundedFollowing() =>
+        new($"{Keywords.Unbounded} {Keywords.Following}");
 
     internal override void Format(SqlBuildingBuffer buffer) =>
         buffer.Append(_text);

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Over/OverClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Over/OverClause.cs
@@ -2,30 +2,26 @@
 
 public sealed class OverClause : SqlPart
 {
-    private readonly PartitionByClause? _partitionByClause;
-    private readonly OrderByClause? _orderByClause;
-    private readonly PartitionByAndOrderBy? _partitionByAndOrderBy;
+    private readonly SqlPart? _content;
 
-    private OverClause(
-        PartitionByClause? partitionByClause = null,
-        PartitionByAndOrderBy? partitionByAndOrderBy = null,
-        OrderByClause? orderByClause = null)
+    private OverClause(SqlPart? content = null)
     {
-        _partitionByClause = partitionByClause;
-        _partitionByAndOrderBy = partitionByAndOrderBy;
-        _orderByClause = orderByClause;
+        _content = content;
     }
 
     internal static OverClause Of() => new();
 
-    internal static OverClause Of(PartitionByClause partitionByClause) =>
-        new(partitionByClause);
+    internal static OverClause Of(PartitionByClause content) =>
+        new(content);
 
-    internal static OverClause Of(PartitionByAndOrderBy partitionByAndOrderBy) =>
-        new(null, partitionByAndOrderBy);
+    internal static OverClause Of(OrderByClause content) =>
+        new(content);
 
-    internal static OverClause Of(OrderByClause orderByClause) =>
-        new(null, null, orderByClause);
+    internal static OverClause Of(PartitionByAndOrderBy content) =>
+        new(content);
+
+    internal static OverClause Of(WindowFrameClause content) =>
+        new(content);
 
     internal override void Format(SqlBuildingBuffer buffer)
     {
@@ -33,18 +29,7 @@ public sealed class OverClause : SqlPart
             .AppendSpace()
             .OpenParenthesis();
 
-        if (_partitionByAndOrderBy is not null)
-        {
-            _partitionByAndOrderBy.Format(buffer);
-        }
-        else if (_partitionByClause is not null)
-        {
-            _partitionByClause.Format(buffer);
-        }
-        else if (_orderByClause is not null)
-        {
-            _orderByClause.Format(buffer);
-        }
+        _content?.Format(buffer);
 
         buffer.CloseParenthesis();
     }

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Over/PartitionByAndOrderBy.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Over/PartitionByAndOrderBy.cs
@@ -13,6 +13,32 @@ public sealed class PartitionByAndOrderBy : SqlPart
         _orderByClause = orderByClause;
     }
 
+    /// <summary>
+    /// Adds a <c>ROWS bound</c> window frame to this partition/ordering (for use within <c>OVER</c>).
+    /// </summary>
+    public WindowFrameClause Rows(FrameBound bound) =>
+        new(this, new WindowFrame(Keywords.Rows, bound));
+
+    /// <summary>
+    /// Adds a <c>ROWS BETWEEN start AND end</c> window frame to this partition/ordering
+    /// (for use within <c>OVER</c>).
+    /// </summary>
+    public WindowFrameClause RowsBetween(FrameBound start, FrameBound end) =>
+        new(this, new WindowFrame(Keywords.Rows, new FrameBetween(start, end)));
+
+    /// <summary>
+    /// Adds a <c>RANGE bound</c> window frame to this partition/ordering (for use within <c>OVER</c>).
+    /// </summary>
+    public WindowFrameClause Range(FrameBound bound) =>
+        new(this, new WindowFrame(Keywords.Range, bound));
+
+    /// <summary>
+    /// Adds a <c>RANGE BETWEEN start AND end</c> window frame to this partition/ordering
+    /// (for use within <c>OVER</c>).
+    /// </summary>
+    public WindowFrameClause RangeBetween(FrameBound start, FrameBound end) =>
+        new(this, new WindowFrame(Keywords.Range, new FrameBetween(start, end)));
+
     internal override void Format(SqlBuildingBuffer buffer) => buffer
         .AppendSpaceIfNotNull(_partitionByClause)
         .Append(_orderByClause);

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Over/PartitionByAndOrderBy.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Over/PartitionByAndOrderBy.cs
@@ -14,19 +14,6 @@ public sealed class PartitionByAndOrderBy : SqlPart
     }
 
     /// <summary>
-    /// Adds a <c>ROWS bound</c> window frame to this partition/ordering (for use within <c>OVER</c>).
-    /// </summary>
-    public WindowFrameClause Rows(FrameBound bound) =>
-        new(this, new WindowFrame(Keywords.Rows, bound));
-
-    /// <summary>
-    /// Adds a <c>ROWS BETWEEN start AND end</c> window frame to this partition/ordering
-    /// (for use within <c>OVER</c>).
-    /// </summary>
-    public WindowFrameClause RowsBetween(FrameBound start, FrameBound end) =>
-        new(this, new WindowFrame(Keywords.Rows, new FrameBetween(start, end)));
-
-    /// <summary>
     /// Adds a <c>RANGE bound</c> window frame to this partition/ordering (for use within <c>OVER</c>).
     /// </summary>
     public WindowFrameClause Range(FrameBound bound) =>
@@ -38,6 +25,19 @@ public sealed class PartitionByAndOrderBy : SqlPart
     /// </summary>
     public WindowFrameClause RangeBetween(FrameBound start, FrameBound end) =>
         new(this, new WindowFrame(Keywords.Range, new FrameBetween(start, end)));
+
+    /// <summary>
+    /// Adds a <c>ROWS bound</c> window frame to this partition/ordering (for use within <c>OVER</c>).
+    /// </summary>
+    public WindowFrameClause Rows(FrameBound bound) =>
+        new(this, new WindowFrame(Keywords.Rows, bound));
+
+    /// <summary>
+    /// Adds a <c>ROWS BETWEEN start AND end</c> window frame to this partition/ordering
+    /// (for use within <c>OVER</c>).
+    /// </summary>
+    public WindowFrameClause RowsBetween(FrameBound start, FrameBound end) =>
+        new(this, new WindowFrame(Keywords.Rows, new FrameBetween(start, end)));
 
     internal override void Format(SqlBuildingBuffer buffer) => buffer
         .AppendSpaceIfNotNull(_partitionByClause)

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Over/WindowFrame.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Over/WindowFrame.cs
@@ -1,0 +1,18 @@
+﻿namespace SqlArtisan.Internal;
+
+internal sealed class WindowFrame : SqlPart
+{
+    private readonly string _unit;
+    private readonly SqlPart _extent;
+
+    internal WindowFrame(string unit, SqlPart extent)
+    {
+        _unit = unit;
+        _extent = extent;
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append(_unit)
+        .AppendSpace()
+        .Append(_extent);
+}

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Over/WindowFrameClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Over/WindowFrameClause.cs
@@ -1,0 +1,21 @@
+﻿namespace SqlArtisan.Internal;
+
+/// <summary>
+/// A window specification with a frame: an <c>ORDER BY</c> (optionally preceded
+/// by <c>PARTITION BY</c>) followed by a <c>ROWS</c> / <c>RANGE</c> frame.
+/// </summary>
+public sealed class WindowFrameClause : SqlPart
+{
+    private readonly SqlPart _windowOrdering;
+    private readonly WindowFrame _frame;
+
+    internal WindowFrameClause(SqlPart windowOrdering, WindowFrame frame)
+    {
+        _windowOrdering = windowOrdering;
+        _frame = frame;
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .AppendSpace(_windowOrdering)
+        .Append(_frame);
+}

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/AggregateFunction/AggregateFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/AggregateFunction/AggregateFunction.cs
@@ -27,6 +27,13 @@ public abstract class AggregateFunction : SqlExpression
         new(this, OverClause.Of(partitionByClause));
 
     /// <summary>
+    /// Turns the aggregate into a window function ordered over the whole result
+    /// set: <c>OVER (ORDER BY ...)</c>.
+    /// </summary>
+    public WindowFunction Over(OrderByClause orderByClause) =>
+        new(this, OverClause.Of(orderByClause));
+
+    /// <summary>
     /// Turns the aggregate into a window function partitioned and ordered:
     /// <c>OVER (PARTITION BY ... ORDER BY ...)</c>.
     /// </summary>
@@ -34,9 +41,9 @@ public abstract class AggregateFunction : SqlExpression
         new(this, OverClause.Of(partitionByAndOrderBy));
 
     /// <summary>
-    /// Turns the aggregate into a window function ordered over the whole result
-    /// set: <c>OVER (ORDER BY ...)</c>.
+    /// Turns the aggregate into a window function with an explicit frame:
+    /// <c>OVER (... ROWS/RANGE ...)</c>.
     /// </summary>
-    public WindowFunction Over(OrderByClause orderByClause) =>
-        new(this, OverClause.Of(orderByClause));
+    public WindowFunction Over(WindowFrameClause windowFrameClause) =>
+        new(this, OverClause.Of(windowFrameClause));
 }

--- a/src/SqlArtisan/Internal/SqlPart/Keywords.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Keywords.cs
@@ -20,6 +20,7 @@ internal static class Keywords
     internal const string Count = "COUNT";
     internal const string Cross = "CROSS";
     internal const string CumeDist = "CUME_DIST";
+    internal const string Current = "CURRENT";
     internal const string CurrentDate = "CURRENT_DATE";
     internal const string CurrentTime = "CURRENT_TIME";
     internal const string CurrentTimestamp = "CURRENT_TIMESTAMP";
@@ -38,6 +39,7 @@ internal static class Keywords
     internal const string Extract = "EXTRACT";
     internal const string Fetch = "FETCH";
     internal const string First = "FIRST";
+    internal const string Following = "FOLLOWING";
     internal const string For = "FOR";
     internal const string From = "FROM";
     internal const string Full = "FULL";
@@ -85,6 +87,8 @@ internal static class Keywords
     internal const string Over = "OVER";
     internal const string Partition = "PARTITION";
     internal const string PercentRank = "PERCENT_RANK";
+    internal const string Preceding = "PRECEDING";
+    internal const string Range = "RANGE";
     internal const string Rank = "RANK";
     internal const string Recursive = "RECURSIVE";
     internal const string RegexpCount = "REGEXP_COUNT";
@@ -94,6 +98,7 @@ internal static class Keywords
     internal const string Replace = "REPLACE";
     internal const string Returning = "RETURNING";
     internal const string Right = "RIGHT";
+    internal const string Row = "ROW";
     internal const string RowNumber = "ROW_NUMBER";
     internal const string Rows = "ROWS";
     internal const string Rpad = "RPAD";
@@ -113,6 +118,7 @@ internal static class Keywords
     internal const string ToTimestamp = "TO_TIMESTAMP";
     internal const string Trim = "TRIM";
     internal const string Trunc = "TRUNC";
+    internal const string Unbounded = "UNBOUNDED";
     internal const string Union = "UNION";
     internal const string Update = "UPDATE";
     internal const string Upper = "UPPER";

--- a/src/SqlArtisan/Sql/Sql.C.cs
+++ b/src/SqlArtisan/Sql/Sql.C.cs
@@ -411,6 +411,12 @@ public static partial class Sql
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public static CurrentDateFunction CurrentDate => new();
 
+    /// <summary>
+    /// The <c>CURRENT ROW</c> window-frame bound.
+    /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public static FrameBound CurrentRow => FrameBound.CurrentRow();
+
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public static CurrentTimeFunction CurrentTime => new();
 

--- a/src/SqlArtisan/Sql/Sql.F.cs
+++ b/src/SqlArtisan/Sql/Sql.F.cs
@@ -1,0 +1,12 @@
+﻿using SqlArtisan.Internal;
+
+namespace SqlArtisan;
+
+public static partial class Sql
+{
+    /// <summary>
+    /// A <c>n FOLLOWING</c> window-frame bound (offset rows/range after the
+    /// current row).
+    /// </summary>
+    public static FrameBound Following(int offset) => FrameBound.Following(offset);
+}

--- a/src/SqlArtisan/Sql/Sql.P.cs
+++ b/src/SqlArtisan/Sql/Sql.P.cs
@@ -9,4 +9,10 @@ public static partial class Sql
         params object[] expressions) => new(Resolve(expressions));
 
     public static AnalyticPercentRankFunction PercentRank() => new();
+
+    /// <summary>
+    /// A <c>n PRECEDING</c> window-frame bound (offset rows/range before the
+    /// current row).
+    /// </summary>
+    public static FrameBound Preceding(int offset) => FrameBound.Preceding(offset);
 }

--- a/src/SqlArtisan/Sql/Sql.U.cs
+++ b/src/SqlArtisan/Sql/Sql.U.cs
@@ -7,16 +7,16 @@ namespace SqlArtisan;
 public static partial class Sql
 {
     /// <summary>
-    /// The <c>UNBOUNDED FOLLOWING</c> window-frame bound.
-    /// </summary>
-    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    public static FrameBound UnboundedFollowing => FrameBound.UnboundedFollowing();
-
-    /// <summary>
     /// The <c>UNBOUNDED PRECEDING</c> window-frame bound.
     /// </summary>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public static FrameBound UnboundedPreceding => FrameBound.UnboundedPreceding();
+
+    /// <summary>
+    /// The <c>UNBOUNDED FOLLOWING</c> window-frame bound.
+    /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public static FrameBound UnboundedFollowing => FrameBound.UnboundedFollowing();
 
     public static IUpdateBuilderUpdate Update(DbTableBase table) =>
         new UpdateBuilder(new UpdateClause(table));

--- a/src/SqlArtisan/Sql/Sql.U.cs
+++ b/src/SqlArtisan/Sql/Sql.U.cs
@@ -1,10 +1,23 @@
-﻿using SqlArtisan.Internal;
+﻿using System.Diagnostics;
+using SqlArtisan.Internal;
 using static SqlArtisan.Internal.ExpressionResolver;
 
 namespace SqlArtisan;
 
 public static partial class Sql
 {
+    /// <summary>
+    /// The <c>UNBOUNDED FOLLOWING</c> window-frame bound.
+    /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public static FrameBound UnboundedFollowing => FrameBound.UnboundedFollowing();
+
+    /// <summary>
+    /// The <c>UNBOUNDED PRECEDING</c> window-frame bound.
+    /// </summary>
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    public static FrameBound UnboundedPreceding => FrameBound.UnboundedPreceding();
+
     public static IUpdateBuilderUpdate Update(DbTableBase table) =>
         new UpdateBuilder(new UpdateClause(table));
 

--- a/tests/SqlArtisan.Tests/AggregateWindowTests.cs
+++ b/tests/SqlArtisan.Tests/AggregateWindowTests.cs
@@ -33,6 +33,19 @@ public class AggregateWindowTests
     }
 
     [Fact]
+    public void Sum_OverOrderBy_CorrectSql()
+    {
+        // Arrange
+        string expected = "SELECT SUM(code) OVER (ORDER BY code)";
+
+        // Act
+        SqlStatement sql = Select(Sum(_t.Code).Over(OrderBy(_t.Code))).Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
     public void Sum_OverPartitionByOrderBy_CorrectSql()
     {
         // Arrange
@@ -42,19 +55,6 @@ public class AggregateWindowTests
         SqlStatement sql =
             Select(Sum(_t.Code).Over(PartitionBy(_t.Name).OrderBy(_t.Code)))
             .Build();
-
-        // Assert
-        Assert.Equal(expected, sql.Text);
-    }
-
-    [Fact]
-    public void Sum_OverOrderBy_CorrectSql()
-    {
-        // Arrange
-        string expected = "SELECT SUM(code) OVER (ORDER BY code)";
-
-        // Act
-        SqlStatement sql = Select(Sum(_t.Code).Over(OrderBy(_t.Code))).Build();
 
         // Assert
         Assert.Equal(expected, sql.Text);

--- a/tests/SqlArtisan.Tests/WindowFrameTests.cs
+++ b/tests/SqlArtisan.Tests/WindowFrameTests.cs
@@ -1,0 +1,96 @@
+using static SqlArtisan.Sql;
+
+namespace SqlArtisan.Tests;
+
+public class WindowFrameTests
+{
+    private readonly TestTable _t = new();
+
+    [Fact]
+    public void Rows_UnboundedPreceding_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT SUM(code) OVER (ORDER BY code ROWS UNBOUNDED PRECEDING)";
+
+        // Act
+        SqlStatement sql =
+            Select(Sum(_t.Code).Over(OrderBy(_t.Code).Rows(UnboundedPreceding)))
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void Rows_Preceding_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT AVG(code) OVER (ORDER BY code ROWS 4 PRECEDING)";
+
+        // Act
+        SqlStatement sql =
+            Select(Avg(_t.Code).Over(OrderBy(_t.Code).Rows(Preceding(4))))
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void RowsBetween_UnboundedPrecedingAndCurrentRow_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT SUM(code) OVER (ORDER BY code ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)";
+
+        // Act
+        SqlStatement sql =
+            Select(
+                Sum(_t.Code).Over(
+                    OrderBy(_t.Code).RowsBetween(UnboundedPreceding, CurrentRow)))
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void RangeBetween_PrecedingAndFollowing_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT SUM(code) OVER (ORDER BY code RANGE BETWEEN 10 PRECEDING AND 10 FOLLOWING)";
+
+        // Act
+        SqlStatement sql =
+            Select(
+                Sum(_t.Code).Over(
+                    OrderBy(_t.Code).RangeBetween(Preceding(10), Following(10))))
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void RowsBetween_WithPartitionBy_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT SUM(code) OVER (PARTITION BY name ORDER BY code ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)";
+
+        // Act
+        SqlStatement sql =
+            Select(
+                Sum(_t.Code).Over(
+                    PartitionBy(_t.Name)
+                    .OrderBy(_t.Code)
+                    .RowsBetween(CurrentRow, UnboundedFollowing)))
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+}


### PR DESCRIPTION
Closes #58

## Summary

Adds `ROWS` / `RANGE` window frames, enabling moving and cumulative window calculations and laying the groundwork for `LAST_VALUE` / `NTH_VALUE`. Scope matches the window-frame coverage of "SQLポケットリファレンス (改訂第5版)".

## API

Frames attach to an ordered window (a frame requires `ORDER BY`, enforced by the type system):

```csharp
Sum(u.Amount).Over(OrderBy(u.Date).Rows(UnboundedPreceding))                          // ROWS UNBOUNDED PRECEDING
Avg(u.Price).Over(OrderBy(u.Date).Rows(Preceding(4)))                                 // ROWS 4 PRECEDING (moving avg)
Sum(u.Amount).Over(PartitionBy(u.Dept).OrderBy(u.Date).RowsBetween(UnboundedPreceding, CurrentRow))
                                                                                      // ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
Sum(u.Amount).Over(OrderBy(u.Age).RangeBetween(Preceding(10), Following(10)))         // RANGE BETWEEN 10 PRECEDING AND 10 FOLLOWING
```

- Methods: `Rows` / `RowsBetween` / `Range` / `RangeBetween` (names mirror the SQL phrases, like `OrderBy`, `GroupBy`, `NullsFirst`). Each maps 1:1 to a distinct SQL frame form.
- Bounds: `UnboundedPreceding`, `CurrentRow`, `UnboundedFollowing` (properties); `Preceding(n)`, `Following(n)` (methods). Offsets are emitted as integer literals (SQL Server requires constant frame offsets).
- No global `Between` helper — `BETWEEN` is expressed by the `RowsBetween` / `RangeBetween` method names, avoiding any collision with the `col.Between(...)` condition.
- The extent is emitted verbatim; SqlArtisan does not validate bound combinations, consistent with the faithful-generation philosophy.
- `OverClause` is simplified to a single content part.

## Out of scope

- `GROUPS` frame unit and `EXCLUDE ...` (not in the reference; deferred).

## Dialect note

`ROWS` / `RANGE` frames require PostgreSQL, Oracle, MySQL 8.0+, SQLite 3.25+, or SQL Server 2012+.

## Testing

- Added `WindowFrameTests` (single bound, `ROWS BETWEEN`, `RANGE BETWEEN`, with `PARTITION BY`), Arrange-Act-Assert style.
- Full suite: 314 tests passing; Release build clean (0 warnings, 0 errors).
- README and CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
