### PR TITLE
perf: Reduce per-build allocations in SqlBuildingBuffer

### DIFF
--- a/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
@@ -6,10 +6,16 @@ namespace SqlArtisan.Internal;
 internal sealed class SqlBuildingBuffer : IDisposable
 {
     private const int InitialCapacity = 2048;
+
+    // Shared, never-mutated instance handed to parameterless statements so they
+    // don't each allocate an empty dictionary. SqlParameters only ever reads it.
+    private static readonly Dictionary<string, BindValue> s_emptyParameters = new();
+
     private readonly IDbmsDialect _dialect;
     private char[] _buffer;
     private int _position;
-    private Dictionary<string, BindValue> _parameters = [];
+    // Allocated lazily on the first parameter; parameterless statements keep this null.
+    private Dictionary<string, BindValue>? _parameters;
     private bool _disposed;
 
     internal SqlBuildingBuffer(IDbmsDialect dialect)
@@ -32,7 +38,7 @@ internal sealed class SqlBuildingBuffer : IDisposable
             _buffer = null!;
         }
 
-        _parameters = null!;
+        _parameters = null;
         _disposed = true;
     }
 
@@ -262,6 +268,7 @@ internal sealed class SqlBuildingBuffer : IDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
+        _parameters ??= new();
         string name = $"{_dialect.ParameterMarker}{_parameters.Count}";
         Append(name);
         _parameters.Add(name, bindValue);
@@ -272,6 +279,7 @@ internal sealed class SqlBuildingBuffer : IDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
+        _parameters ??= new();
         string name = $"{_dialect.ParameterMarker}{variable}";
 
         if (_parameters.ContainsKey(name))
@@ -295,8 +303,8 @@ internal sealed class SqlBuildingBuffer : IDisposable
         // The buffer relinquishes its reference so the caller's instance is
         // never mutated after this point (Dispose only returns the char buffer).
         string sql = new(_buffer, 0, _position);
-        Dictionary<string, BindValue> parameters = _parameters;
-        _parameters = null!;
+        Dictionary<string, BindValue> parameters = _parameters ?? s_emptyParameters;
+        _parameters = null;
         return new(sql, parameters);
     }
 

--- a/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
@@ -8,14 +8,16 @@ internal sealed class SqlBuildingBuffer : IDisposable
     private const int InitialCapacity = 2048;
 
     // Shared, never-mutated instance handed to parameterless statements so they
-    // don't each allocate an empty dictionary. SqlParameters only ever reads it.
-    private static readonly Dictionary<string, BindValue> s_emptyParameters = new();
+    // don't each allocate a list. SqlParameters only ever reads it.
+    private static readonly List<KeyValuePair<string, BindValue>> s_emptyParameters = new();
 
     private readonly IDbmsDialect _dialect;
     private char[] _buffer;
     private int _position;
     // Allocated lazily on the first parameter; parameterless statements keep this null.
-    private Dictionary<string, BindValue>? _parameters;
+    // A list (insertion-ordered) is used over a dictionary: parameter counts are
+    // small, so linear lookup is cheap and it allocates less than a hash table.
+    private List<KeyValuePair<string, BindValue>>? _parameters;
     private bool _disposed;
 
     internal SqlBuildingBuffer(IDbmsDialect dialect)
@@ -271,7 +273,7 @@ internal sealed class SqlBuildingBuffer : IDisposable
         _parameters ??= new();
         string name = $"{_dialect.ParameterMarker}{_parameters.Count}";
         Append(name);
-        _parameters.Add(name, bindValue);
+        _parameters.Add(new(name, bindValue));
         return this;
     }
 
@@ -282,16 +284,16 @@ internal sealed class SqlBuildingBuffer : IDisposable
         _parameters ??= new();
         string name = $"{_dialect.ParameterMarker}{variable}";
 
-        if (_parameters.ContainsKey(name))
+        if (ContainsParameterName(name))
         {
             throw new ArgumentException(
                 $"Duplicate variable name '{variable}' in RETURNING INTO clause. Each variable name must be unique.");
         }
 
         Append(name);
-        _parameters.Add(name, new BindValue(
+        _parameters.Add(new(name, new BindValue(
             DBNull.Value,
-            direction: ParameterDirection.Output));
+            direction: ParameterDirection.Output)));
         return this;
     }
 
@@ -303,9 +305,27 @@ internal sealed class SqlBuildingBuffer : IDisposable
         // The buffer relinquishes its reference so the caller's instance is
         // never mutated after this point (Dispose only returns the char buffer).
         string sql = new(_buffer, 0, _position);
-        Dictionary<string, BindValue> parameters = _parameters ?? s_emptyParameters;
+        List<KeyValuePair<string, BindValue>> parameters = _parameters ?? s_emptyParameters;
         _parameters = null;
         return new(sql, parameters);
