### PR TITLE
Add Claude Code setup (CLAUDE.md + SessionStart hook)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+# Ensures the .NET 8 SDK is available and NuGet packages are restored so that
+# `dotnet build` / `dotnet test` work immediately in remote sessions.
+set -euo pipefail
+
+# Only run in Claude Code on the web (remote env). Locally we assume the
+# developer already manages their own .NET SDK.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+    exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+    SUDO="sudo"
+fi
+
+# Install the .NET 8 SDK from the Ubuntu archive if it isn't already present.
+# (The official dot.net / Azure CDN installers are blocked by the network
+# policy in this environment, but archive.ubuntu.com is reachable.)
+if ! command -v dotnet >/dev/null 2>&1; then
+    echo "Installing .NET 8 SDK..."
+    export DEBIAN_FRONTEND=noninteractive
+    # Refresh package lists; tolerate failures from unrelated third-party PPAs.
+    $SUDO apt-get update -qq || true
+    $SUDO apt-get install -y --no-install-recommends dotnet-sdk-8.0
+fi
+
+# Quiet the first-run banner and telemetry for this and the session's commands.
+export DOTNET_NOLOGO=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    {
+        echo 'export DOTNET_NOLOGO=1'
+        echo 'export DOTNET_CLI_TELEMETRY_OPTOUT=1'
+    } >> "$CLAUDE_ENV_FILE"
+fi
+
+echo "dotnet $(dotnet --version)"
+
+# Restore NuGet packages so the first build/test in the session is fast.
+dotnet restore "$PROJECT_DIR/SqlArtisan.sln"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## What this project is
+
+**SqlArtisan** is a type-safe SQL query builder for C# (.NET 8). You write
+SQL-like C# and it produces the SQL string plus its bind parameters.
+
+**Core design philosophy — read this before proposing changes:**
+> "The SQL you write is the SQL that runs. Cross-database portability is a
+> deliberate non-goal."
+
+Do **not** introduce abstractions whose purpose is to make one query run
+unchanged across multiple DBMS. DBMS differences are handled only where the
+*syntax* genuinely differs (quoting, parameter markers, pagination), via the
+dialect layer — never by rewriting the user's SQL semantics.
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| `src/SqlArtisan/Sql/Sql.{A..W}.cs` | Public API. `static partial class Sql`, one file per **leading letter** of the function name. |
+| `src/SqlArtisan/Internal/SqlPart/Expression/Function/**` | Internal function node classes (`*Function : SqlExpression`). |
+| `src/SqlArtisan/Internal/SqlBuilder/**` | Statement builders (Select/Insert/Update/Delete/With) + `SqlBuildingBuffer`. |
+| `src/SqlArtisan/Internal/SqlBuilder/DbmsDialect/**` | Per-DBMS syntax (`IDbmsDialect`: `AliasQuote`, `ParameterMarker`). |
+| `src/SqlArtisan/Internal/SqlPart/Keywords.cs` | All SQL keyword string constants. |
+| `src/SqlArtisan/SqlBuilder/` | Public surface: `Dbms`, `DbmsResolver`, `SqlArtisanConfig`, `SqlStatement`, `SqlParameters`, `ISqlBuilder`. |
+| `src/SqlArtisan.Dapper/` | Dapper integration. |
+| `src/SqlArtisan.TableClassGen/` | Console tool that generates table classes from a live DB (Oracle/PgSql). |
+| `tests/SqlArtisan.Tests/` | xUnit tests. `FunctionTests.{A..W}.cs` mirror `Sql.{A..W}.cs`. |
+| `tests/SqlArtisan.Benchmark/` | BenchmarkDotNet comparisons vs other builders. |
+
+Supported DBMS (`Dbms` enum): MySql, Oracle, PostgreSql, Sqlite, SqlServer.
+Default DBMS is `PostgreSql` (`SqlArtisanConfig.DefaultDbms`).
+
+## Build & test
+
+```bash
+dotnet restore
+dotnet build SqlArtisan.sln
+dotnet test tests/SqlArtisan.Tests          # unit tests (xUnit)
+```
+
+Always run `dotnet test` after changing `src/`. Tests assert the **exact** SQL
+string, so any output change will surface here.
+
+## How to add a new SQL function (the most common task)
+
+Touch all four, keeping the alphabetical convention:
+
+1. **Node class** — `src/SqlArtisan/Internal/SqlPart/Expression/Function/<Category>/<Name>Function.cs`:
+   `public sealed class <Name>Function : SqlExpression`, `internal` constructor,
+   `internal override void Format(SqlBuildingBuffer buffer)` that emits via the
+   fluent buffer (`.Append`, `.OpenParenthesis()`, `.PrependComma()`, etc.).
+2. **Keyword** — add the SQL token to `Keywords.cs` (keep alphabetical).
+3. **Public factory** — add a `public static <Name>Function <Name>(object ...)`
+   method to `Sql.<Letter>.cs`, wrapping args with
+   `ExpressionResolver.Resolve(...)`.
+4. **Test** — add `[Fact]`s to `FunctionTests.<Letter>.cs` asserting the exact
+   `SqlStatement.Text` (and parameters where relevant).
+
+Follow `AbsFunction` (single arg) and `AddMonthsFunction` (multi arg) as
+reference implementations.
+
+## Conventions
+
+- Style is enforced by `.editorconfig` (4-space indent, Allman braces,
+  explicit types over `var` unless the type is apparent, `Nullable` enabled,
+  implicit usings). Match it.
+- Keep DBMS-specific syntax inside `DbmsDialect`; never branch on `Dbms` inside
+  function nodes.
+- Public API lives only in `Sql.*.cs` and `src/SqlArtisan/SqlBuilder/`;
+  everything under `Internal/` is implementation detail.
+- Tests build expected SQL with a `StringBuilder` and assert equality — mirror
+  that pattern.
+- Update `CHANGELOG.md` for user-visible changes; the README is the canonical
+  user-facing documentation.
+
+## Git
+
+Develop on the assigned feature branch. Do not open a PR unless explicitly asked.


