### PR TITLE
chore: Allowlist safe dotnet and read-only git commands for Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,18 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(dotnet build:*)",
+      "Bash(dotnet test:*)",
+      "Bash(dotnet restore:*)",
+      "Bash(dotnet format:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git fetch:*)"
+    ]
+  },
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary

Adds a permission allowlist to `.claude/settings.json` so routine, safe
commands run without a permission prompt during Claude Code sessions.

## Changes

- **`.claude/settings.json`** — new `permissions.allow` list:
  - `dotnet build` / `test` / `restore` / `format`
  - read-only git: `status` / `diff` / `log` / `show` / `branch` / `fetch`

State-changing / outward-facing commands (`git commit`, `git push`, `git add`)
are intentionally **not** allowlisted, so they remain review checkpoints.

The existing `SessionStart` hook configuration is unchanged.

https://claude.ai/code/session_01XEZ32rAe5rpAnd9TqfYWky

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEZ32rAe5rpAnd9TqfYWky)_