+    }
+
+    private bool ContainsParameterName(string name)
+    {
+        if (_parameters is null)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < _parameters.Count; i++)
+        {
+            if (_parameters[i].Key == name)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void AppendSelectItem(SqlPart selectItem)

--- a/src/SqlArtisan/SqlBuilder/SqlParameters.cs
+++ b/src/SqlArtisan/SqlBuilder/SqlParameters.cs
@@ -4,9 +4,9 @@ namespace SqlArtisan;
 
 public sealed class SqlParameters
 {
-    private readonly Dictionary<string, BindValue> _parameters;
+    private readonly List<KeyValuePair<string, BindValue>> _parameters;
 
-    internal SqlParameters(Dictionary<string, BindValue> parameters) =>
+    internal SqlParameters(List<KeyValuePair<string, BindValue>> parameters) =>
         _parameters = parameters;
 
     public int Count => _parameters.Count;
@@ -21,8 +21,16 @@ public sealed class SqlParameters
         }
     }
 
-    public T? Get<T>(string name) =>
-        _parameters.TryGetValue(name, out BindValue? value)
-        ? (T?)value.Value
-        : default;
+    public T? Get<T>(string name)
+    {
+        foreach (KeyValuePair<string, BindValue> parameter in _parameters)
+        {
+            if (parameter.Key == name)
+            {
+                return (T?)parameter.Value.Value;
+            }
+        }
+
+        return default;
+    }
 }

--- a/src/SqlArtisan/SqlBuilder/SqlStatement.cs
+++ b/src/SqlArtisan/SqlBuilder/SqlStatement.cs
@@ -4,7 +4,7 @@ namespace SqlArtisan;
 
 public sealed class SqlStatement
 {
-    internal SqlStatement(string text, Dictionary<string, BindValue> parameters)
+    internal SqlStatement(string text, List<KeyValuePair<string, BindValue>> parameters)
     {
         Text = text;
         Parameters = new(parameters);


### PR DESCRIPTION
## Summary

Two allocation/throughput improvements on the hot `SqlBuildingBuffer` build path.

## Commits

### 1. Lazily allocate the parameter container — parameterless builds
Parameterless statements no longer allocate a parameter container: it's created
on the first parameter, and a shared static empty instance is handed to
statements that have none (safe because `SqlParameters` only reads it).

### 2. Store parameters in a list instead of a dictionary — parameterized builds
Parameter counts are small, so an insertion-ordered `List<KeyValuePair<...>>`
with linear name lookup allocates less than a hash table and avoids hashing on
the build path. `SqlParameters`' public API (`Count`, `ParameterNames`,
`ForEach`, `Get<T>`) is unchanged; only the internal storage type changes.

## Measured impact — ad-hoc harness (GC bytes / Build, net8.0 Release)

| Query | Before | After | Delta |
|-------|-------:|------:|------:|
| Parameterless | 584 B | **504 B** | **−14%** |
| 1 parameter | 890 B | **786 B** | **−12%** |
| 4 parameters | 1736 B | **1418 B** | **−18%** |

Parameterized builds are also ~7–12% faster (best-of-N ns/op); allocation
figures are deterministic and repeatable.

## Verified with `SqlArtisan.Benchmark` (BenchmarkDotNet + MemoryDiagnoser)

`SqlBuildingBufferBenchmark` (a join/where/group-by query with 2 parameters),
`--job short`:

| | Mean | Allocated |
|---|-----:|----------:|
| Before (eager dictionary) | 963.5 ns | 896 B |
| After (this PR) | 951.3 ns | **800 B** |
| Delta | comparable (within ShortRun noise) | **−96 B (−10.7%)** |

The `Allocated` column is exact (deterministic), confirming the ad-hoc numbers;
time is comparable with no regression.

## Why a list (and not a dictionary / sorted collection / extra index)

Benchmarked at high N: the list builds faster and allocates far less than a
dictionary, and the gap widens with N (e.g. 1000 params: build −31%, alloc
−47%). A dictionary only wins on `Get<T>(name)` lookup (O(1) vs the list's
O(N)), but that is a rarely-used convenience API — Dapper consumes parameters
via `ForEach` (sequential, equal cost either way). Sorted collections were
rejected: `SortedList` inserts in O(N) (→ O(N²) build) and both sorted
collections reorder keys lexicographically (`:10` before `:2`), breaking
positional order. If by-name lookup at high N ever matters, the right fix is a
dictionary index built lazily inside `SqlParameters.Get<T>`, keeping the build
path cheap.

## Validation

- ✅ Core library builds with 0 analyzer warnings
- ✅ `dotnet format --verify-no-changes` — clean
- ✅ `dotnet test` — 348 passed, 0 failed (RETURNING INTO duplicate detection
  and `Get<T>` lookups included)

https://claude.ai/code/session_01XEZ32rAe5rpAnd9TqfYWky