### PR TITLE
fix: Reject empty or null PARTITION BY / ORDER BY / GROUP BY (#69)

### DIFF
--- a/src/SqlArtisan/Internal/SqlPart/Clause/GroupBy/GroupByClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/GroupBy/GroupByClause.cs
@@ -6,6 +6,12 @@ internal sealed class GroupByClause : SqlPart
 
     private GroupByClause(SqlPart[] groupByItems)
     {
+        if (groupByItems.Length == 0)
+        {
+            throw new ArgumentException(
+                "GROUP BY requires at least one item.");
+        }
+
         _groupByItems = groupByItems;
     }
 

--- a/src/SqlArtisan/Internal/SqlPart/Clause/GroupBy/GroupByItemResolver.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/GroupBy/GroupByItemResolver.cs
@@ -4,6 +4,12 @@ internal static class GroupByItemResolver
 {
     internal static SqlPart[] Resolve(object[] groupByItems)
     {
+        if (groupByItems is null)
+        {
+            throw new ArgumentNullException(
+                nameof(groupByItems), ExpressionResolver.NullValueMessage);
+        }
+
         var resolved = new SqlPart[groupByItems.Length];
 
         for (int i = 0; i < groupByItems.Length; i++)

--- a/src/SqlArtisan/Internal/SqlPart/Clause/OrderBy/OrderByClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/OrderBy/OrderByClause.cs
@@ -6,6 +6,12 @@ public sealed class OrderByClause : SqlPart
 
     private OrderByClause(SqlPart[] orderByItems)
     {
+        if (orderByItems.Length == 0)
+        {
+            throw new ArgumentException(
+                "ORDER BY requires at least one item.");
+        }
+
         _orderByItems = orderByItems;
     }
 

--- a/src/SqlArtisan/Internal/SqlPart/Clause/OrderBy/OrderByItemResolver.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/OrderBy/OrderByItemResolver.cs
@@ -6,6 +6,12 @@ internal static class OrderByItemResolver
 {
     internal static SqlPart[] Resolve(object[] orderByItems)
     {
+        if (orderByItems is null)
+        {
+            throw new ArgumentNullException(
+                nameof(orderByItems), ExpressionResolver.NullValueMessage);
+        }
+
         var resolved = new SqlPart[orderByItems.Length];
 
         for (int i = 0; i < orderByItems.Length; i++)

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Over/PartitionByClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Over/PartitionByClause.cs
@@ -6,6 +6,12 @@ public sealed class PartitionByClause : SqlPart
 
     internal PartitionByClause(SqlExpression[] expressions)
     {
+        if (expressions.Length == 0)
+        {
+            throw new ArgumentException(
+                "PARTITION BY requires at least one expression.");
+        }
+
         _expressions = expressions;
     }
 

--- a/src/SqlArtisan/Internal/SqlPart/Expression/ExpressionResolver.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/ExpressionResolver.cs
@@ -4,7 +4,7 @@ namespace SqlArtisan.Internal;
 
 internal static class ExpressionResolver
 {
-    private const string NullValueMessage =
+    internal const string NullValueMessage =
         "Value cannot be null. Use Sql.Null to represent SQL NULL.";
 
     internal static (SqlExpression, SqlExpression)[] Resolve((object, object)[] pairs)

--- a/tests/SqlArtisan.Tests/AggregateWindowTests.cs
+++ b/tests/SqlArtisan.Tests/AggregateWindowTests.cs
@@ -111,4 +111,18 @@ public class AggregateWindowTests
         // Assert
         Assert.Equal(expected, sql.Text);
     }
+
+    [Fact]
+    public void PartitionBy_WithNoExpressions_ThrowsArgumentException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => PartitionBy());
+    }
+
+    [Fact]
+    public void PartitionBy_WithNullExpressions_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => PartitionBy(null!));
+    }
 }

--- a/tests/SqlArtisan.Tests/GroupByTests.cs
+++ b/tests/SqlArtisan.Tests/GroupByTests.cs
@@ -52,4 +52,19 @@ public class GroupByTests
 
         Assert.Equal(expected.ToString(), sql.Text);
     }
+
+    [Fact]
+    public void GroupBy_WithNoItems_ThrowsArgumentException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => Select(_t.Code).From(_t).GroupBy());
+    }
+
+    [Fact]
+    public void GroupBy_WithNullItems_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            Select(_t.Code).From(_t).GroupBy(null!));
+    }
 }

--- a/tests/SqlArtisan.Tests/OrderByTests.cs
+++ b/tests/SqlArtisan.Tests/OrderByTests.cs
@@ -94,4 +94,18 @@ public class OrderByTests
 
         Assert.Equal(expected.ToString(), sql.Text);
     }
+
+    [Fact]
+    public void OrderBy_WithNoItems_ThrowsArgumentException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => OrderBy());
+    }
+
+    [Fact]
+    public void OrderBy_WithNullItems_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => OrderBy(null!));
+    }
 }


### PR DESCRIPTION
## Summary
`PartitionBy()`, `OrderBy()`, and `GroupBy()` called with no items rendered a
dangling clause keyword — `PARTITION BY `, `ORDER BY `, `GROUP BY ` — which is a
syntax error in every database. This fixes #69 and, while in the same code,
closes the matching null-array hole so the three variadic clause factories
behave consistently.

```csharp
Sum(t.Code).Over(PartitionBy())   // before: SUM(code) OVER (PARTITION BY )  → DB syntax error
                                  // after:  ArgumentException at build time
```

## Changes
- **Empty guard**: the `PartitionByClause`, `OrderByClause`, and `GroupByClause`
  constructors throw `ArgumentException` when the item list is empty. An empty
  clause keyword is universally invalid SQL, so this follows the same
  "gate what is invalid everywhere" criterion as the multi-row INSERT arity
  check (#54).
- **Null guard**: `OrderByItemResolver` / `GroupByItemResolver` now reject a null
  array with the same `ArgumentNullException` that `ExpressionResolver` already
  raised for `PartitionBy` (#60). `ExpressionResolver.NullValueMessage` was
  promoted to `internal` so the message stays identical across all three.

| input | PartitionBy | OrderBy | GroupBy |
| --- | --- | --- | --- |
| empty (0 items) | `ArgumentException` | `ArgumentException` | `ArgumentException` |
| null array | `ArgumentNullException` (was already #60) | `ArgumentNullException` (new) | `ArgumentNullException` (new) |

## Notes
- The constructor guards are null-safe by construction (they receive a resolver's
  output, which is never null), so the null case is handled at the resolver/input
  level where it actually occurs.
- No existing test changed — confirming nothing legitimately builds an empty clause.

## Tests
- `OrderByTests` / `GroupByTests` / `AggregateWindowTests`: empty-throws and
  null-throws for each of the three factories (6 tests).
- Full suite: 348 passing, 0 build warnings (Release).

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)
