### PR TITLE
fix: Use invariant culture for window-frame offsets (#61)

### DIFF
--- a/src/SqlArtisan/Internal/SqlPart/Clause/Over/FrameBound.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Over/FrameBound.cs
@@ -17,13 +17,13 @@ public sealed class FrameBound : SqlPart
         new($"{Keywords.Unbounded} {Keywords.Preceding}");
 
     internal static FrameBound Preceding(int offset) =>
-        new($"{offset} {Keywords.Preceding}");
+        new($"{offset.ToInvariantString()} {Keywords.Preceding}");
 
     internal static FrameBound CurrentRow() =>
         new($"{Keywords.Current} {Keywords.Row}");
 
     internal static FrameBound Following(int offset) =>
-        new($"{offset} {Keywords.Following}");
+        new($"{offset.ToInvariantString()} {Keywords.Following}");
 
     internal static FrameBound UnboundedFollowing() =>
         new($"{Keywords.Unbounded} {Keywords.Following}");

--- a/tests/SqlArtisan.Tests/WindowFrameTests.cs
+++ b/tests/SqlArtisan.Tests/WindowFrameTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using static SqlArtisan.Sql;
 
 namespace SqlArtisan.Tests;
@@ -92,5 +93,33 @@ public class WindowFrameTests
 
         // Assert
         Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void Preceding_NegativeOffsetUnderNonAsciiNegativeSignCulture_RendersInvariantSql()
+    {
+        // Arrange
+        CultureInfo original = CultureInfo.CurrentCulture;
+        CultureInfo culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        culture.NumberFormat.NegativeSign = "\u2212";
+        CultureInfo.CurrentCulture = culture;
+
+        try
+        {
+            string expected =
+                "SELECT SUM(code) OVER (ORDER BY code ROWS -1 PRECEDING)";
+
+            // Act
+            SqlStatement sql =
+                Select(Sum(_t.Code).Over(OrderBy(_t.Code).Rows(Preceding(-1))))
+                .Build();
+
+            // Assert
+            Assert.Equal(expected, sql.Text);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
     }
 }


### PR DESCRIPTION
## Summary
`FrameBound.Preceding` / `Following` formatted their integer offset with the **current culture** (`$"{offset} ..."`), so under a culture whose `NumberFormat.NegativeSign` is not ASCII (e.g. U+2212 on some ICU cultures), a negative frame offset rendered a non-ASCII minus sign into the SQL text — which databases reject as a syntax error.

The offset is now formatted with `InvariantCulture` via the `ToInvariantString()` extension (introduced for LAG / LEAD in #60), so the SQL text is culture-independent.

```csharp
internal static FrameBound Preceding(int offset) =>
    new($"{offset.ToInvariantString()} {Keywords.Preceding}");

internal static FrameBound Following(int offset) =>
    new($"{offset.ToInvariantString()} {Keywords.Following}");
```

## Test
Adds a deterministic regression test in `WindowFrameTests`: it sets `CurrentCulture` to a clone of the invariant culture with `NegativeSign = "−"`, then asserts that `Preceding(-1)` renders an ASCII `-1` (the test fails against the old current-culture formatting). The culture is restored in a `finally`; no CLDR data dependency.

## Notes
- No CHANGELOG entry: window frames (#58) are still unreleased, so this culture bug never reached a published version.
- Full suite: 325 passing, 0 build warnings (Release).

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)
