### PR TITLE
feat: Add support for LAG / LEAD window functions (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for multi-row `INSERT ... VALUES` by chaining `Values()`. (#54)
 - Added support for aggregate window functions (`Sum`/`Count`/`Avg`/`Max`/`Min` with `Over(...)`). (#56)
 - Added support for window frames (`ROWS` / `RANGE`) via `Rows(...)` / `Range(...)`. (#58)
+- Added support for the `LAG` / `LEAD` offset window functions. (#60)
 
 ### Changed
 - Improved `SqlBuildingBuffer` memory efficiency and throughput. (#45)
 - Documented the design philosophy and non-goals, and surfaced dialect-specific features in the README and via XML doc comments. (#47)
+- Consolidated the ranking window functions' shared `Over(...)` overloads onto the `AnalyticFunction` base class (non-breaking). (#60)
 
 ## [0.2.0-beta.3] - 2026-06-07
 ### Added

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ So you can focus on the query logic, not the boilerplate. That’s why SqlArtisa
     - [Date and Time Functions](#date-and-time-functions): `ADD_MONTHS`, `CURRENT_DATE`, `CURRENT_TIME`, `CURRENT_TIMESTAMP`, `EXTRACT`, `LAST_DAY`, `MONTHS_BETWEEN`, `SYSDATE`, `SYSTIMESTAMP`, `TRUNC`
     - [Conversion Functions](#conversion-functions): `COALESCE`, `DECODE`, `NVL`, `TO_CHAR`, `TO_DATE`, `TO_NUMBER`, `TO_TIMESTAMP`
     - [Aggregate Functions](#aggregate-functions): `AVG`, `COUNT`, `MAX`, `MIN`, `SUM`
-    - [Window Functions](#window-functions-1): `CUME_DIST`, `DENSE_RANK`, `PERCENT_RANK`, `RANK`, `ROW_NUMBER`
+    - [Window Functions](#window-functions-1): `CUME_DIST`, `DENSE_RANK`, `LAG`, `LEAD`, `PERCENT_RANK`, `RANK`, `ROW_NUMBER`
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -1248,6 +1248,29 @@ SqlStatement sql =
 
 For a comprehensive list of all available window functions, please refer to the [Additional Query Details: Window Functions](#window-functions-1) section.
 
+##### Example using LAG / LEAD
+
+`Lag(...)` / `Lead(...)` read a value from a row a given number of rows behind or ahead of the current row. The offset defaults to `1`, and an optional default value fills the gap at the edge of the window.
+
+```csharp
+UsersTable u = new();
+SqlStatement sql =
+    Select(
+        u.Id,
+        u.Salary,
+        Lag(u.Salary).Over(OrderBy(u.Id)).As("prev_salary"),
+        Lead(u.Salary, 1, 0).Over(OrderBy(u.Id)).As("next_salary"))
+    .From(u)
+    .Build();
+
+// SELECT id, salary,
+// LAG(salary) OVER (ORDER BY id) "prev_salary",
+// LEAD(salary, 1, :0) OVER (ORDER BY id) "next_salary"
+// FROM users
+```
+
+Both require an `OrderBy(...)` (optionally with `PartitionBy(...)`). The offset is emitted as a literal so the SQL stays portable (MySQL requires a literal here), while the default value is parameterized.
+
 ##### Example using an Aggregate
 
 Aggregate functions (`Sum`, `Count`, `Avg`, `Max`, `Min`) can also be used as window functions via `Over(...)`.
@@ -1429,6 +1452,8 @@ SqlArtisan provides C# APIs that map to various SQL functions, enabling you to u
 
 - `CumeDist()` for `CUME_DIST()`
 - `DenseRank()` for `DENSE_RANK()`
+- `Lag(expr[, offset[, default]])` for `LAG(...)`
+- `Lead(expr[, offset[, default]])` for `LEAD(...)`
 - `PercentRank()` for `PERCENT_RANK()`
 - `Rank()` for `RANK()`
 - `RowNumber()` for `ROW_NUMBER()`

--- a/src/SqlArtisan/Internal/Extensions/Int32Extensions.cs
+++ b/src/SqlArtisan/Internal/Extensions/Int32Extensions.cs
@@ -1,0 +1,9 @@
+﻿using System.Globalization;
+
+namespace SqlArtisan.Internal;
+
+internal static class Int32Extensions
+{
+    internal static string ToInvariantString(this int value) =>
+        value.ToString(CultureInfo.InvariantCulture);
+}

--- a/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
@@ -222,6 +222,17 @@ internal sealed class SqlBuildingBuffer : IDisposable
         return this;
     }
 
+    internal SqlBuildingBuffer PrependCommaIfNotNull(string? value)
+    {
+        if (value is not null)
+        {
+            Append(", ");
+            Append(value);
+        }
+
+        return this;
+    }
+
     internal SqlBuildingBuffer PrependSpace(SqlPart part)
     {
         AppendSpace();

--- a/src/SqlArtisan/Internal/SqlPart/Expression/ExpressionResolver.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/ExpressionResolver.cs
@@ -4,8 +4,16 @@ namespace SqlArtisan.Internal;
 
 internal static class ExpressionResolver
 {
+    private const string NullValueMessage =
+        "Value cannot be null. Use Sql.Null to represent SQL NULL.";
+
     internal static (SqlExpression, SqlExpression)[] Resolve((object, object)[] pairs)
     {
+        if (pairs is null)
+        {
+            throw new ArgumentNullException(nameof(pairs), NullValueMessage);
+        }
+
         var resolved = new (SqlExpression, SqlExpression)[pairs.Length];
 
         for (int i = 0; i < pairs.Length; i++)
@@ -18,6 +26,11 @@ internal static class ExpressionResolver
 
     internal static SqlExpression[] Resolve(object[] items)
     {
+        if (items is null)
+        {
+            throw new ArgumentNullException(nameof(items), NullValueMessage);
+        }
+
         var resolved = new SqlExpression[items.Length];
 
         for (int i = 0; i < items.Length; i++)
@@ -30,6 +43,11 @@ internal static class ExpressionResolver
 
     internal static SqlExpression Resolve(object item)
     {
+        if (item is null)
+        {
+            throw new ArgumentNullException(nameof(item), NullValueMessage);
+        }
+
 #pragma warning disable IDE0046
         if (item is SqlExpression expr)
         {

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticCumeDistFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticCumeDistFunction.cs
@@ -4,12 +4,6 @@ public sealed class AnalyticCumeDistFunction : AnalyticFunction
 {
     internal AnalyticCumeDistFunction() { }
 
-    public WindowFunction Over(PartitionByAndOrderBy partitionByAndOrderBy) =>
-        new(this, OverClause.Of(partitionByAndOrderBy));
-
-    public WindowFunction Over(OrderByClause orderByClause) =>
-        new(this, OverClause.Of(orderByClause));
-
     internal override void Format(SqlBuildingBuffer buffer) => buffer
         .Append(Keywords.CumeDist)
         .OpenParenthesis()

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticDenseRankFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticDenseRankFunction.cs
@@ -4,12 +4,6 @@ public sealed class AnalyticDenseRankFunction : AnalyticFunction
 {
     internal AnalyticDenseRankFunction() { }
 
-    public WindowFunction Over(PartitionByAndOrderBy partitionByAndOrderBy) =>
-        new(this, OverClause.Of(partitionByAndOrderBy));
-
-    public WindowFunction Over(OrderByClause orderByClause) =>
-        new(this, OverClause.Of(orderByClause));
-
     internal override void Format(SqlBuildingBuffer buffer) => buffer
         .Append(Keywords.DenseRank)
         .OpenParenthesis()

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticFunction.cs
@@ -1,5 +1,27 @@
 ﻿namespace SqlArtisan.Internal;
 
+/// <summary>
+/// Base class for the ranking and offset (<c>LAG</c>/<c>LEAD</c>) analytic
+/// functions, whose window must be ordered and cannot take a frame.
+/// </summary>
+/// <remarks>
+/// They require <c>ORDER BY</c> and accept no <c>ROWS</c>/<c>RANGE</c> frame, so
+/// only the ordered <c>Over(...)</c> overloads are exposed — unlike
+/// <see cref="AggregateFunction"/>.
+/// </remarks>
 public abstract class AnalyticFunction() : SqlExpression
 {
+    /// <summary>
+    /// Turns the analytic function into a window function ordered over the whole
+    /// result set: <c>OVER (ORDER BY ...)</c>.
+    /// </summary>
+    public WindowFunction Over(OrderByClause orderByClause) =>
+        new(this, OverClause.Of(orderByClause));
+
+    /// <summary>
+    /// Turns the analytic function into a window function partitioned and
+    /// ordered: <c>OVER (PARTITION BY ... ORDER BY ...)</c>.
+    /// </summary>
+    public WindowFunction Over(PartitionByAndOrderBy partitionByAndOrderBy) =>
+        new(this, OverClause.Of(partitionByAndOrderBy));
 }

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticLagFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticLagFunction.cs
@@ -1,0 +1,40 @@
+﻿namespace SqlArtisan.Internal;
+
+public sealed class AnalyticLagFunction : AnalyticFunction
+{
+    private readonly SqlExpression _expr;
+    private readonly int? _offset;
+    private readonly SqlExpression? _default;
+
+    internal AnalyticLagFunction(SqlExpression expr)
+    {
+        _expr = expr;
+        _offset = null;
+        _default = null;
+    }
+
+    internal AnalyticLagFunction(SqlExpression expr, int offset)
+    {
+        _expr = expr;
+        _offset = offset;
+        _default = null;
+    }
+
+    internal AnalyticLagFunction(
+        SqlExpression expr,
+        int offset,
+        SqlExpression @default)
+    {
+        _expr = expr;
+        _offset = offset;
+        _default = @default;
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append(Keywords.Lag)
+        .OpenParenthesis()
+        .Append(_expr)
+        .PrependCommaIfNotNull(_offset?.ToInvariantString())
+        .PrependCommaIfNotNull(_default)
+        .CloseParenthesis();
+}

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticLeadFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticLeadFunction.cs
@@ -1,0 +1,40 @@
+﻿namespace SqlArtisan.Internal;
+
+public sealed class AnalyticLeadFunction : AnalyticFunction
+{
+    private readonly SqlExpression _expr;
+    private readonly int? _offset;
+    private readonly SqlExpression? _default;
+
+    internal AnalyticLeadFunction(SqlExpression expr)
+    {
+        _expr = expr;
+        _offset = null;
+        _default = null;
+    }
+
+    internal AnalyticLeadFunction(SqlExpression expr, int offset)
+    {
+        _expr = expr;
+        _offset = offset;
+        _default = null;
+    }
+
+    internal AnalyticLeadFunction(
+        SqlExpression expr,
+        int offset,
+        SqlExpression @default)
+    {
+        _expr = expr;
+        _offset = offset;
+        _default = @default;
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append(Keywords.Lead)
+        .OpenParenthesis()
+        .Append(_expr)
+        .PrependCommaIfNotNull(_offset?.ToInvariantString())
+        .PrependCommaIfNotNull(_default)
+        .CloseParenthesis();
+}

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticPercentRankFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticPercentRankFunction.cs
@@ -4,12 +4,6 @@ public sealed class AnalyticPercentRankFunction : AnalyticFunction
 {
     internal AnalyticPercentRankFunction() { }
 
-    public WindowFunction Over(PartitionByAndOrderBy partitionByAndOrderBy) =>
-        new(this, OverClause.Of(partitionByAndOrderBy));
-
-    public WindowFunction Over(OrderByClause orderByClause) =>
-        new(this, OverClause.Of(orderByClause));
-
     internal override void Format(SqlBuildingBuffer buffer) => buffer
         .Append(Keywords.PercentRank)
         .OpenParenthesis()

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticRankFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticRankFunction.cs
@@ -4,12 +4,6 @@ public sealed class AnalyticRankFunction : AnalyticFunction
 {
     internal AnalyticRankFunction() { }
 
-    public WindowFunction Over(PartitionByAndOrderBy partitionByAndOrderBy) =>
-        new(this, OverClause.Of(partitionByAndOrderBy));
-
-    public WindowFunction Over(OrderByClause orderByClause) =>
-        new(this, OverClause.Of(orderByClause));
-
     internal override void Format(SqlBuildingBuffer buffer) => buffer
         .Append(Keywords.Rank)
         .OpenParenthesis()

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticRowNumberFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticRowNumberFunction.cs
@@ -4,12 +4,6 @@ public sealed class AnalyticRowNumberFunction : AnalyticFunction
 {
     internal AnalyticRowNumberFunction() { }
 
-    public WindowFunction Over(PartitionByAndOrderBy partitionByAndOrderBy) =>
-        new(this, OverClause.Of(partitionByAndOrderBy));
-
-    public WindowFunction Over(OrderByClause orderByClause) =>
-        new(this, OverClause.Of(orderByClause));
-
     internal override void Format(SqlBuildingBuffer buffer) => buffer
         .Append(Keywords.RowNumber)
         .OpenParenthesis()

--- a/src/SqlArtisan/Internal/SqlPart/Keywords.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Keywords.cs
@@ -54,7 +54,9 @@ internal static class Keywords
     internal const string Into = "INTO";
     internal const string Is = "IS";
     internal const string Join = "JOIN";
+    internal const string Lag = "LAG";
     internal const string LastDay = "LAST_DAY";
+    internal const string Lead = "LEAD";
     internal const string Least = "LEAST";
     internal const string Left = "LEFT";
     internal const string Length = "LENGTH";

--- a/src/SqlArtisan/Sql/Sql.L.cs
+++ b/src/SqlArtisan/Sql/Sql.L.cs
@@ -5,8 +5,74 @@ namespace SqlArtisan;
 
 public static partial class Sql
 {
+    /// <summary>
+    /// The <c>LAG(expr)</c> analytic function: the value of
+    /// <paramref name="expr"/> from the row one position before the current row
+    /// in the window.
+    /// </summary>
+    public static AnalyticLagFunction Lag(object expr) =>
+        new(Resolve(expr));
+
+    /// <summary>
+    /// The <c>LAG(expr, offset)</c> analytic function: the value of
+    /// <paramref name="expr"/> from the row <paramref name="offset"/> positions
+    /// before the current row. The offset is emitted as an integer literal (not
+    /// a bind parameter), because some databases (e.g. MySQL) require a constant.
+    /// </summary>
+    public static AnalyticLagFunction Lag(object expr, int offset) =>
+        new(Resolve(expr), offset);
+
+    /// <summary>
+    /// The <c>LAG(expr, offset, default)</c> analytic function: the value of
+    /// <paramref name="expr"/> from the row <paramref name="offset"/> positions
+    /// before the current row, or <paramref name="defaultValue"/> when that row
+    /// falls outside the partition. The offset is emitted as an integer literal
+    /// (some databases, e.g. MySQL, require a constant); the default value is
+    /// parameterized.
+    /// </summary>
+    public static AnalyticLagFunction Lag(
+        object expr,
+        int offset,
+        object defaultValue) => new(
+            Resolve(expr),
+            offset,
+            Resolve(defaultValue));
+
     public static LastDayFunction LastDay(object date) =>
         new(Resolve(date));
+
+    /// <summary>
+    /// The <c>LEAD(expr)</c> analytic function: the value of
+    /// <paramref name="expr"/> from the row one position after the current row
+    /// in the window.
+    /// </summary>
+    public static AnalyticLeadFunction Lead(object expr) =>
+        new(Resolve(expr));
+
+    /// <summary>
+    /// The <c>LEAD(expr, offset)</c> analytic function: the value of
+    /// <paramref name="expr"/> from the row <paramref name="offset"/> positions
+    /// after the current row. The offset is emitted as an integer literal (not a
+    /// bind parameter), because some databases (e.g. MySQL) require a constant.
+    /// </summary>
+    public static AnalyticLeadFunction Lead(object expr, int offset) =>
+        new(Resolve(expr), offset);
+
+    /// <summary>
+    /// The <c>LEAD(expr, offset, default)</c> analytic function: the value of
+    /// <paramref name="expr"/> from the row <paramref name="offset"/> positions
+    /// after the current row, or <paramref name="defaultValue"/> when that row
+    /// falls outside the partition. The offset is emitted as an integer literal
+    /// (some databases, e.g. MySQL, require a constant); the default value is
+    /// parameterized.
+    /// </summary>
+    public static AnalyticLeadFunction Lead(
+        object expr,
+        int offset,
+        object defaultValue) => new(
+            Resolve(expr),
+            offset,
+            Resolve(defaultValue));
 
     public static LeastFunction Least(params object[] expressions) =>
         new(Resolve(expressions));

--- a/tests/SqlArtisan.Tests/SqlBuilder/ExpressionResolverTests.cs
+++ b/tests/SqlArtisan.Tests/SqlBuilder/ExpressionResolverTests.cs
@@ -82,4 +82,22 @@ public class ExpressionResolverTests
             SqlStatement sql = Select(_t.Code.Asc).Build();
         });
     }
+
+    [Fact]
+    public void Resolve_WithNull_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            SqlStatement sql = Select(Abs(null!)).Build();
+        });
+    }
+
+    [Fact]
+    public void Resolve_WithNullArray_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            SqlStatement sql = Select(Least(null!)).Build();
+        });
+    }
 }

--- a/tests/SqlArtisan.Tests/WindowFunctionTests/WindowLagTests.cs
+++ b/tests/SqlArtisan.Tests/WindowFunctionTests/WindowLagTests.cs
@@ -1,0 +1,66 @@
+﻿using static SqlArtisan.Sql;
+
+namespace SqlArtisan.Tests;
+
+public class WindowLagTests
+{
+    private readonly TestTable _t = new();
+
+    [Fact]
+    public void Lag_OverOrderBy_CorrectSql()
+    {
+        // Arrange
+        string expected = "SELECT LAG(code) OVER (ORDER BY code)";
+
+        // Act
+        SqlStatement sql = Select(Lag(_t.Code).Over(OrderBy(_t.Code))).Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void Lag_WithOffset_CorrectSql()
+    {
+        // Arrange
+        string expected = "SELECT LAG(code, 2) OVER (ORDER BY code)";
+
+        // Act
+        SqlStatement sql = Select(Lag(_t.Code, 2).Over(OrderBy(_t.Code))).Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void Lag_WithOffsetAndDefault_CorrectSql()
+    {
+        // Arrange
+        string expected = "SELECT LAG(code, 1, :0) OVER (ORDER BY code)";
+
+        // Act
+        SqlStatement sql =
+            Select(Lag(_t.Code, 1, 0).Over(OrderBy(_t.Code))).Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+        Assert.Equal(1, sql.Parameters.Count);
+        Assert.Equal(0, sql.Parameters.Get<int>(":0"));
+    }
+
+    [Fact]
+    public void Lag_OverPartitionByOrderBy_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT LAG(code) OVER (PARTITION BY name ORDER BY code)";
+
+        // Act
+        SqlStatement sql =
+            Select(Lag(_t.Code).Over(PartitionBy(_t.Name).OrderBy(_t.Code)))
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+}

--- a/tests/SqlArtisan.Tests/WindowFunctionTests/WindowLeadTests.cs
+++ b/tests/SqlArtisan.Tests/WindowFunctionTests/WindowLeadTests.cs
@@ -1,0 +1,66 @@
+﻿using static SqlArtisan.Sql;
+
+namespace SqlArtisan.Tests;
+
+public class WindowLeadTests
+{
+    private readonly TestTable _t = new();
+
+    [Fact]
+    public void Lead_OverOrderBy_CorrectSql()
+    {
+        // Arrange
+        string expected = "SELECT LEAD(code) OVER (ORDER BY code)";
+
+        // Act
+        SqlStatement sql = Select(Lead(_t.Code).Over(OrderBy(_t.Code))).Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void Lead_WithOffset_CorrectSql()
+    {
+        // Arrange
+        string expected = "SELECT LEAD(code, 2) OVER (ORDER BY code)";
+
+        // Act
+        SqlStatement sql = Select(Lead(_t.Code, 2).Over(OrderBy(_t.Code))).Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void Lead_WithOffsetAndDefault_CorrectSql()
+    {
+        // Arrange
+        string expected = "SELECT LEAD(code, 1, :0) OVER (ORDER BY code)";
+
+        // Act
+        SqlStatement sql =
+            Select(Lead(_t.Code, 1, 0).Over(OrderBy(_t.Code))).Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+        Assert.Equal(1, sql.Parameters.Count);
+        Assert.Equal(0, sql.Parameters.Get<int>(":0"));
+    }
+
+    [Fact]
+    public void Lead_OverPartitionByOrderBy_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT LEAD(code) OVER (PARTITION BY name ORDER BY code)";
+
+        // Act
+        SqlStatement sql =
+            Select(Lead(_t.Code).Over(PartitionBy(_t.Name).OrderBy(_t.Code)))
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+}


### PR DESCRIPTION
## Summary
Adds the `LAG` and `LEAD` offset window functions.

```sql
LAG(expr [, offset [, default]]) OVER ([PARTITION BY ...] ORDER BY ...)
LEAD(expr [, offset [, default]]) OVER ([PARTITION BY ...] ORDER BY ...)
```

```csharp
Select(
    u.Id,
    u.Salary,
    Lag(u.Salary).Over(OrderBy(u.Id)).As("prev_salary"),
    Lead(u.Salary, 1, 0).Over(OrderBy(u.Id)).As("next_salary"))
.From(u)
.Build();

// SELECT id, salary,
// LAG(salary) OVER (ORDER BY id) "prev_salary",
// LEAD(salary, 1, :0) OVER (ORDER BY id) "next_salary"
// FROM users
```

## API
- `Sql.Lag(expr)`, `Sql.Lag(expr, offset)`, `Sql.Lag(expr, offset, defaultValue)`
- `Sql.Lead(expr)`, `Sql.Lead(expr, offset)`, `Sql.Lead(expr, offset, defaultValue)`
- Both require an ordered window: `Over(OrderBy(...))` or `Over(PartitionBy(...).OrderBy(...))`.

## Notes
- The `offset` is emitted as an integer literal (some databases, e.g. MySQL, require a constant — consistent with how window-frame offsets are rendered); the `default` value is parameterized.
- Three explicit constructors make the invalid state (a default without an offset) unrepresentable, and the offset is formatted with `InvariantCulture` so the SQL text is culture-independent.

## Design decision
`AnalyticFunction` is kept as a flat base with exactly the two ordered `Over(...)` overloads, which the ranking and offset functions share (the duplicated overloads were consolidated here from the five ranking classes — source- and binary-compatible). `Over()` / `Over(PartitionBy(...))` / `Over(WindowFrameClause)` are intentionally omitted: these functions require `ORDER BY` and reject a frame, so a frame overload would only ever generate SQL every database rejects. No mid-tier base is introduced now (YAGNI; mirrors the flat `AggregateFunction`). When frame-aware value functions (`FIRST_VALUE`/`LAST_VALUE`/`NTH_VALUE`) are added, they derive from this base and add their own `Over(WindowFrameClause)`.

## Incidental fix
`ExpressionResolver.Resolve` now throws a clear `ArgumentNullException` (pointing users to `Sql.Null`) instead of a raw `NullReferenceException` when a `null` value is passed to any factory — covering both the scalar and the params-array overloads.

## Tests
- `WindowLagTests` / `WindowLeadTests` (AAA): no-offset, offset, offset+default (with bind-parameter assertions), and partitioned windows.
- `ExpressionResolverTests`: null scalar and null array both throw `ArgumentNullException`.
- Full suite: 324 passing, 0 build warnings (Release).

A follow-up issue (#61) tracks the same culture-sensitive offset formatting in `FrameBound`.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)
