### PR TITLE
refactor: Order builder interfaces and members alphabetically

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,12 @@ reference implementations.
   token with no underscore stays a single word — never invent internal capitals.
   So `ADD_MONTHS`→`AddMonths`, `DATE_TRUNC`→`DateTrunc`, but `DATEPART`→`Datepart`,
   `CURRVAL`→`Currval`, and `DATEADD`/`DATEDIFF`→`Dateadd`/`Datediff`.
+- Order a statement builder's **implemented-interface list** and its **member
+  methods** alphabetically by name (e.g. `DeleteBuilder`, `UpdateBuilder`).
+  Properties precede methods and the `protected` build hook trails; overloads
+  stay adjacent and explicit interface implementations sort by their simple
+  name. Within an interface definition, declare members alphabetically too. This
+  is mechanical and keeps builders consistent as they grow.
 - Tests build expected SQL with a `StringBuilder` and assert equality — mirror
   that pattern.
 - Update `CHANGELOG.md` for user-visible changes; the README is the canonical

--- a/src/SqlArtisan/Internal/SqlBuilder/Insert/InsertBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Insert/InsertBuilder.cs
@@ -3,19 +3,13 @@
 internal sealed class InsertBuilder(params SqlPart[] rootParts) :
     SelectBuilder(rootParts),
     IInsertBuilderColumns,
+    IInsertBuilderDoUpdateSet,
+    IInsertBuilderOnConflict,
     IInsertBuilderSet,
     IInsertBuilderTable,
-    IInsertBuilderValues,
-    IInsertBuilderOnConflict,
-    IInsertBuilderDoUpdateSet
+    IInsertBuilderValues
 {
     private InsertValuesClause? _valuesClause;
-
-    public IInsertBuilderOnConflict OnConflict(params DbColumn[] conflictTarget)
-    {
-        AddPart(new OnConflictClause(conflictTarget));
-        return this;
-    }
 
     public IReturning DoNothing()
     {
@@ -29,19 +23,16 @@ internal sealed class InsertBuilder(params SqlPart[] rootParts) :
         return this;
     }
 
+    public IInsertBuilderOnConflict OnConflict(params DbColumn[] conflictTarget)
+    {
+        AddPart(new OnConflictClause(conflictTarget));
+        return this;
+    }
+
     public IReturning OnDuplicateKeyUpdate(params EqualityBasedCondition[] assignments)
     {
         AddPart(new RowAliasClause());
         AddPart(OnDuplicateKeyUpdateClause.Parse(assignments));
-        return this;
-    }
-
-    // The DO UPDATE SET WHERE filter. Explicit implementation keeps this distinct
-    // from the inherited SelectBuilder.Where (which returns a SELECT builder);
-    // both add the same WhereClause, but this preserves the UPSERT chain.
-    IReturning IInsertBuilderDoUpdateSet.Where(SqlCondition condition)
-    {
-        AddPart(new WhereClause(condition));
         return this;
     }
 
@@ -66,6 +57,15 @@ internal sealed class InsertBuilder(params SqlPart[] rootParts) :
             _valuesClause.AddRow(values);
         }
 
+        return this;
+    }
+
+    // The DO UPDATE SET WHERE filter. Explicit implementation keeps this distinct
+    // from the inherited SelectBuilder.Where (which returns a SELECT builder);
+    // both add the same WhereClause, but this preserves the UPSERT chain.
+    IReturning IInsertBuilderDoUpdateSet.Where(SqlCondition condition)
+    {
+        AddPart(new WhereClause(condition));
         return this;
     }
 

--- a/src/SqlArtisan/Internal/SqlBuilder/Select/SelectBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Select/SelectBuilder.cs
@@ -4,16 +4,16 @@ namespace SqlArtisan.Internal;
 
 internal class SelectBuilder(params SqlPart[] rootParts) :
     SqlBuilderBase(rootParts),
+    ILimitOffsetBuilder,
+    IOffsetFetchBuilder,
     ISelectBuilderFrom,
     ISelectBuilderGroupBy,
     ISelectBuilderHaving,
-    ISelectBuilderSetOperator,
     ISelectBuilderJoin,
     ISelectBuilderOrderBy,
     ISelectBuilderSelect,
