### PR TITLE
perf: Write single-char tokens as char; pre-size the builder parts list

### DIFF
--- a/src/SqlArtisan/Internal/SqlBuilder/DbmsDialect/IDbmsDialect.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/DbmsDialect/IDbmsDialect.cs
@@ -2,7 +2,7 @@ namespace SqlArtisan.Internal;
 
 internal interface IDbmsDialect
 {
-    string AliasQuote { get; }
+    char AliasQuote { get; }
 
-    string ParameterMarker { get; }
+    char ParameterMarker { get; }
 }

--- a/src/SqlArtisan/Internal/SqlBuilder/DbmsDialect/MySqlDialect.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/DbmsDialect/MySqlDialect.cs
@@ -2,7 +2,7 @@ namespace SqlArtisan.Internal;
 
 internal sealed class MySqlDialect : IDbmsDialect
 {
-    public string AliasQuote => "`";
+    public char AliasQuote => '`';
 
-    public string ParameterMarker => "?";
+    public char ParameterMarker => '?';
 }

--- a/src/SqlArtisan/Internal/SqlBuilder/DbmsDialect/OracleDialect.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/DbmsDialect/OracleDialect.cs
@@ -2,7 +2,7 @@ namespace SqlArtisan.Internal;
 
 internal sealed class OracleDialect : IDbmsDialect
 {
-    public string AliasQuote => "\"";
+    public char AliasQuote => '"';
 
-    public string ParameterMarker => ":";
+    public char ParameterMarker => ':';
 }

--- a/src/SqlArtisan/Internal/SqlBuilder/DbmsDialect/PostgreSqlDialect.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/DbmsDialect/PostgreSqlDialect.cs
@@ -2,7 +2,7 @@ namespace SqlArtisan.Internal;
 
 internal sealed class PostgreSqlDialect : IDbmsDialect
 {
-    public string AliasQuote => "\"";
+    public char AliasQuote => '"';
 
-    public string ParameterMarker => ":";
+    public char ParameterMarker => ':';
 }

--- a/src/SqlArtisan/Internal/SqlBuilder/DbmsDialect/SqlServerDialect.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/DbmsDialect/SqlServerDialect.cs
@@ -2,7 +2,7 @@ namespace SqlArtisan.Internal;
 
 internal sealed class SqlServerDialect : IDbmsDialect
 {
-    public string AliasQuote => "\"";
+    public char AliasQuote => '"';
 
-    public string ParameterMarker => "@";
+    public char ParameterMarker => '@';
 }

--- a/src/SqlArtisan/Internal/SqlBuilder/DbmsDialect/SqliteDialect.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/DbmsDialect/SqliteDialect.cs
@@ -2,7 +2,7 @@ namespace SqlArtisan.Internal;
 
 internal sealed class SqliteDialect : IDbmsDialect
 {
-    public string AliasQuote => "\"";
+    public char AliasQuote => '"';
 
-    public string ParameterMarker => ":";
+    public char ParameterMarker => ':';
 }

--- a/src/SqlArtisan/Internal/SqlBuilder/SqlBuilderBase.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/SqlBuilderBase.cs
@@ -1,8 +1,19 @@
 namespace SqlArtisan.Internal;
 
-internal abstract class SqlBuilderBase(SqlPart[] rootParts)
+internal abstract class SqlBuilderBase
 {
-    private readonly List<SqlPart> _parts = [.. rootParts];
+    // The collection-expression spread would start the list at the root-part
+    // count (usually 1) and immediately reallocate on the first appended clause.
+    // Start at the List growth step instead so that initial array is never wasted.
+    private const int ExpectedClauseCount = 4;
+
+    private readonly List<SqlPart> _parts;
+
+    protected SqlBuilderBase(SqlPart[] rootParts)
+    {
+        _parts = new List<SqlPart>(Math.Max(rootParts.Length, ExpectedClauseCount));
+        _parts.AddRange(rootParts);
+    }
 
     protected internal void AddPart(SqlPart part) => _parts.Add(part);
 

--- a/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
@@ -61,6 +61,13 @@ internal sealed class SqlBuildingBuffer : IDisposable
         return this;
     }
 
+    internal SqlBuildingBuffer Append(char value)
+    {
+        EnsureCapacity(1);
+        _buffer[_position++] = value;
+        return this;
+    }
+
     internal SqlBuildingBuffer AppendCsv(SqlPart[] parts)
     {
         if (parts.Length == 0)
@@ -338,13 +345,6 @@ internal sealed class SqlBuildingBuffer : IDisposable
         {
             selectItem.Format(this);
         }
-    }
-
-    private SqlBuildingBuffer Append(char value)
-    {
-        EnsureCapacity(1);
-        _buffer[_position++] = value;
-        return this;
     }
 
     private SqlBuildingBuffer Append(ReadOnlySpan<char> value)

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Insert/InsertIntoClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Insert/InsertIntoClause.cs
@@ -17,7 +17,7 @@ internal sealed class InsertIntoClause(DbTableBase table, DbColumn[] columns) : 
 
         if (_columns.Length > 0)
         {
-            buffer.Append(" ")
+            buffer.AppendSpace()
                 .OpenParenthesis()
                 .AppendCsv(_columns)
                 .CloseParenthesis();

--- a/src/SqlArtisan/SqlPart/Expression/DbColumn.cs
+++ b/src/SqlArtisan/SqlPart/Expression/DbColumn.cs
@@ -12,7 +12,7 @@ public sealed class DbColumn(string tableAlias, string columnName) : SqlExpressi
         if (!string.IsNullOrEmpty(_tableAlias))
         {
             buffer.EncloseInAliasQuotes(_tableAlias);
-            buffer.Append(".");
+            buffer.Append('.');
         }
 
         buffer.Append(Name);


### PR DESCRIPTION
## Summary

Two low-risk, internal-only performance improvements to the `Build()` / format
hot path. No public API changes. Output is preserved exactly (the 348 exact-SQL
tests pass), the core library stays at 0 analyzer warnings, and `dotnet format`
is clean.

## Changes

### Speed: write single-character tokens as `char`
- `IDbmsDialect.AliasQuote` / `ParameterMarker` are now `char` (they are always
  one character), `SqlBuildingBuffer.Append(char)` is `internal`, and the column
  dot and the `InsertIntoClause` space are written as chars. This skips the
  string→span append machinery for the many single-character tokens (alias
  quotes, dots) emitted per query.
- **~10% faster `Build()`** on a join + aggregate query; allocation unchanged.

### Allocation: pre-size the builder parts list
- The parts list started at the root-part count (usually 1) and reallocated its
  backing array on the first appended clause. Starting at the List growth step
  (4) removes that wasted initial array.
- **~15–25 B/op less**, with no regression on simple or complex queries.

## Validation
- ✅ Core library builds with 0 analyzer warnings
- ✅ `dotnet format --verify-no-changes` — clean
- ✅ `dotnet test` — 348 passed, 0 failed

## Note
An earlier draft of this branch also added fixed-arity `Select`/`From`/`GroupBy`/
`OrderBy` overloads to avoid the `params` array (~140 B/op). That was dropped:
it added public API surface and overload-resolution subtlety for a
non-differentiating allocation win (allocation already leads in the benchmark).
Kept here are only the internal-only changes.

https://claude.ai/code/session_01XEZ32rAe5rpAnd9TqfYWky