### PR TITLE
perf: Trim build-path work and AND/OR condition allocations

### DIFF
--- a/src/SqlArtisan/Internal/SqlBuilder/SqlBuilderBase.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/SqlBuilderBase.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace SqlArtisan.Internal;
 
 internal abstract class SqlBuilderBase
@@ -38,10 +40,10 @@ internal abstract class SqlBuilderBase
         IDbmsDialect dialect = DbmsDialectFactory.Create(dbms);
         using SqlBuildingBuffer buffer = new(dialect);
         return buffer
-            .AppendSpaceSeparated(_parts)
+            .AppendSpaceSeparated(CollectionsMarshal.AsSpan(_parts))
             .ToSqlStatement();
     }
 
     internal void FormatCore(SqlBuildingBuffer buffer) =>
-        buffer.AppendSpaceSeparated(_parts);
+        buffer.AppendSpaceSeparated(CollectionsMarshal.AsSpan(_parts));
 }

--- a/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
@@ -138,16 +138,16 @@ internal sealed class SqlBuildingBuffer : IDisposable
         return this;
     }
 
-    internal SqlBuildingBuffer AppendSpaceSeparated(IList<SqlPart> parts)
+    internal SqlBuildingBuffer AppendSpaceSeparated(ReadOnlySpan<SqlPart> parts)
     {
-        if (parts.Count == 0)
+        if (parts.Length == 0)
         {
             return this;
         }
 
         parts[0].Format(this);
 
-        for (int i = 1; i < parts.Count; i++)
+        for (int i = 1; i < parts.Length; i++)
         {
             AppendSpace();
             parts[i].Format(this);

--- a/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
@@ -360,10 +360,12 @@ internal sealed class SqlBuildingBuffer : IDisposable
         return this;
     }
 
+    // No disposed check here: this runs on every append (the hottest path) and
+    // the buffer's lifecycle is internal (built, finalized via ToSqlStatement,
+    // then disposed). Disposal is still guarded at the entry points
+    // (AddParameter / AddOutParameter / ToSqlStatement).
     private void EnsureCapacity(int additionalChars)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
-
         if (_position + additionalChars > _buffer.Length)
         {
             int requiredCapacity = _position + additionalChars;

--- a/src/SqlArtisan/Internal/SqlPart/Condition/LogicalCondition/AndCondition.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Condition/LogicalCondition/AndCondition.cs
@@ -1,41 +1,58 @@
-﻿namespace SqlArtisan.Internal;
+namespace SqlArtisan.Internal;
 
 public sealed class AndCondition : SqlCondition
 {
-    private readonly List<SqlCondition> _conditions;
+    private readonly SqlCondition _first;
+    private readonly SqlCondition _second;
 
-    internal AndCondition(SqlCondition leftSide, SqlCondition rightRide)
+    // Third and later operands of a chained `a & b & c` only; the common binary
+    // AND keeps this null and allocates no list.
+    private List<SqlCondition>? _rest;
+
+    internal AndCondition(SqlCondition leftSide, SqlCondition rightSide)
     {
-        _conditions = new List<SqlCondition>
-        {
-            leftSide,
-            rightRide
-        };
+        _first = leftSide;
+        _second = rightSide;
     }
 
     internal override void Format(SqlBuildingBuffer buffer)
     {
         bool added = false;
 
-        for (int i = 0; i < _conditions.Count; i++)
+        FormatOperand(buffer, _first, ref added);
+        FormatOperand(buffer, _second, ref added);
+
+        if (_rest is not null)
         {
-            if (_conditions[i] is EmptyCondition)
+            for (int i = 0; i < _rest.Count; i++)
             {
-                continue;
+                FormatOperand(buffer, _rest[i], ref added);
             }
-
-            if (added)
-            {
-                buffer.EncloseInSpaces(Keywords.And);
-            }
-
-            buffer.EncloseInParentheses(_conditions[i]);
-            added = true;
         }
     }
 
     internal void Add(SqlCondition condition)
     {
-        _conditions.Add(condition);
+        _rest ??= [];
+        _rest.Add(condition);
+    }
+
+    private static void FormatOperand(
+        SqlBuildingBuffer buffer,
+        SqlCondition condition,
+        ref bool added)
+    {
+        if (condition is EmptyCondition)
+        {
+            return;
+        }
+
+        if (added)
+        {
+            buffer.EncloseInSpaces(Keywords.And);
+        }
+
+        buffer.EncloseInParentheses(condition);
+        added = true;
     }
 }

--- a/src/SqlArtisan/Internal/SqlPart/Condition/LogicalCondition/OrCondition.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Condition/LogicalCondition/OrCondition.cs
@@ -1,41 +1,58 @@
-﻿namespace SqlArtisan.Internal;
+namespace SqlArtisan.Internal;
 
 public sealed class OrCondition : SqlCondition
 {
-    private readonly List<SqlCondition> _conditions;
+    private readonly SqlCondition _first;
+    private readonly SqlCondition _second;
 
-    internal OrCondition(SqlCondition leftSide, SqlCondition rightRide)
+    // Third and later operands of a chained `a | b | c` only; the common binary
+    // OR keeps this null and allocates no list.
+    private List<SqlCondition>? _rest;
+
+    internal OrCondition(SqlCondition leftSide, SqlCondition rightSide)
     {
-        _conditions = new List<SqlCondition>
-        {
-            leftSide,
-            rightRide
-        };
+        _first = leftSide;
+        _second = rightSide;
     }
 
     internal override void Format(SqlBuildingBuffer buffer)
     {
         bool added = false;
 
-        for (int i = 0; i < _conditions.Count; i++)
+        FormatOperand(buffer, _first, ref added);
+        FormatOperand(buffer, _second, ref added);
+
+        if (_rest is not null)
         {
-            if (_conditions[i] is EmptyCondition)
+            for (int i = 0; i < _rest.Count; i++)
             {
-                continue;
+                FormatOperand(buffer, _rest[i], ref added);
             }
-
-            if (added)
-            {
-                buffer.EncloseInSpaces(Keywords.Or);
-            }
-
-            buffer.EncloseInParentheses(_conditions[i]);
-            added = true;
         }
     }
 
     internal void Add(SqlCondition condition)
     {
-        _conditions.Add(condition);
+        _rest ??= [];
+        _rest.Add(condition);
+    }
+
+    private static void FormatOperand(
+        SqlBuildingBuffer buffer,
+        SqlCondition condition,
+        ref bool added)
+    {
+        if (condition is EmptyCondition)
+        {
+            return;
+        }
+
+        if (added)
+        {
+            buffer.EncloseInSpaces(Keywords.Or);
+        }
+
+        buffer.EncloseInParentheses(condition);
+        added = true;
     }
 }

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Case/SearchedCaseExpression/SearchedCaseExpression.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Case/SearchedCaseExpression/SearchedCaseExpression.cs
@@ -22,7 +22,7 @@ public sealed class SearchedCaseExpression : SqlExpression
     internal override void Format(SqlBuildingBuffer buffer)
     {
         buffer.Append($"{Keywords.Case} ")
-            .AppendSpaceSeparated(_whenClauses);
+            .AppendSpaceSeparated((SqlPart[])_whenClauses);
 
         if (_elseClause is not null)
         {

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Case/SimpleCaseExpression/SimpleCaseExpression.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Case/SimpleCaseExpression/SimpleCaseExpression.cs
@@ -29,7 +29,7 @@ public sealed class SimpleCaseExpression : SqlExpression
     {
         buffer.Append($"{Keywords.Case} ")
             .AppendSpace(_expr)
-            .AppendSpaceSeparated(_whenClauses);
+            .AppendSpaceSeparated((SqlPart[])_whenClauses);
 
         if (_elseClause is not null)
         {


### PR DESCRIPTION
## Summary

Internal-only micro-optimizations to the `Build()` / format hot path. **No
public API changes**, output is preserved exactly (the 348 exact-SQL tests
pass), the core library stays at 0 analyzer warnings, and `dotnet format` is
clean.

## Changes

### Speed
- **Drop the per-append disposed check.** `EnsureCapacity` ran
  `ObjectDisposedException.ThrowIf` on every append (the hottest path). Disposal
  is still guarded at the entry points (`AddParameter` / `AddOutParameter` /
  `ToSqlStatement`) and the buffer's lifecycle is internal. ~42 ns less per
  `Build` (isolated, near-in-time measurement).
  - **Trade-off:** use-after-dispose now surfaces as `NullReferenceException`
    instead of `ObjectDisposedException`.
- **Iterate the parts list as a span.** `BuildCore` / `FormatCore` pass the parts
  via `CollectionsMarshal.AsSpan` and `AppendSpaceSeparated` takes
  `ReadOnlySpan<SqlPart>`, removing `IList` interface dispatch on the top-level
  clause loop (strictly fewer operations; no allocation change).

### Allocation
- **Store the first two AND/OR operands inline.** `AndCondition` / `OrCondition`
  kept all operands in a `List`, allocating one even for the common binary
  `a & b` / `a | b`. The first two operands now live in fields; a list is
  allocated lazily only for the third+ operand of a chained expression.
  SqlArtisan benchmark allocation: **2.30 KB → 2.23 KB**.

## Benchmark context (`SqlBuilderBenchmarks`, this machine — directional only)

Among the parameterizing query builders, SqlArtisan now allocates the least at
**2.23 KB** (next: Sqlify 3.13 KB, Dapper.SqlBuilder 5.12 KB), while the
hand-written `StringBuilder` floor is 1.38 KB. Time is top-tier and within
measurement noise of the fastest builder.

> ⚠️ The allocation figures are deterministic. The **time** figures here are
> not publishable: in this shared CI environment the run-to-run drift (~10%)
> exceeds the few-% gaps between the fastest builders, so the relative speed
> ranking flips between runs. The speed changes above are justified by reduced
> work (fewer per-append branches / no interface dispatch), not by a headline
> number — the source of record for published numbers is a quiet local machine.

## Validation
- ✅ Core library builds with 0 analyzer warnings
- ✅ `dotnet format --verify-no-changes` — clean
- ✅ `dotnet test` — 348 passed, 0 failed (logical conditions, `ConditionIf`,
  chained AND/OR, RETURNING INTO all covered)

https://claude.ai/code/session_01XEZ32rAe5rpAnd9TqfYWky

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEZ32rAe5rpAnd9TqfYWky)_