-    ISelectBuilderWhere,
-    ILimitOffsetBuilder,
-    IOffsetFetchBuilder
+    ISelectBuilderSetOperator,
+    ISelectBuilderWhere
 {
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public ISelectBuilderSetOperator Except
@@ -101,37 +101,9 @@ internal class SelectBuilder(params SqlPart[] rootParts) :
     public SqlStatement Build(Dbms dbms) =>
         BuildCore(dbms);
 
-    public void Format(SqlBuildingBuffer buffer) => FormatCore(buffer);
-
-    public ISqlBuilder ForUpdate(LockBehaviorBase? lockBehavior = null)
+    public ISelectBuilderFrom CrossJoin(TableReference table)
     {
-        AddPart(new ForUpdateClause(lockBehavior));
-        return this;
-    }
-
-    public ISqlBuilder ForUpdate(
-        OfClause ofClause,
-        LockBehaviorBase? lockBehavior = null)
-    {
-        AddPart(new ForUpdateClause(ofClause, lockBehavior));
-        return this;
-    }
-
-    public ILimitOffsetBuilder Limit(int count)
-    {
-        AddPart(new LimitClause(count));
-        return this;
-    }
-
-    public ISqlBuilder Offset(int start)
-    {
-        AddPart(new OffsetClause(start));
-        return this;
-    }
-
-    public IOffsetFetchBuilder OffsetRows(int start)
-    {
-        AddPart(new OffsetRowsClause(start));
+        AddPart(new CrossJoinClause(table));
         return this;
     }
 
@@ -147,9 +119,19 @@ internal class SelectBuilder(params SqlPart[] rootParts) :
         return this;
     }
 
-    public ISelectBuilderFrom CrossJoin(TableReference table)
+    public void Format(SqlBuildingBuffer buffer) => FormatCore(buffer);
+
+    public ISqlBuilder ForUpdate(LockBehaviorBase? lockBehavior = null)
     {
-        AddPart(new CrossJoinClause(table));
+        AddPart(new ForUpdateClause(lockBehavior));
+        return this;
+    }
+
+    public ISqlBuilder ForUpdate(
+        OfClause ofClause,
+        LockBehaviorBase? lockBehavior = null)
+    {
+        AddPart(new ForUpdateClause(ofClause, lockBehavior));
         return this;
     }
 
@@ -189,9 +171,21 @@ internal class SelectBuilder(params SqlPart[] rootParts) :
         return this;
     }
 
-    public ISelectBuilderJoin RightJoin(TableReference table)
+    public ILimitOffsetBuilder Limit(int count)
     {
-        AddPart(new RightJoinClause(table));
+        AddPart(new LimitClause(count));
+        return this;
+    }
+
+    public ISqlBuilder Offset(int start)
+    {
+        AddPart(new OffsetClause(start));
+        return this;
+    }
+
+    public IOffsetFetchBuilder OffsetRows(int start)
+    {
+        AddPart(new OffsetRowsClause(start));
         return this;
     }
 
@@ -205,6 +199,12 @@ internal class SelectBuilder(params SqlPart[] rootParts) :
         params object[] orderByItems)
     {
         AddPart(OrderByClause.Parse(orderByItems));
+        return this;
+    }
+
+    public ISelectBuilderJoin RightJoin(TableReference table)
+    {
+        AddPart(new RightJoinClause(table));
         return this;
     }
 


### PR DESCRIPTION
## Summary

Standardize the statement builders on a single, mechanical ordering rule so they stay consistent as they grow: the **implemented-interface list** and the **class member methods** are ordered alphabetically by name. This was prompted by review discussion on the MERGE builder (#109), where we agreed the codebase lacked one consistent rule (only the trivial `UpdateBuilder` was cleanly alphabetical, while `InsertBuilder`/`SelectBuilder` mixed feature-grouping with alphabetical).

## Changes

- **InsertBuilder**: reorder the implemented-interface list and the methods alphabetically.
- **SelectBuilder**: reorder the methods alphabetically. The set-operator *properties* were already alphabetical and remain ahead of the methods (properties precede methods).
- **CLAUDE.md**: document the convention (interface list + members alphabetical; properties before methods; `protected` build hook trails; overloads adjacent; explicit interface implementations sort by simple name; interface definitions alphabetical too).

`DeleteBuilder` and `UpdateBuilder` already conformed and are untouched. An audit confirmed every `I*Builder*` interface definition already declares its members alphabetically, so no interface files changed.

## Scope notes

- `ReturningBuilder` is a single-interface helper (static factory + `Into`/`Build`), not one of the multi-state fluent builders this rule targets, so it is left as-is.
- `MergeBuilder` (introduced in #109, not yet merged) was already aligned to this same alphabetical rule on that branch.

## Verification

- No behavioral change — this is a pure declaration/member reordering.
- `dotnet build -c Release`: 0 warnings / 0 errors.
- `dotnet test`: **388 passed** (exact-SQL assertions unchanged).
- `dotnet format --verify-no-changes`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3wacx424KXDV9oYQ3H6DV

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3wacx424KXDV9oYQ3H6DV)_