### PR TITLE
perf: Inline the buffer append hot path and cut more allocations

### DIFF
--- a/src/SqlArtisan/Internal/SqlBuilder/ParameterNameCache.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/ParameterNameCache.cs
@@ -1,0 +1,48 @@
+namespace SqlArtisan.Internal;
+
+// Positional parameter names (":0", ":1", "@0", ...) are highly repetitive, so
+// the common low indices are cached per marker and reused instead of formatting
+// (and allocating) a fresh string on every parameter.
+internal static class ParameterNameCache
+{
+    private const int CachedCount = 64;
+
+    private static readonly string[] s_colon = Build(':');
+    private static readonly string[] s_at = Build('@');
+    private static readonly string[] s_question = Build('?');
+
+    internal static string Get(char marker, int index)
+    {
+        if ((uint)index < CachedCount)
+        {
+            switch (marker)
+            {
+                case ':':
+                    return s_colon[index];
+                case '@':
+                    return s_at[index];
+                case '?':
+                    return s_question[index];
+                default:
+                    break;
+            }
+        }
+
+        return Format(marker, index);
+    }
+
+    private static string[] Build(char marker)
+    {
+        string[] names = new string[CachedCount];
+
+        for (int i = 0; i < CachedCount; i++)
+        {
+            names[i] = Format(marker, i);
+        }
+
+        return names;
+    }
+
+    private static string Format(char marker, int index) =>
+        marker + index.ToInvariantString();
+}

--- a/src/SqlArtisan/Internal/SqlBuilder/ReturningBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/ReturningBuilder.cs
@@ -20,11 +20,14 @@ internal sealed class ReturningBuilder : IReturningBuilder
 
         SqlPart[] resolved = SelectItemResolver.Resolve(expressions);
 
-        if (resolved.Any(p => p is ExpressionAlias))
+        for (int i = 0; i < resolved.Length; i++)
         {
-            throw new ArgumentException(
-                "Use plain column expressions in Returning(). " +
-                "To specify INTO variables, chain .Into(\"var1\", \"var2\").");
+            if (resolved[i] is ExpressionAlias)
+            {
+                throw new ArgumentException(
+                    "Use plain column expressions in Returning(). " +
+                    "To specify INTO variables, chain .Into(\"var1\", \"var2\").");
+            }
         }
 
         return new ReturningBuilder(inner, resolved);

--- a/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
@@ -278,7 +278,7 @@ internal sealed class SqlBuildingBuffer : IDisposable
         ObjectDisposedException.ThrowIf(_disposed, this);
 
         _parameters ??= new();
-        string name = $"{_dialect.ParameterMarker}{_parameters.Count}";
+        string name = ParameterNameCache.Get(_dialect.ParameterMarker, _parameters.Count);
         Append(name);
         _parameters.Add(new(name, bindValue));
         return this;

--- a/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
@@ -156,31 +156,6 @@ internal sealed class SqlBuildingBuffer : IDisposable
         return this;
     }
 
