### PR TITLE
feat: Add support for PERCENTILE_CONT / PERCENTILE_DISC (WITHIN GROUP) (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for window frames (`ROWS` / `RANGE`) via `Rows(...)` / `Range(...)`. (#58)
 - Added support for the `LAG` / `LEAD` offset window functions. (#60)
 - Added support for the `NTILE(n)` window function. (#64)
+- Added support for the `PERCENTILE_CONT` / `PERCENTILE_DISC` ordered-set aggregates (`WITHIN GROUP (ORDER BY ...)`). (#66)
 
 ### Changed
 - Improved `SqlBuildingBuffer` memory efficiency and throughput. (#45)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ So you can focus on the query logic, not the boilerplate. That’s why SqlArtisa
     - [Date and Time Functions](#date-and-time-functions): `ADD_MONTHS`, `CURRENT_DATE`, `CURRENT_TIME`, `CURRENT_TIMESTAMP`, `EXTRACT`, `LAST_DAY`, `MONTHS_BETWEEN`, `SYSDATE`, `SYSTIMESTAMP`, `TRUNC`
     - [Conversion Functions](#conversion-functions): `COALESCE`, `DECODE`, `NVL`, `TO_CHAR`, `TO_DATE`, `TO_NUMBER`, `TO_TIMESTAMP`
     - [Aggregate Functions](#aggregate-functions): `AVG`, `COUNT`, `MAX`, `MIN`, `SUM`
-    - [Window Functions](#window-functions-1): `CUME_DIST`, `DENSE_RANK`, `LAG`, `LEAD`, `NTILE`, `PERCENT_RANK`, `RANK`, `ROW_NUMBER`
+    - [Window Functions](#window-functions-1): `CUME_DIST`, `DENSE_RANK`, `LAG`, `LEAD`, `NTILE`, `PERCENTILE_CONT`, `PERCENTILE_DISC`, `PERCENT_RANK`, `RANK`, `ROW_NUMBER`
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -1317,6 +1317,32 @@ SqlStatement sql =
 - A frame requires `ORDER BY`, so `Rows(...)` / `Range(...)` are available only after `OrderBy(...)` (optionally with `PartitionBy(...)`).
 - Requires PostgreSQL, Oracle, MySQL 8.0+, SQLite 3.25+, or SQL Server 2012+.
 
+##### Example using PERCENTILE_CONT / PERCENTILE_DISC
+
+`PercentileCont(...)` and `PercentileDisc(...)` are ordered-set aggregates that compute a percentile over an ordered group via `WITHIN GROUP (ORDER BY ...)`. The fraction (0..1) is emitted as a literal.
+
+```csharp
+UsersTable u = new();
+SqlStatement sql =
+    Select(PercentileCont(0.5).WithinGroup(OrderBy(u.Salary)).As("median"))
+    .From(u)
+    .Build();
+
+// SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY salary) "median" FROM users
+```
+
+Attach `.Over(...)` for the windowed form — `Over()` over the whole result set, or `Over(PartitionBy(...))`:
+
+```csharp
+PercentileCont(0.5).WithinGroup(OrderBy(u.Salary)).Over()
+// PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY salary) OVER ()
+
+PercentileCont(0.5).WithinGroup(OrderBy(u.Salary)).Over(PartitionBy(u.DepartmentId))
+// PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY salary) OVER (PARTITION BY department_id)
+```
+
+- Dialect support is split: Oracle allows both forms; PostgreSQL only the plain `WITHIN GROUP` form; SQL Server only the windowed `.Over(PartitionBy(...))` form. MySQL and SQLite do not support these functions.
+
 ---
 
 #### Sequence
@@ -1455,6 +1481,8 @@ SqlArtisan provides C# APIs that map to various SQL functions, enabling you to u
 - `Lag(expr[, offset[, default]])` for `LAG(...)`
 - `Lead(expr[, offset[, default]])` for `LEAD(...)`
 - `Ntile(buckets)` for `NTILE(n)`
+- `PercentileCont(fraction).WithinGroup(OrderBy(...))` for `PERCENTILE_CONT(fraction) WITHIN GROUP (ORDER BY ...)`
+- `PercentileDisc(fraction).WithinGroup(OrderBy(...))` for `PERCENTILE_DISC(fraction) WITHIN GROUP (ORDER BY ...)`
 - `PercentRank()` for `PERCENT_RANK()`
 - `Rank()` for `RANK()`
 - `RowNumber()` for `ROW_NUMBER()`

--- a/src/SqlArtisan/Internal/Extensions/DoubleExtensions.cs
+++ b/src/SqlArtisan/Internal/Extensions/DoubleExtensions.cs
@@ -1,0 +1,9 @@
+﻿using System.Globalization;
+
+namespace SqlArtisan.Internal;
+
+internal static class DoubleExtensions
+{
+    internal static string ToInvariantString(this double value) =>
+        value.ToString(CultureInfo.InvariantCulture);
+}

--- a/src/SqlArtisan/Internal/SqlPart/Clause/WithinGroup/WithinGroupClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/WithinGroup/WithinGroupClause.cs
@@ -1,0 +1,21 @@
+﻿namespace SqlArtisan.Internal;
+
+/// <summary>
+/// The <c>WITHIN GROUP (ORDER BY ...)</c> clause of an ordered-set aggregate.
+/// </summary>
+public sealed class WithinGroupClause : SqlPart
+{
+    private readonly OrderByClause _orderByClause;
+
+    internal WithinGroupClause(OrderByClause orderByClause)
+    {
+        _orderByClause = orderByClause;
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append(Keywords.WithinGroup)
+        .AppendSpace()
+        .OpenParenthesis()
+        .Append(_orderByClause)
+        .CloseParenthesis();
+}

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/OrderedSetAggregateFunction/PercentileContFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/OrderedSetAggregateFunction/PercentileContFunction.cs
@@ -1,0 +1,29 @@
+﻿namespace SqlArtisan.Internal;
+
+/// <summary>
+/// The <c>PERCENTILE_CONT</c> ordered-set aggregate, pending its mandatory
+/// <c>WITHIN GROUP (ORDER BY ...)</c> clause.
+/// </summary>
+public sealed class PercentileContFunction
+{
+    private readonly double _fraction;
+
+    internal PercentileContFunction(double fraction)
+    {
+        if (!double.IsFinite(fraction))
+        {
+            throw new ArgumentException(
+                "The percentile fraction must be a finite number.",
+                nameof(fraction));
+        }
+
+        _fraction = fraction;
+    }
+
+    /// <summary>
+    /// Supplies the mandatory <c>WITHIN GROUP (ORDER BY ...)</c> clause that the
+    /// percentile is computed over.
+    /// </summary>
+    public PercentileFunction WithinGroup(OrderByClause orderByClause) =>
+        new(Keywords.PercentileCont, _fraction, new WithinGroupClause(orderByClause));
+}

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/OrderedSetAggregateFunction/PercentileDiscFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/OrderedSetAggregateFunction/PercentileDiscFunction.cs
@@ -1,0 +1,29 @@
+﻿namespace SqlArtisan.Internal;
+
+/// <summary>
+/// The <c>PERCENTILE_DISC</c> ordered-set aggregate, pending its mandatory
+/// <c>WITHIN GROUP (ORDER BY ...)</c> clause.
+/// </summary>
+public sealed class PercentileDiscFunction
+{
+    private readonly double _fraction;
+
+    internal PercentileDiscFunction(double fraction)
+    {
+        if (!double.IsFinite(fraction))
+        {
+            throw new ArgumentException(
+                "The percentile fraction must be a finite number.",
+                nameof(fraction));
+        }
+
+        _fraction = fraction;
+    }
+
+    /// <summary>
+    /// Supplies the mandatory <c>WITHIN GROUP (ORDER BY ...)</c> clause that the
+    /// percentile is computed over.
+    /// </summary>
+    public PercentileFunction WithinGroup(OrderByClause orderByClause) =>
+        new(Keywords.PercentileDisc, _fraction, new WithinGroupClause(orderByClause));
+}

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/OrderedSetAggregateFunction/PercentileFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/OrderedSetAggregateFunction/PercentileFunction.cs
@@ -1,0 +1,44 @@
+﻿namespace SqlArtisan.Internal;
+
+/// <summary>
+/// An ordered-set aggregate (<c>PERCENTILE_CONT</c> / <c>PERCENTILE_DISC</c>)
+/// in the form <c>FUNC(fraction) WITHIN GROUP (ORDER BY ...)</c>. Attach
+/// <see cref="Over()"/> or <see cref="Over(PartitionByClause)"/> for the
+/// windowed form.
+/// </summary>
+public sealed class PercentileFunction : SqlExpression
+{
+    private readonly string _function;
+    private readonly double _fraction;
+    private readonly WithinGroupClause _withinGroup;
+
+    internal PercentileFunction(
+        string function,
+        double fraction,
+        WithinGroupClause withinGroup)
+    {
+        _function = function;
+        _fraction = fraction;
+        _withinGroup = withinGroup;
+    }
+
+    /// <summary>
+    /// Turns the ordered-set aggregate into a window function over the whole
+    /// result set: <c>... OVER ()</c>.
+    /// </summary>
+    public WindowFunction Over() => new(this, OverClause.Of());
+
+    /// <summary>
+    /// Turns the ordered-set aggregate into a window function partitioned by the
+    /// given expressions: <c>... OVER (PARTITION BY ...)</c>.
+    /// </summary>
+    public WindowFunction Over(PartitionByClause partitionByClause) =>
+        new(this, OverClause.Of(partitionByClause));
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append(_function)
+        .OpenParenthesis()
+        .Append(_fraction.ToInvariantString())
+        .CloseParenthesis()
+        .PrependSpace(_withinGroup);
+}

--- a/src/SqlArtisan/Internal/SqlPart/Keywords.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Keywords.cs
@@ -89,6 +89,8 @@ internal static class Keywords
     internal const string Order = "ORDER";
     internal const string Over = "OVER";
     internal const string Partition = "PARTITION";
+    internal const string PercentileCont = "PERCENTILE_CONT";
+    internal const string PercentileDisc = "PERCENTILE_DISC";
     internal const string PercentRank = "PERCENT_RANK";
     internal const string Preceding = "PRECEDING";
     internal const string Range = "RANGE";
@@ -131,4 +133,5 @@ internal static class Keywords
     internal const string When = "WHEN";
     internal const string Where = "WHERE";
     internal const string With = "WITH";
+    internal const string WithinGroup = "WITHIN GROUP";
 }

--- a/src/SqlArtisan/Sql/Sql.P.cs
+++ b/src/SqlArtisan/Sql/Sql.P.cs
@@ -8,6 +8,29 @@ public static partial class Sql
     public static PartitionByClause PartitionBy(
         params object[] expressions) => new(Resolve(expressions));
 
+    /// <summary>
+    /// The <c>PERCENTILE_CONT(fraction)</c> ordered-set aggregate (continuous
+    /// percentile, interpolated). Complete it with <c>.WithinGroup(OrderBy(...))</c>.
+    /// The fraction (0..1) is emitted as a literal, because some databases
+    /// require a constant. Dialect support is split: Oracle allows both forms,
+    /// PostgreSQL only the plain <c>WithinGroup(...)</c> form, and SQL Server
+    /// only the windowed <c>.Over(...)</c> form.
+    /// </summary>
+    public static PercentileContFunction PercentileCont(double fraction) =>
+        new(fraction);
+
+    /// <summary>
+    /// The <c>PERCENTILE_DISC(fraction)</c> ordered-set aggregate (discrete
+    /// percentile, an actual value from the set). Complete it with
+    /// <c>.WithinGroup(OrderBy(...))</c>. The fraction (0..1) is emitted as a
+    /// literal, because some databases require a constant. Dialect support is
+    /// split: Oracle allows both forms, PostgreSQL only the plain
+    /// <c>WithinGroup(...)</c> form, and SQL Server only the windowed
+    /// <c>.Over(...)</c> form.
+    /// </summary>
+    public static PercentileDiscFunction PercentileDisc(double fraction) =>
+        new(fraction);
+
     public static AnalyticPercentRankFunction PercentRank() => new();
 
     /// <summary>

--- a/tests/SqlArtisan.Tests/PercentileTests.cs
+++ b/tests/SqlArtisan.Tests/PercentileTests.cs
@@ -1,0 +1,124 @@
+﻿using static SqlArtisan.Sql;
+
+namespace SqlArtisan.Tests;
+
+public class PercentileTests
+{
+    private readonly TestTable _t = new();
+
+    [Fact]
+    public void PercentileCont_WithinGroup_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY code)";
+
+        // Act
+        SqlStatement sql =
+            Select(PercentileCont(0.5).WithinGroup(OrderBy(_t.Code))).Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void PercentileCont_WithinGroupOverEmpty_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY code) OVER ()";
+
+        // Act
+        SqlStatement sql =
+            Select(PercentileCont(0.5).WithinGroup(OrderBy(_t.Code)).Over())
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void PercentileCont_WithinGroupOverPartitionBy_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY code) OVER (PARTITION BY name)";
+
+        // Act
+        SqlStatement sql =
+            Select(
+                PercentileCont(0.5)
+                    .WithinGroup(OrderBy(_t.Code))
+                    .Over(PartitionBy(_t.Name)))
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void PercentileCont_WithFractionAndAlias_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY code DESC) \"p90\"";
+
+        // Act
+        SqlStatement sql =
+            Select(
+                PercentileCont(0.9).WithinGroup(OrderBy(_t.Code.Desc)).As("p90"))
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void PercentileDisc_WithinGroup_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY code)";
+
+        // Act
+        SqlStatement sql =
+            Select(PercentileDisc(0.5).WithinGroup(OrderBy(_t.Code))).Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void PercentileDisc_WithinGroupOverPartitionBy_CorrectSql()
+    {
+        // Arrange
+        string expected =
+            "SELECT PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY code) OVER (PARTITION BY name)";
+
+        // Act
+        SqlStatement sql =
+            Select(
+                PercentileDisc(0.5)
+                    .WithinGroup(OrderBy(_t.Code))
+                    .Over(PartitionBy(_t.Name)))
+            .Build();
+
+        // Assert
+        Assert.Equal(expected, sql.Text);
+    }
+
+    [Fact]
+    public void PercentileCont_WithNaNFraction_ThrowsArgumentException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => PercentileCont(double.NaN));
+    }
+
+    [Fact]
+    public void PercentileDisc_WithInfinityFraction_ThrowsArgumentException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() =>
+            PercentileDisc(double.PositiveInfinity));
+    }
+}


### PR DESCRIPTION
## Summary
Adds the inverse-distribution ordered-set aggregates `PERCENTILE_CONT` and
`PERCENTILE_DISC`, introducing the `WITHIN GROUP (ORDER BY ...)` syntax.

```sql
PERCENTILE_CONT(fraction) WITHIN GROUP (ORDER BY expr) [ OVER ([PARTITION BY ...]) ]
PERCENTILE_DISC(fraction) WITHIN GROUP (ORDER BY expr) [ OVER ([PARTITION BY ...]) ]
```

```csharp
Select(PercentileCont(0.5).WithinGroup(OrderBy(u.Salary)).As("median"))
    .From(u)
    .Build();
// SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY salary) "median" FROM users

// Windowed form (SQL Server requires OVER; whole result set or partitioned):
PercentileCont(0.5).WithinGroup(OrderBy(u.Salary)).Over()
PercentileCont(0.5).WithinGroup(OrderBy(u.Salary)).Over(PartitionBy(u.DepartmentId))
```

## API
- `Sql.PercentileCont(double fraction)` / `Sql.PercentileDisc(double fraction)` → builders exposing `.WithinGroup(OrderBy(...))`.
- The result (`PercentileFunction`) is a regular expression (aliasable via `.As`) and optionally takes `.Over()` / `.Over(PartitionBy(...))`.

## Design notes
- **Two-step builder**: `WITHIN GROUP` is mandatory in every dialect, so `PercentileCont(0.5)` alone is not a `SqlExpression` — the incomplete state is unrepresentable.
- **Fraction as invariant literal**: SQL Server's grammar requires a numeric literal and Oracle expects a constant, so the fraction is emitted via a new `double.ToInvariantString()` extension (avoids the decimal-separator culture trap, same lesson as #61/#63). `NaN`/`Infinity` are rejected with `ArgumentException` — they form invalid SQL in every dialect (same criterion as the multi-row INSERT arity check). Out-of-range values (e.g. negative) are not gated: the database validates ranges.
- **New `WithinGroupClause`** SqlPart; these types do **not** derive from `AnalyticFunction` (ordered-set aggregates are not OVER-based analytics). The windowed form reuses the existing `WindowFunction`/`OverClause` machinery.
- Class named `PercentileFunction` (not family-level `OrderedSetAggregateFunction`) since its shape — a `double` fraction — is percentile-specific; the folder keeps the category name.

## Dialect support (split — documented in XML docs + README)
| DBMS | plain `WITHIN GROUP` | windowed `OVER (...)` |
| --- | --- | --- |
| Oracle | yes | yes |
| PostgreSQL | yes | no |
| SQL Server | no | yes (`OVER` required) |
| MySQL / SQLite | no | no |

## Tests
- `PercentileTests` (AAA): plain form, `OVER ()`, `OVER (PARTITION BY ...)`, alias + non-default fraction, both twins, and `NaN`/`Infinity` rejection.
- Full suite: 335 passing, 0 build warnings (Release).

Related: #69 (pre-existing zero-argument `PartitionBy()` hole, filed separately).

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)
