### PR TITLE
chore: Release SqlArtisan 0.2.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [0.2.0-beta.4] - 2026-06-12
 ### Added
 - Added support for pagination: `Limit`/`Offset` (PostgreSQL/MySQL/SQLite) and `OffsetRows`/`FetchFirst`/`FetchNext` (Oracle 12c+/SQL Server 2012+). (#49)
 - Added support for the ANSI `CAST(expr AS type)` expression. (#52)
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Improved `SqlBuildingBuffer` memory efficiency and throughput. (#45)
 - Documented the design philosophy and non-goals, and surfaced dialect-specific features in the README and via XML doc comments. (#47)
 - Consolidated the ranking window functions' shared `Over(...)` overloads onto the `AnalyticFunction` base class (non-breaking). (#60)
+
+### Fixed
+- `PartitionBy` / `OrderBy` / `GroupBy` with no items (or a null array) now throw a clear exception at build time instead of generating invalid SQL such as `ORDER BY `. (#69)
 
 ## [0.2.0-beta.3] - 2026-06-07
 ### Added

--- a/src/SqlArtisan/SqlArtisan.csproj
+++ b/src/SqlArtisan/SqlArtisan.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
 
     <VersionPrefix>0.2.0</VersionPrefix>
-    <VersionSuffix>beta.3</VersionSuffix>
+    <VersionSuffix>beta.4</VersionSuffix>
     <Copyright>Copyright (c) h.tacayama 2025</Copyright>
 
     <Authors>h.tacayama</Authors>


### PR DESCRIPTION
## Summary
Release prep for **SqlArtisan 0.2.0-beta.4**.

## Changes
- Bump `SqlArtisan` `VersionSuffix` `beta.3` → `beta.4` (independent numbering; `SqlArtisan.Dapper` / `SqlArtisan.TableClassGen` are unchanged this cycle and stay as-is).
- CHANGELOG: convert `[Unreleased]` to `## [0.2.0-beta.4] - 2026-06-12`, and add a `### Fixed` entry for the `PartitionBy` / `OrderBy` / `GroupBy` empty-or-null guard (#69).

## This release accumulates
LIMIT/OFFSET/FETCH pagination (#49), ANSI `CAST` (#52), multi-row `INSERT ... VALUES` (#54), aggregate window functions (#56), window frames (#58), `LAG`/`LEAD` (#60), `NTILE` (#64), `FIRST_VALUE`/`LAST_VALUE`/`NTH_VALUE` (#65), `PERCENTILE_CONT`/`PERCENTILE_DISC` (#66); plus the `SqlBuildingBuffer` perf work (#45), design-philosophy docs (#47), the `Over` consolidation (#60), and the empty/null clause guard (#69).

## Verified
- Release build: 0 warnings.
- Tests: 348 passing.
- `dotnet pack` produces `SqlArtisan.0.2.0-beta.4.nupkg` with `README.md` (NuGet page syncs from the repo README) and the `MIT` SPDX license expression.

## Notes
- `GenerateDocumentationFile` is intentionally left off for this release, so XML doc comments are not yet shipped to consumers — tracked as a follow-up.
- No new empty `[Unreleased]` heading was re-added; it will return with the next change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
