### PR TITLE
docs: Trim [Unreleased] CHANGELOG entries to the one-line house style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- Added support for per-dialect string aggregation: `StringAgg()` (PostgreSQL/SQL Server), `Listagg()` (Oracle), and `GroupConcat()` (MySQL/SQLite). Note: MySQL's `GROUP_CONCAT` silently truncates at `group_concat_max_len` (1024 bytes by default). (#88)
-- Added support for the date/time arithmetic functions `DATEADD`, `DATEDIFF` (SQL Server) and `DATE_TRUNC` (PostgreSQL), exposed as distinct per-dialect methods (`Dateadd()` / `Datediff()` / `DateTrunc()`), each emitted verbatim so the caller picks the form their target DBMS requires. Units reuse the `DateTimePart` enum. Oracle's `TRUNC(date, fmt)` truncation remains available via the date/time overload of `Trunc()`. (#86)
-- Added support for UPSERT on the `INSERT` builder via per-dialect methods: `OnConflict(...).DoUpdateSet(...)` / `.DoNothing()` with an optional `Where(...)` (PostgreSQL/SQLite `ON CONFLICT`), and `OnDuplicateKeyUpdate(...)` (MySQL `ON DUPLICATE KEY UPDATE`). Reference the proposed row with `Sql.Excluded(column)`, which resolves to `EXCLUDED` (PostgreSQL), `excluded` (SQLite), or the `new` row alias (MySQL 8.0.19+). (#85)
-- Added support for the scalar functions `NULLIF`, `ROUND`, `CEIL`, `CEILING`, `FLOOR`, `POWER`, `SQRT`, and `SIGN`. `CEIL` and `CEILING` are exposed as distinct functions (`Ceil()` / `Ceiling()`), each emitted verbatim, so the caller picks the spelling their target DBMS requires. (#84)
+- Added support for per-dialect string aggregation: `StringAgg()` (PostgreSQL/SQL Server), `Listagg()` (Oracle), and `GroupConcat()` (MySQL/SQLite). (#88)
+- Added support for the date/time arithmetic functions `DATEADD` / `DATEDIFF` (SQL Server) and `DATE_TRUNC` (PostgreSQL), as distinct per-dialect methods (`Dateadd()` / `Datediff()` / `DateTrunc()`). (#86)
+- Added support for UPSERT on `INSERT`: `OnConflict(...).DoUpdateSet(...)` / `.DoNothing()` (PostgreSQL/SQLite) and `OnDuplicateKeyUpdate(...)` (MySQL), referencing the proposed row with `Sql.Excluded(column)`. (#85)
+- Added support for the scalar functions `NULLIF`, `ROUND`, `CEIL`, `CEILING`, `FLOOR`, `POWER`, `SQRT`, and `SIGN`. (#84)
 
 ### Changed
-- **Breaking:** Renamed the `Datepart` enum to `DateTimePart`. The previous name collided with the `Sql.Datepart()` factory method, so any enum member written in expression position under the recommended `using static SqlArtisan.Sql;` failed to compile with `CS0119` (this affected `Extract`, `Datepart`, `Dateadd`, `Datediff`, and `DateTrunc`). The enum members and the emitted SQL are unchanged; callers update only the type name (e.g. `Datepart.Year` → `DateTimePart.Year`). (#99)
+- **Breaking:** Renamed the `Datepart` enum to `DateTimePart` to avoid a `CS0119` collision with the `Sql.Datepart()` factory; emitted SQL is unchanged, callers update only the type name (e.g. `Datepart.Year` → `DateTimePart.Year`). (#99)
 
 ## [0.2.0-beta.4] - 2026-06-12
 ### Added


### PR DESCRIPTION
## Summary

Brings the `[Unreleased]` CHANGELOG entries back to the project's one-line house style. Every released section (`0.2.0-beta.4` and earlier) uses a single terse `Added support for <what>. (#NN)` line, with rationale and caveats living in the README. The `[Unreleased]` entries for #88/#86/#85/#84 (and the #99 *Changed* note) had grown into multi-sentence paragraphs; this trims them.

Closes #106.

## Changes

`CHANGELOG.md` only — docs, no source/SQL behavior change.

| Entry | Before | After |
|---|---|---|
| #88 string aggregation | one line + truncation note | one line |
| #86 DATEADD/DATEDIFF/DATE_TRUNC | 4 sentences | one line |
| #85 UPSERT | 3 sentences | one line |
| #84 scalar functions | 2 sentences | one line |
| #99 `DateTimePart` rename | long `CS0119` explanation | one line + migration note (kept, in style) |

## No caveat lost

Detail dropped from the CHANGELOG is already documented in the README, verified:
- MySQL `group_concat_max_len` truncation note — `README.md` (String Aggregation section).
- UPSERT `Excluded(column)` dialect resolution (`EXCLUDED` / `excluded` / `new` alias) — `README.md` (INSERT / UPSERT section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZLdHeGdDPgmuKFnGPAyLP

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZLdHeGdDPgmuKFnGPAyLP)_