### PR TITLE
fix: Allow ORDER BY to follow HAVING in the SELECT builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - **[BREAKING CHANGE]** Renamed the `Datepart` enum to `DateTimePart` to avoid a `CS0119` collision with the `Sql.Datepart()` factory; emitted SQL is unchanged, callers update only the type name (e.g. `Datepart.Year` → `DateTimePart.Year`). (#99)
 
+### Fixed
+- `ORDER BY` can now follow `HAVING`: `GroupBy(...).Having(...).OrderBy(...)` previously did not compile, making `GROUP BY ... HAVING ... ORDER BY ...` inexpressible. (#111)
+
 ## [0.2.0-beta.4] - 2026-06-12
 ### Added
 - Added support for pagination: `Limit`/`Offset` (PostgreSQL/MySQL/SQLite) and `OffsetRows`/`FetchFirst`/`FetchNext` (Oracle 12c+/SQL Server 2012+). (#49)

--- a/src/SqlArtisan/Internal/SqlBuilder/Select/ISelectBuilderHaving.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Select/ISelectBuilderHaving.cs
@@ -2,4 +2,6 @@
 
 public interface ISelectBuilderHaving : ISqlBuilder, ISetOperator, ISubquery, IPagination
 {
+    ISelectBuilderOrderBy OrderBy(
+        params object[] orderByItems);
 }

--- a/tests/SqlArtisan.Tests/HavingTests.cs
+++ b/tests/SqlArtisan.Tests/HavingTests.cs
@@ -29,4 +29,58 @@ public class HavingTests
 
         Assert.Equal(expected.ToString(), sql.Text);
     }
+
+    [Fact]
+    public void Having_FollowedByOrderBy_CorrectSql()
+    {
+        SqlStatement sql =
+            Select(_t.Name)
+            .From(_t)
+            .GroupBy(_t.Name)
+            .Having(Count(_t.Name) > 1)
+            .OrderBy(_t.Name)
+            .Build();
+
+        StringBuilder expected = new();
+        expected.Append("SELECT ");
+        expected.Append("\"t\".name ");
+        expected.Append("FROM ");
+        expected.Append("test_table \"t\" ");
+        expected.Append("GROUP BY ");
+        expected.Append("\"t\".name ");
+        expected.Append("HAVING ");
+        expected.Append("COUNT(\"t\".name) > :0 ");
+        expected.Append("ORDER BY ");
+        expected.Append("\"t\".name");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
+    public void Having_FollowedByOrderByAndLimit_CorrectSql()
+    {
+        SqlStatement sql =
+            Select(_t.Name)
+            .From(_t)
+            .GroupBy(_t.Name)
+            .Having(Count(_t.Name) > 1)
+            .OrderBy(Count(_t.Name).Desc)
+            .Limit(10)
+            .Build();
+
+        StringBuilder expected = new();
+        expected.Append("SELECT ");
+        expected.Append("\"t\".name ");
+        expected.Append("FROM ");
+        expected.Append("test_table \"t\" ");
+        expected.Append("GROUP BY ");
+        expected.Append("\"t\".name ");
+        expected.Append("HAVING ");
+        expected.Append("COUNT(\"t\".name) > :0 ");
+        expected.Append("ORDER BY ");
+        expected.Append("COUNT(\"t\".name) DESC ");
+        expected.Append("LIMIT :1");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
 }


### PR DESCRIPTION
## Summary

Closes #111. `ISelectBuilderHaving` exposed no `OrderBy`, so `GroupBy(...).Having(...).OrderBy(...)` did not compile and **`GROUP BY ... HAVING ... ORDER BY ...` was inexpressible** — in either ordering, since `ISelectBuilderOrderBy` has no `Having`. The gap was sharpened by `IPagination`: a non-deterministic `HAVING ... LIMIT` was expressible while the `ORDER BY` that would make it deterministic was not.

```csharp
// Before: CS1061 — 'ISelectBuilderHaving' does not contain a definition for 'OrderBy'
Select(t.Dept, Count(t.Id))
    .From(t).GroupBy(t.Dept).Having(Count(t.Id) > 5)
    .OrderBy(Count(t.Id).Desc)
    .Build(Dbms.PostgreSql);
// SELECT ... GROUP BY ... HAVING COUNT(...) > :0 ORDER BY COUNT(...) DESC
```

## Change

Add `OrderBy` (returning `ISelectBuilderOrderBy`) to `ISelectBuilderHaving`:

```csharp
public interface ISelectBuilderHaving : ISqlBuilder, ISetOperator, ISubquery, IPagination
{
    ISelectBuilderOrderBy OrderBy(params object[] orderByItems);
}
```

`SelectBuilder` already implements `public ISelectBuilderOrderBy OrderBy(params object[])` and already implements `ISelectBuilderHaving`, so **no new implementation is required** — only the interface declaration. `ISelectBuilderOrderBy` already exposes `IPagination`, so `HAVING ... ORDER BY ... LIMIT ...` now composes.

## Tests

Added exact-`Text` tests to `HavingTests.cs`:
- `GROUP BY ... HAVING ... ORDER BY ...`
- `GROUP BY ... HAVING ... ORDER BY ... DESC LIMIT ...`

## Verification

- `dotnet build -c Release`: 0 warnings / 0 errors.
- `dotnet test`: **399 passed** (397 + 2 new).
- `dotnet format --verify-no-changes`: clean.
- CHANGELOG `[Unreleased] > Fixed` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3wacx424KXDV9oYQ3H6DV

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3wacx424KXDV9oYQ3H6DV)_