### PR TITLE
docs: Unify the breaking-change prefix to [BREAKING CHANGE]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for the scalar functions `NULLIF`, `ROUND`, `CEIL`, `CEILING`, `FLOOR`, `POWER`, `SQRT`, and `SIGN`. (#84)
 
 ### Changed
-- **Breaking:** Renamed the `Datepart` enum to `DateTimePart` to avoid a `CS0119` collision with the `Sql.Datepart()` factory; emitted SQL is unchanged, callers update only the type name (e.g. `Datepart.Year` → `DateTimePart.Year`). (#99)
+- **[BREAKING CHANGE]** Renamed the `Datepart` enum to `DateTimePart` to avoid a `CS0119` collision with the `Sql.Datepart()` factory; emitted SQL is unchanged, callers update only the type name (e.g. `Datepart.Year` → `DateTimePart.Year`). (#99)
 
 ## [0.2.0-beta.4] - 2026-06-12
 ### Added


### PR DESCRIPTION
## Summary

Unifies the breaking-change prefix in `CHANGELOG.md`. The `[Unreleased]` #99 `DateTimePart` rename was written with a `**Breaking:**` prefix, which differs from the style used by every released breaking change (`**[BREAKING CHANGE]**`, e.g. #27 and #21). This aligns #99 to that established style.

## Change

`CHANGELOG.md` only — docs, no source/SQL behavior change.

```diff
-- **Breaking:** Renamed the `Datepart` enum to `DateTimePart` ... (#99)
+- **[BREAKING CHANGE]** Renamed the `Datepart` enum to `DateTimePart` ... (#99)
```

All breaking-change entries now use the same `**[BREAKING CHANGE]**` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZLdHeGdDPgmuKFnGPAyLP

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZLdHeGdDPgmuKFnGPAyLP)_