### PR TITLE
chore: Enable Recommended analyzers for the core library

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -157,6 +157,9 @@ file_header_template =
 
 # Suppress specific diagnostics (C#)
 dotnet_diagnostic.IDE0130.severity = none
+# CA1716: the fluent SQL DSL deliberately uses names that match language keywords
+# (e.g. In, As). Allow them.
+dotnet_diagnostic.CA1716.severity = none
 
 # C++ Files
 [*.{cpp,h,in}]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+
+  <!--
+    Enable the broader "Recommended" set of .NET code-quality analyzers for the
+    shipped core library. Warnings only (never errors): analyzer rule sets differ
+    across SDK builds, so promoting them to errors would make CI non-deterministic.
+    Other projects (tests, benchmark, tooling) keep the SDK defaults.
+  -->
+  <PropertyGroup Condition="'$(MSBuildProjectName)' == 'SqlArtisan'">
+    <AnalysisMode>Recommended</AnalysisMode>
+  </PropertyGroup>
+
+</Project>

--- a/src/SqlArtisan/Internal/SqlBuilder/Delete/DeleteBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Delete/DeleteBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace SqlArtisan.Internal;
 
-internal class DeleteBuilder(params SqlPart[] rootParts) :
+internal sealed class DeleteBuilder(params SqlPart[] rootParts) :
     SqlBuilderBase(rootParts),
     IDeleteBuilderDelete,
     IDeleteBuilderWhere

--- a/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
@@ -10,7 +10,7 @@ internal sealed class SqlBuildingBuffer : IDisposable
     private char[] _buffer;
     private int _position;
     private Dictionary<string, BindValue> _parameters = [];
-    private bool _disposed = false;
+    private bool _disposed;
 
     internal SqlBuildingBuffer(IDbmsDialect dialect)
     {

--- a/src/SqlArtisan/Internal/SqlPart/RegexpOptions/RegexpOptionsExtensions.cs
+++ b/src/SqlArtisan/Internal/SqlPart/RegexpOptions/RegexpOptionsExtensions.cs
@@ -10,34 +10,34 @@ internal static class RegexpOptionsExtensions
     internal static string ToSql(this RegexpOptions options)
     {
         StringBuilder result = new();
-        result.Append("'");
+        result.Append('\'');
 
         if (options.HasFlag(RegexpOptions.CaseSensitive))
         {
-            result.Append("c");
+            result.Append('c');
         }
 
         if (options.HasFlag(RegexpOptions.CaseInsensitive))
         {
-            result.Append("i");
+            result.Append('i');
         }
 
         if (options.HasFlag(RegexpOptions.MultipleLines))
         {
-            result.Append("m");
+            result.Append('m');
         }
 
         if (options.HasFlag(RegexpOptions.NewLine))
         {
-            result.Append("n");
+            result.Append('n');
         }
 
         if (options.HasFlag(RegexpOptions.ExcludingWhiteSpace))
         {
-            result.Append("x");
+            result.Append('x');
         }
 
-        result.Append("'");
+        result.Append('\'');
         return result.ToString();
     }
 }


### PR DESCRIPTION
## Summary

Enables the broader **Recommended** set of .NET code-quality analyzers for the
shipped core library (`SqlArtisan`), and fixes the findings so the library
builds warning-free.

## Changes

- **`Directory.Build.props`** (new) — sets `AnalysisMode=Recommended` scoped to
  the `SqlArtisan` core project only. **Warnings, not errors** (analyzer rule
  sets differ across SDK builds, so promoting to errors would make CI
  non-deterministic — same class of issue we hit with `dotnet format`). Tests,
  benchmark, and tooling keep SDK defaults to avoid convention noise (e.g.
  CA1707 on the underscore test-naming convention).
- **`.editorconfig`** — suppress **CA1716**: the fluent SQL DSL deliberately
  uses keyword-like names (`In`, `As`).
- **Analyzer fixes** in the core library (no behavioral change):
  - **CA1834 ×7** (`RegexpOptionsExtensions`) — `StringBuilder.Append(char)`
    for single-char constants (minor perf, relevant in a string-building lib).
  - **CA1852 ×1** — seal internal `DeleteBuilder`.
  - **CA1805 ×1** — drop redundant explicit default initialization.

## Validation (local)

- ✅ Core library builds with **0 analyzer warnings**
- ✅ Full solution: 0 warnings, 0 errors
- ✅ `dotnet format --verify-no-changes` — clean
- ✅ `dotnet test` — 348 passed, 0 failed

## Scope note

Analyzers are intentionally scoped to the core library for now — that's what
ships and what the `/add-sql-function` workflow touches. Coverage can be
extended to `SqlArtisan.Dapper` / tooling later if desired.

https://claude.ai/code/session_01XEZ32rAe5rpAnd9TqfYWky

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEZ32rAe5rpAnd9TqfYWky)_