-    internal SqlBuildingBuffer AppendUpperSnakeCase(Enum value) =>
-        AppendUpperSnakeCase(value.ToString());
-
-    internal SqlBuildingBuffer AppendUpperSnakeCase(string text)
-    {
-        if (string.IsNullOrEmpty(text))
-        {
-            return this;
-        }
-
-        for (int i = 0; i < text.Length; i++)
-        {
-            char c = text[i];
-
-            if (i > 0 && char.IsUpper(c))
-            {
-                Append('_');
-            }
-
-            Append(char.ToUpperInvariant(c));
-        }
-
-        return this;
-    }
-
     internal SqlBuildingBuffer CloseParenthesis(SqlPart? part = null)
     {
         part?.Format(this);

--- a/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Data;
+using System.Runtime.CompilerServices;
 
 namespace SqlArtisan.Internal;
 
@@ -50,6 +51,7 @@ internal sealed class SqlBuildingBuffer : IDisposable
         return this;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal SqlBuildingBuffer Append(string? value)
     {
         if (string.IsNullOrEmpty(value))
@@ -61,6 +63,7 @@ internal sealed class SqlBuildingBuffer : IDisposable
         return this;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal SqlBuildingBuffer Append(char value)
     {
         EnsureCapacity(1);
@@ -322,6 +325,7 @@ internal sealed class SqlBuildingBuffer : IDisposable
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private SqlBuildingBuffer Append(ReadOnlySpan<char> value)
     {
         if (value.IsEmpty)
@@ -339,16 +343,25 @@ internal sealed class SqlBuildingBuffer : IDisposable
     // the buffer's lifecycle is internal (built, finalized via ToSqlStatement,
     // then disposed). Disposal is still guarded at the entry points
     // (AddParameter / AddOutParameter / ToSqlStatement).
+    // The common case (no growth) is a single bounds check so it inlines into
+    // the Append callers; the rare growth is a separate, non-inlined method.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void EnsureCapacity(int additionalChars)
     {
         if (_position + additionalChars > _buffer.Length)
         {
-            int requiredCapacity = _position + additionalChars;
-            int newSize = Math.Max(_buffer.Length * 2, requiredCapacity);
-            char[] newBuffer = ArrayPool<char>.Shared.Rent(newSize);
-            _buffer.AsSpan(0, _position).CopyTo(newBuffer);
-            ArrayPool<char>.Shared.Return(_buffer);
-            _buffer = newBuffer;
+            Grow(additionalChars);
         }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void Grow(int additionalChars)
+    {
+        int requiredCapacity = _position + additionalChars;
+        int newSize = Math.Max(_buffer.Length * 2, requiredCapacity);
+        char[] newBuffer = ArrayPool<char>.Shared.Rent(newSize);
+        _buffer.AsSpan(0, _position).CopyTo(newBuffer);
+        ArrayPool<char>.Shared.Return(_buffer);
+        _buffer = newBuffer;
     }
 }

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/DateTimeFunction/DatepartFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/DateTimeFunction/DatepartFunction.cs
@@ -14,7 +14,7 @@ public sealed class DatepartFunction : SqlExpression
     internal override void Format(SqlBuildingBuffer buffer) => buffer
         .Append(Keywords.Datepart)
         .OpenParenthesis()
-        .AppendUpperSnakeCase(_datepart)
+        .Append(DatepartKeywords.Of(_datepart))
         .PrependComma(_source)
         .CloseParenthesis();
 }

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/DateTimeFunction/DatepartKeywords.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/DateTimeFunction/DatepartKeywords.cs
@@ -1,0 +1,45 @@
+using System.Text;
+
+namespace SqlArtisan.Internal;
+
+// Datepart SQL keywords (e.g. Datepart.DayHour -> "DAY_HOUR") are fixed, so they
+// are computed once and reused instead of formatting the enum name (which calls
+// the relatively expensive Enum.ToString) on every Format.
+internal static class DatepartKeywords
+{
+    private static readonly string[] s_keywords = Build();
+
+    internal static string Of(Datepart datepart) => s_keywords[(int)datepart];
+
+    private static string[] Build()
+    {
+        Datepart[] values = Enum.GetValues<Datepart>();
+        string[] keywords = new string[values.Length];
+
+        foreach (Datepart value in values)
+        {
+            keywords[(int)value] = ToUpperSnakeCase(value.ToString());
+        }
+
+        return keywords;
+    }
+
+    private static string ToUpperSnakeCase(string name)
+    {
+        StringBuilder result = new(name.Length + 4);
+
+        for (int i = 0; i < name.Length; i++)
+        {
+            char c = name[i];
+
+            if (i > 0 && char.IsUpper(c))
+            {
+                result.Append('_');
+            }
+
+            result.Append(char.ToUpperInvariant(c));
+        }
+
+        return result.ToString();
+    }
+}

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/DateTimeFunction/ExtractFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/DateTimeFunction/ExtractFunction.cs
@@ -14,7 +14,7 @@ public sealed class ExtractFunction : SqlExpression
     internal override void Format(SqlBuildingBuffer buffer) => buffer
         .Append(Keywords.Extract)
         .OpenParenthesis()
-        .AppendUpperSnakeCase(_datepart)
+        .Append(DatepartKeywords.Of(_datepart))
         .EncloseInSpaces(Keywords.From)
         .Append(_source)
         .CloseParenthesis();

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/SequenceFunction/NextValueForFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/SequenceFunction/NextValueForFunction.cs
@@ -12,5 +12,6 @@ public sealed class NextValueForFunction : SqlExpression
     }
 
     internal override void Format(SqlBuildingBuffer buffer) => buffer
-        .Append($"{Next} {Value} {For} {_sequenceName}");
+        .Append($"{Next} {Value} {For} ")
+        .Append(_sequenceName);
 }


### PR DESCRIPTION
## Summary

More build-path performance work, all **internal-only** — no public API changes,
output preserved exactly (348 exact-SQL tests pass), 0 analyzer warnings,
`dotnet format` clean.

## Changes

### Speed (the big wins)
- **Split the buffer-growth slow path out of `EnsureCapacity`.** The ArrayPool
  grow logic lived inline in `EnsureCapacity`, making it too large for the JIT
  to inline into the per-append callers — so *every* append paid a method call.
  Growth now lives in a separate cold `Grow` method, leaving `EnsureCapacity` as
  a single bounds check that inlines. **~25% faster** isolated `Build`.
- **Aggressively inline the `Append` primitives** (`char` / `string?` /
  `ReadOnlySpan<char>`) so they fold into the many per-token `Format` callers.
  Another **~7%** on top.

  Combined, the isolated `SqlBuildingBufferBenchmark` `Build` went **~608 → ~428
  ns** (MediumRun, before/after in the same session) — ~30%.

### Allocation
- **Cache positional parameter names.** `:0`, `:1`, `@0`, … are highly
  repetitive but were formatted (and allocated) fresh per parameter; the low
  indices are now cached per marker. ~32–58 B less per parameter.
- **Remove incidental allocations in niche format paths:** RETURNING validation
  uses a loop instead of LINQ `.Any` (no boxed enumerator); `NEXT VALUE FOR`
  appends the sequence name separately so the keyword prefix is a folded
  constant; `EXTRACT` / `DATEPART` keywords are precomputed/cached instead of
  `Enum.ToString` + snake-casing per `Format` (the now-unused
  `AppendUpperSnakeCase` helpers are removed).

## Validation
- ✅ Core library builds with 0 analyzer warnings
- ✅ `dotnet format --verify-no-changes` — clean
- ✅ `dotnet test` — 348 passed, 0 failed

> Time figures are from a shared CI environment and are directional only (the
> EnsureCapacity / inlining deltas were measured as same-session before/after on
> the isolated buffer benchmark, which is the most stable signal here). The
> source of record for published numbers remains a quiet local machine.

https://claude.ai/code/session_01XEZ32rAe5rpAnd9TqfYWky

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEZ32rAe5rpAnd9TqfYWky)_