### PR DESCRIPTION
Sets up this repository for high-quality Claude Code sessions.

## Changes

### CLAUDE.md
Project memory that Claude Code reads at the start of every session:
- Core design philosophy ("the SQL you write is the SQL that runs" — cross-DB portability is a deliberate non-goal), so no misguided abstraction proposals
- Layout map: public API (`Sql.{A..W}.cs`), internal nodes, builders, dialect layer
- Build & test commands
- Step-by-step guide for the most common task: adding a new SQL function (node class → `Keywords.cs` → `Sql.<Letter>.cs` factory → mirrored test)
- Conventions: `.editorconfig` style, DBMS differences confined to `DbmsDialect`, exact-SQL test pattern, CHANGELOG updates

### SessionStart hook (`.claude/hooks/session-start.sh` + `.claude/settings.json`)
Remote (web) sessions start without the .NET SDK, so builds and tests were impossible. The hook:
- Runs only when `CLAUDE_CODE_REMOTE=true` (local environments are untouched)
- Installs `dotnet-sdk-8.0` via apt from the Ubuntu archive if missing (the official dot.net / Azure CDN installers are blocked by the environment's network policy; archive.ubuntu.com is reachable)
- Runs `dotnet restore SqlArtisan.sln`
- Idempotent; sets `DOTNET_NOLOGO` / `DOTNET_CLI_TELEMETRY_OPTOUT` for the session

## Validation (in the remote environment)
- ✅ Hook executes cleanly (exit 0), skips SDK install when already present
- ✅ `dotnet format --verify-no-changes` passes on existing code
- ✅ Sample unit test passes (`dotnet test --filter Abs_NumericValue_CorrectSql`)

Once merged into `main`, all future Claude Code web sessions pick up both the project memory and the SDK setup automatically.

https://claude.ai/code/session_01XEZ32rAe5rpAnd9TqfYWky