### PR TITLE
feat: Add support for FIRST_VALUE / LAST_VALUE / NTH_VALUE window functions (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for window frames (`ROWS` / `RANGE`) via `Rows(...)` / `Range(...)`. (#58)
 - Added support for the `LAG` / `LEAD` offset window functions. (#60)
 - Added support for the `NTILE(n)` window function. (#64)
+- Added support for the `FIRST_VALUE` / `LAST_VALUE` / `NTH_VALUE` window functions. (#65)
 
 ### Changed
 - Improved `SqlBuildingBuffer` memory efficiency and throughput. (#45)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ So you can focus on the query logic, not the boilerplate. That’s why SqlArtisa
     - [Date and Time Functions](#date-and-time-functions): `ADD_MONTHS`, `CURRENT_DATE`, `CURRENT_TIME`, `CURRENT_TIMESTAMP`, `EXTRACT`, `LAST_DAY`, `MONTHS_BETWEEN`, `SYSDATE`, `SYSTIMESTAMP`, `TRUNC`
     - [Conversion Functions](#conversion-functions): `COALESCE`, `DECODE`, `NVL`, `TO_CHAR`, `TO_DATE`, `TO_NUMBER`, `TO_TIMESTAMP`
     - [Aggregate Functions](#aggregate-functions): `AVG`, `COUNT`, `MAX`, `MIN`, `SUM`
-    - [Window Functions](#window-functions-1): `CUME_DIST`, `DENSE_RANK`, `LAG`, `LEAD`, `NTILE`, `PERCENT_RANK`, `RANK`, `ROW_NUMBER`
+    - [Window Functions](#window-functions-1): `CUME_DIST`, `DENSE_RANK`, `FIRST_VALUE`, `LAG`, `LAST_VALUE`, `LEAD`, `NTH_VALUE`, `NTILE`, `PERCENT_RANK`, `RANK`, `ROW_NUMBER`
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -1271,6 +1271,29 @@ SqlStatement sql =
 
 Both require an `OrderBy(...)` (optionally with `PartitionBy(...)`). The offset is emitted as a literal so the SQL stays portable (MySQL requires a literal here), while the default value is parameterized.
 
+##### Example using FIRST_VALUE / LAST_VALUE / NTH_VALUE
+
+`FirstValue(...)`, `LastValue(...)`, and `NthValue(...)` read a value from a specific row of the window. Unlike the ranking and offset functions, they can be scoped by an explicit frame (`Rows(...)` / `Range(...)`).
+
+```csharp
+UsersTable u = new();
+SqlStatement sql =
+    Select(
+        u.Id,
+        FirstValue(u.Salary)
+            .Over(PartitionBy(u.DepartmentId).OrderBy(u.Salary.Desc))
+            .As("top_salary"))
+    .From(u)
+    .Build();
+
+// SELECT id,
+// FIRST_VALUE(salary) OVER (PARTITION BY department_id ORDER BY salary DESC) "top_salary"
+// FROM users
+```
+
+- `LastValue` is frame-sensitive: the default frame ends at the current row, so pair it with an explicit frame such as `RowsBetween(UnboundedPreceding, UnboundedFollowing)` to read the last row of the whole partition.
+- `NthValue`'s position is emitted as an integer literal, and is **not supported by SQL Server**.
+
 ##### Example using an Aggregate
 
 Aggregate functions (`Sum`, `Count`, `Avg`, `Max`, `Min`) can also be used as window functions via `Over(...)`.
@@ -1452,8 +1475,11 @@ SqlArtisan provides C# APIs that map to various SQL functions, enabling you to u
 
 - `CumeDist()` for `CUME_DIST()`
 - `DenseRank()` for `DENSE_RANK()`
+- `FirstValue(expr)` for `FIRST_VALUE(expr)`
 - `Lag(expr[, offset[, default]])` for `LAG(...)`
+- `LastValue(expr)` for `LAST_VALUE(expr)`
 - `Lead(expr[, offset[, default]])` for `LEAD(...)`
+- `NthValue(expr, n)` for `NTH_VALUE(expr, n)` (not supported by SQL Server)
 - `Ntile(buckets)` for `NTILE(n)`
 - `PercentRank()` for `PERCENT_RANK()`
 - `Rank()` for `RANK()`

--- a/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
@@ -211,6 +211,13 @@ internal sealed class SqlBuildingBuffer : IDisposable
         return this;
     }
 
+    internal SqlBuildingBuffer PrependComma(string value)
+    {
+        Append(", ");
+        Append(value);
+        return this;
+    }
+
     internal SqlBuildingBuffer PrependCommaIfNotNull(SqlPart? part)
     {
         if (part is not null)

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticFirstValueFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticFirstValueFunction.cs
@@ -1,0 +1,17 @@
+﻿namespace SqlArtisan.Internal;
+
+public sealed class AnalyticFirstValueFunction : ValueAnalyticFunction
+{
+    private readonly SqlExpression _expr;
+
+    internal AnalyticFirstValueFunction(SqlExpression expr)
+    {
+        _expr = expr;
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append(Keywords.FirstValue)
+        .OpenParenthesis()
+        .Append(_expr)
+        .CloseParenthesis();
+}

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticLastValueFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticLastValueFunction.cs
@@ -1,0 +1,17 @@
+﻿namespace SqlArtisan.Internal;
+
+public sealed class AnalyticLastValueFunction : ValueAnalyticFunction
+{
+    private readonly SqlExpression _expr;
+
+    internal AnalyticLastValueFunction(SqlExpression expr)
+    {
+        _expr = expr;
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append(Keywords.LastValue)
+        .OpenParenthesis()
+        .Append(_expr)
+        .CloseParenthesis();
+}

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticNthValueFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticNthValueFunction.cs
@@ -1,0 +1,20 @@
+﻿namespace SqlArtisan.Internal;
+
+public sealed class AnalyticNthValueFunction : ValueAnalyticFunction
+{
+    private readonly SqlExpression _expr;
+    private readonly int _n;
+
+    internal AnalyticNthValueFunction(SqlExpression expr, int n)
+    {
+        _expr = expr;
+        _n = n;
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append(Keywords.NthValue)
+        .OpenParenthesis()
+        .Append(_expr)
+        .PrependComma(_n.ToInvariantString())
+        .CloseParenthesis();
+}

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/ValueAnalyticFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/ValueAnalyticFunction.cs
@@ -1,0 +1,16 @@
+﻿namespace SqlArtisan.Internal;
+
+/// <summary>
+/// Base class for the value analytic functions (<c>FIRST_VALUE</c>,
+/// <c>LAST_VALUE</c>, <c>NTH_VALUE</c>), which extend the ordered window with an
+/// optional explicit frame.
+/// </summary>
+public abstract class ValueAnalyticFunction : AnalyticFunction
+{
+    /// <summary>
+    /// Turns the analytic function into a window function with an explicit frame:
+    /// <c>OVER (... ROWS/RANGE ...)</c>.
+    /// </summary>
+    public WindowFunction Over(WindowFrameClause windowFrameClause) =>
+        new(this, OverClause.Of(windowFrameClause));
+}

--- a/src/SqlArtisan/Internal/SqlPart/Keywords.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Keywords.cs
@@ -39,6 +39,7 @@ internal static class Keywords
     internal const string Extract = "EXTRACT";
     internal const string Fetch = "FETCH";
     internal const string First = "FIRST";
+    internal const string FirstValue = "FIRST_VALUE";
     internal const string Following = "FOLLOWING";
     internal const string For = "FOR";
     internal const string From = "FROM";
@@ -56,6 +57,7 @@ internal static class Keywords
     internal const string Join = "JOIN";
     internal const string Lag = "LAG";
     internal const string LastDay = "LAST_DAY";
+    internal const string LastValue = "LAST_VALUE";
     internal const string Lead = "LEAD";
     internal const string Least = "LEAST";
     internal const string Left = "LEFT";
@@ -76,6 +78,7 @@ internal static class Keywords
     internal const string Nextval = "NEXTVAL";
     internal const string Not = "NOT";
     internal const string Nowait = "NOWAIT";
+    internal const string NthValue = "NTH_VALUE";
     internal const string Ntile = "NTILE";
     internal const string Null = "NULL";
     internal const string NullsFirst = "NULLS FIRST";

--- a/src/SqlArtisan/Sql/Sql.F.cs
+++ b/src/SqlArtisan/Sql/Sql.F.cs
@@ -1,9 +1,17 @@
 ﻿using SqlArtisan.Internal;
+using static SqlArtisan.Internal.ExpressionResolver;
 
 namespace SqlArtisan;
 
 public static partial class Sql
 {
+    /// <summary>
+    /// The <c>FIRST_VALUE(expr)</c> analytic function: the value of
+    /// <paramref name="expr"/> from the first row of the window frame.
+    /// </summary>
+    public static AnalyticFirstValueFunction FirstValue(object expr) =>
+        new(Resolve(expr));
+
     /// <summary>
     /// A <c>n FOLLOWING</c> window-frame bound (offset rows/range after the
     /// current row).

--- a/src/SqlArtisan/Sql/Sql.L.cs
+++ b/src/SqlArtisan/Sql/Sql.L.cs
@@ -42,6 +42,16 @@ public static partial class Sql
         new(Resolve(date));
 
     /// <summary>
+    /// The <c>LAST_VALUE(expr)</c> analytic function: the value of
+    /// <paramref name="expr"/> from the last row of the window frame. Note the
+    /// default frame ends at the current row, so an explicit frame (e.g.
+    /// <c>ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING</c>) is
+    /// usually intended.
+    /// </summary>
+    public static AnalyticLastValueFunction LastValue(object expr) =>
+        new(Resolve(expr));
+
+    /// <summary>
     /// The <c>LEAD(expr)</c> analytic function: the value of
     /// <paramref name="expr"/> from the row one position after the current row
     /// in the window.

--- a/src/SqlArtisan/Sql/Sql.N.cs
+++ b/src/SqlArtisan/Sql/Sql.N.cs
@@ -37,6 +37,16 @@ public static partial class Sql
     public static NowaitBehavior Nowait => new();
 
     /// <summary>
+    /// The <c>NTH_VALUE(expr, n)</c> analytic function: the value of
+    /// <paramref name="expr"/> from the <paramref name="n"/>th row of the window
+    /// frame. The position is emitted as an integer literal (not a bind
+    /// parameter), because some databases require a constant. Not supported by
+    /// SQL Server.
+    /// </summary>
+    public static AnalyticNthValueFunction NthValue(object expr, int n) =>
+        new(Resolve(expr), n);
+
+    /// <summary>
     /// The <c>NTILE(buckets)</c> analytic function: distributes the ordered rows
     /// of each window partition into <paramref name="buckets"/> ranked groups.
     /// The bucket count is emitted as an integer literal (not a bind parameter),

--- a/tests/SqlArtisan.Tests/WindowFunctionTests/WindowFirstValueTests.cs
+++ b/tests/SqlArtisan.Tests/WindowFunctionTests/WindowFirstValueTests.cs
@@ -1,0 +1,56 @@
+﻿using static SqlArtisan.Sql;
+
+namespace SqlArtisan.Tests;
+
+public class WindowFirstValueTests
+{
+    private readonly TestTable _t = new();
+
+    [Fact]
+    public void FirstValue_OverOrderBy_CorrectSql()
+    {
+        // Arrange
+        string expected = "SELECT FIRST_VALUE(code) OVER (ORDER BY code)";
+
+        // Act
+        SqlStatement sql =
+            Select(FirstValue(_t.Code).Over(OrderBy(_t.Code))).Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void FirstValue_OverPartitionByOrderBy_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT FIRST_VALUE(code) OVER (PARTITION BY name ORDER BY code)";
+
+        // Act
+        SqlStatement sql =
+            Select(
+                FirstValue(_t.Code).Over(PartitionBy(_t.Name).OrderBy(_t.Code)))
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void FirstValue_OverFrame_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT FIRST_VALUE(code) OVER (ORDER BY code ROWS UNBOUNDED PRECEDING)";
+
+        // Act
+        SqlStatement sql =
+            Select(
+                FirstValue(_t.Code).Over(OrderBy(_t.Code).Rows(UnboundedPreceding)))
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+}

--- a/tests/SqlArtisan.Tests/WindowFunctionTests/WindowLastValueTests.cs
+++ b/tests/SqlArtisan.Tests/WindowFunctionTests/WindowLastValueTests.cs
@@ -1,0 +1,40 @@
+﻿using static SqlArtisan.Sql;
+
+namespace SqlArtisan.Tests;
+
+public class WindowLastValueTests
+{
+    private readonly TestTable _t = new();
+
+    [Fact]
+    public void LastValue_OverOrderBy_CorrectSql()
+    {
+        // Arrange
+        string expected = "SELECT LAST_VALUE(code) OVER (ORDER BY code)";
+
+        // Act
+        SqlStatement sql =
+            Select(LastValue(_t.Code).Over(OrderBy(_t.Code))).Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void LastValue_OverFrameBetween_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT LAST_VALUE(code) OVER (ORDER BY code ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)";
+
+        // Act
+        SqlStatement sql =
+            Select(
+                LastValue(_t.Code).Over(
+                    OrderBy(_t.Code).RowsBetween(UnboundedPreceding, UnboundedFollowing)))
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+}

--- a/tests/SqlArtisan.Tests/WindowFunctionTests/WindowNthValueTests.cs
+++ b/tests/SqlArtisan.Tests/WindowFunctionTests/WindowNthValueTests.cs
@@ -1,0 +1,40 @@
+﻿using static SqlArtisan.Sql;
+
+namespace SqlArtisan.Tests;
+
+public class WindowNthValueTests
+{
+    private readonly TestTable _t = new();
+
+    [Fact]
+    public void NthValue_OverOrderBy_CorrectSql()
+    {
+        // Arrange
+        string expected = "SELECT NTH_VALUE(code, 2) OVER (ORDER BY code)";
+
+        // Act
+        SqlStatement sql =
+            Select(NthValue(_t.Code, 2).Over(OrderBy(_t.Code))).Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void NthValue_OverFrameBetween_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT NTH_VALUE(code, 2) OVER (ORDER BY code ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)";
+
+        // Act
+        SqlStatement sql =
+            Select(
+                NthValue(_t.Code, 2).Over(
+                    OrderBy(_t.Code).RowsBetween(UnboundedPreceding, UnboundedFollowing)))
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+}


### PR DESCRIPTION
## Summary
Adds the **value** window functions `FIRST_VALUE`, `LAST_VALUE`, and `NTH_VALUE`,
which return a value from a specific row of the window. Unlike the ranking and
offset functions, they may be scoped by an explicit frame.

```sql
FIRST_VALUE(expr) OVER ([PARTITION BY ...] ORDER BY ... [frame])
LAST_VALUE(expr)  OVER ([PARTITION BY ...] ORDER BY ... [frame])
NTH_VALUE(expr, n) OVER ([PARTITION BY ...] ORDER BY ... [frame])
```

```csharp
Select(
    u.Id,
    FirstValue(u.Salary)
        .Over(PartitionBy(u.DepartmentId).OrderBy(u.Salary.Desc))
        .As("top_salary"))
    .From(u)
    .Build();
// SELECT id, FIRST_VALUE(salary) OVER (PARTITION BY department_id ORDER BY salary DESC) "top_salary" FROM users
```

## API
- `Sql.FirstValue(expr)`, `Sql.LastValue(expr)`, `Sql.NthValue(expr, int n)`.
- Window via the inherited `Over(OrderBy(...))` / `Over(PartitionBy(...).OrderBy(...))` **plus** the new `Over(... Rows/Range ...)` (`WindowFrameClause`).

## Design notes
- **New `ValueAnalyticFunction` base** derives from `AnalyticFunction` (which already provides the two ordered `Over(...)` overloads) and adds `Over(WindowFrameClause)`. This realizes the extension point documented in `AnalyticFunction`'s `<remarks>` (#60): the frame overload lives on the value-function base, **not** promoted onto `AnalyticFunction` (the ranking/offset functions must not gain it). Mirrors how `AggregateFunction` hosts its shared `Over` overloads.
- `NTH_VALUE`'s position `n` is emitted as an **integer literal** via `int.ToInvariantString()` (some databases require a constant). A new `SqlBuildingBuffer.PrependComma(string)` overload renders the mandatory `, n` — it completes the symmetry with the existing `PrependComma(SqlPart)` and `PrependCommaIfNotNull(string?)`.

## Dialect notes
- `FIRST_VALUE` / `LAST_VALUE`: PostgreSQL, Oracle, MySQL 8.0+, SQL Server 2012+, SQLite 3.25+.
- `NTH_VALUE`: PostgreSQL, Oracle, MySQL 8.0+, SQLite 3.25+ — **not supported by SQL Server** (documented in the XML doc + README).
- `LAST_VALUE` is frame-sensitive (the default frame ends at the current row); the README and XML doc call this out.

## Tests
- `WindowFirstValueTests` / `WindowLastValueTests` / `WindowNthValueTests` (AAA): ordered, partitioned, and **framed** windows; `NTH_VALUE` confirms the literal position.
- Full suite: 334 passing, 0 build warnings (Release).

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)
