### PR TITLE
style: Remove stray trailing semicolon in ISqlBuilderExtensions.Build

### DIFF
--- a/src/SqlArtisan/SqlBuilder/ISqlBuilderExtensions.cs
+++ b/src/SqlArtisan/SqlBuilder/ISqlBuilderExtensions.cs
@@ -7,6 +7,6 @@ public static class ISqlBuilderExtensions
     public static SqlStatement Build(this ISqlBuilder sqlBuilder, IDbConnection cnn)
     {
         Dbms dbms = DbmsResolver.Resolve(cnn);
-        return sqlBuilder.Build(dbms); ;
+        return sqlBuilder.Build(dbms);
     }
 }


### PR DESCRIPTION
## Summary

Removes a stray double semicolon in `ISqlBuilderExtensions.Build(IDbConnection)`:

```diff
-        return sqlBuilder.Build(dbms); ;
+        return sqlBuilder.Build(dbms);
```

Noticed incidentally while working in this area. Pure cleanup — no behavior change.

## Verification
- `dotnet build SqlArtisan.sln` — succeeds, 0 warnings/errors
- `dotnet format SqlArtisan.sln --verify-no-changes` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DW7uki6HGpaBFpLefXpBnd)_