### PR TITLE
feat: Add support for the NTILE(n) window function (#64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for aggregate window functions (`Sum`/`Count`/`Avg`/`Max`/`Min` with `Over(...)`). (#56)
 - Added support for window frames (`ROWS` / `RANGE`) via `Rows(...)` / `Range(...)`. (#58)
 - Added support for the `LAG` / `LEAD` offset window functions. (#60)
+- Added support for the `NTILE(n)` window function. (#64)
 
 ### Changed
 - Improved `SqlBuildingBuffer` memory efficiency and throughput. (#45)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ So you can focus on the query logic, not the boilerplate. That’s why SqlArtisa
     - [Date and Time Functions](#date-and-time-functions): `ADD_MONTHS`, `CURRENT_DATE`, `CURRENT_TIME`, `CURRENT_TIMESTAMP`, `EXTRACT`, `LAST_DAY`, `MONTHS_BETWEEN`, `SYSDATE`, `SYSTIMESTAMP`, `TRUNC`
     - [Conversion Functions](#conversion-functions): `COALESCE`, `DECODE`, `NVL`, `TO_CHAR`, `TO_DATE`, `TO_NUMBER`, `TO_TIMESTAMP`
     - [Aggregate Functions](#aggregate-functions): `AVG`, `COUNT`, `MAX`, `MIN`, `SUM`
-    - [Window Functions](#window-functions-1): `CUME_DIST`, `DENSE_RANK`, `LAG`, `LEAD`, `PERCENT_RANK`, `RANK`, `ROW_NUMBER`
+    - [Window Functions](#window-functions-1): `CUME_DIST`, `DENSE_RANK`, `LAG`, `LEAD`, `NTILE`, `PERCENT_RANK`, `RANK`, `ROW_NUMBER`
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -1454,6 +1454,7 @@ SqlArtisan provides C# APIs that map to various SQL functions, enabling you to u
 - `DenseRank()` for `DENSE_RANK()`
 - `Lag(expr[, offset[, default]])` for `LAG(...)`
 - `Lead(expr[, offset[, default]])` for `LEAD(...)`
+- `Ntile(buckets)` for `NTILE(n)`
 - `PercentRank()` for `PERCENT_RANK()`
 - `Rank()` for `RANK()`
 - `RowNumber()` for `ROW_NUMBER()`

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticNtileFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticNtileFunction.cs
@@ -1,0 +1,17 @@
+﻿namespace SqlArtisan.Internal;
+
+public sealed class AnalyticNtileFunction : AnalyticFunction
+{
+    private readonly int _buckets;
+
+    internal AnalyticNtileFunction(int buckets)
+    {
+        _buckets = buckets;
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append(Keywords.Ntile)
+        .OpenParenthesis()
+        .Append(_buckets.ToInvariantString())
+        .CloseParenthesis();
+}

--- a/src/SqlArtisan/Internal/SqlPart/Keywords.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Keywords.cs
@@ -76,6 +76,7 @@ internal static class Keywords
     internal const string Nextval = "NEXTVAL";
     internal const string Not = "NOT";
     internal const string Nowait = "NOWAIT";
+    internal const string Ntile = "NTILE";
     internal const string Null = "NULL";
     internal const string NullsFirst = "NULLS FIRST";
     internal const string NullsLast = "NULLS LAST";

--- a/src/SqlArtisan/Sql/Sql.N.cs
+++ b/src/SqlArtisan/Sql/Sql.N.cs
@@ -36,6 +36,14 @@ public static partial class Sql
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public static NowaitBehavior Nowait => new();
 
+    /// <summary>
+    /// The <c>NTILE(buckets)</c> analytic function: distributes the ordered rows
+    /// of each window partition into <paramref name="buckets"/> ranked groups.
+    /// The bucket count is emitted as an integer literal (not a bind parameter),
+    /// because some databases require a constant.
+    /// </summary>
+    public static AnalyticNtileFunction Ntile(int buckets) => new(buckets);
+
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public static NullExpression Null => new();
 

--- a/tests/SqlArtisan.Tests/WindowFunctionTests/WindowNtileTests.cs
+++ b/tests/SqlArtisan.Tests/WindowFunctionTests/WindowNtileTests.cs
@@ -1,0 +1,37 @@
+﻿using static SqlArtisan.Sql;
+
+namespace SqlArtisan.Tests;
+
+public class WindowNtileTests
+{
+    private readonly TestTable _t = new();
+
+    [Fact]
+    public void Ntile_OverOrderBy_CorrectSql()
+    {
+        // Arrange
+        string expected = "SELECT NTILE(4) OVER (ORDER BY code)";
+
+        // Act
+        SqlStatement sql = Select(Ntile(4).Over(OrderBy(_t.Code))).Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void Ntile_OverPartitionByOrderBy_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT NTILE(4) OVER (PARTITION BY name ORDER BY code)";
+
+        // Act
+        SqlStatement sql =
+            Select(Ntile(4).Over(PartitionBy(_t.Name).OrderBy(_t.Code)))
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+}


### PR DESCRIPTION
## Summary
Adds the `NTILE(n)` analytic function, which distributes the ordered rows of each
window partition into `n` ranked buckets.

```sql
NTILE(n) OVER ([PARTITION BY ...] ORDER BY ...)
```

```csharp
Select(u.Name, Ntile(4).Over(OrderBy(u.Salary.Desc)).As("quartile"))
    .From(u)
    .Build();
// SELECT name, NTILE(4) OVER (ORDER BY salary DESC) "quartile" FROM users
```

## API
- `Sql.Ntile(int buckets)` returning `AnalyticNtileFunction`.
- Requires an ordered window via the inherited `Over(OrderBy(...))` / `Over(PartitionBy(...).OrderBy(...))`.

## Design notes
- Derives from the existing `AnalyticFunction` base (ordered window, no frame) — same category as the ranking functions; no new base needed.
- The bucket count is emitted as an **integer literal** via `int.ToInvariantString()` (not a bind parameter), like the `LAG`/`LEAD` offset and frame offsets — several databases require a constant here, and invariant formatting keeps the SQL text culture-independent.
- Follows the established one-class-per-function pattern; XML doc on the public `Sql.Ntile` factory.

## Dialect support
PostgreSQL, Oracle, MySQL 8.0+, SQL Server 2012+, SQLite 3.25+.

## Tests
- `WindowNtileTests` (AAA): `OVER (ORDER BY ...)` and `OVER (PARTITION BY ... ORDER BY ...)`.
- Full suite: 327 passing, 0 build warnings (Release).

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)
