### PR TITLE
test: Build dialect-specific assertions with the matching Dbms

### DIFF
--- a/tests/SqlArtisan.Tests/ExpressionsTests.cs
+++ b/tests/SqlArtisan.Tests/ExpressionsTests.cs
@@ -88,7 +88,7 @@ public class ExpressionsTests
             Select(
                 Sequence("seq").Currval,
                 Sequence("seq").Nextval)
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");

--- a/tests/SqlArtisan.Tests/ForUpdateTests.cs
+++ b/tests/SqlArtisan.Tests/ForUpdateTests.cs
@@ -15,7 +15,7 @@ public class ForUpdateTests
             Select(t.Name)
             .From(t)
             .ForUpdate()
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -35,7 +35,7 @@ public class ForUpdateTests
             Select(t.Name)
             .From(t)
             .ForUpdate(Nowait)
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -55,7 +55,7 @@ public class ForUpdateTests
             Select(t.Name)
             .From(t)
             .ForUpdate(SkipLocked)
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -75,7 +75,7 @@ public class ForUpdateTests
             Select(t.Name)
             .From(t)
             .ForUpdate(Wait(5))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -95,7 +95,7 @@ public class ForUpdateTests
             Select(t.Name)
             .From(t)
             .ForUpdate(Of(t.Code))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -115,7 +115,7 @@ public class ForUpdateTests
             Select(t.Name)
             .From(t)
             .ForUpdate(Of(t.Code), Nowait)
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -135,7 +135,7 @@ public class ForUpdateTests
             Select(t.Name)
             .From(t)
             .ForUpdate(Of(t.Code), SkipLocked)
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -155,7 +155,7 @@ public class ForUpdateTests
             Select(t.Name)
             .From(t)
             .ForUpdate(Of(t.Code), Wait(5))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");

--- a/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.A.cs
+++ b/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.A.cs
@@ -26,7 +26,7 @@ public partial class FunctionTests
     {
         SqlStatement sql =
             Select(AddMonths(_t.CreatedAt, 3))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");

--- a/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.D.cs
+++ b/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.D.cs
@@ -21,7 +21,7 @@ public partial class FunctionTests
     }
 
     [Fact]
-    public void Dateadd_NegativeNumberSubtracts_CorrectSql()
+    public void Dateadd_SqlServer_NegativeNumberSubtracts()
     {
         SqlStatement sql =
             Select(Dateadd(DateTimePart.Day, -7, _t.CreatedAt))

--- a/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.D.cs
+++ b/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.D.cs
@@ -10,14 +10,14 @@ public partial class FunctionTests
     {
         SqlStatement sql =
             Select(Dateadd(DateTimePart.Month, 3, _t.CreatedAt))
-            .Build();
+            .Build(Dbms.SqlServer);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
-        expected.Append("DATEADD(MONTH, :0, \"t\".created_at)");
+        expected.Append("DATEADD(MONTH, @0, \"t\".created_at)");
 
         Assert.Equal(expected.ToString(), sql.Text);
-        Assert.Equal(3, sql.Parameters.Get<int>(":0"));
+        Assert.Equal(3, sql.Parameters.Get<int>("@0"));
     }
 
     [Fact]
@@ -25,14 +25,14 @@ public partial class FunctionTests
     {
         SqlStatement sql =
             Select(Dateadd(DateTimePart.Day, -7, _t.CreatedAt))
-            .Build();
+            .Build(Dbms.SqlServer);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
-        expected.Append("DATEADD(DAY, :0, \"t\".created_at)");
+        expected.Append("DATEADD(DAY, @0, \"t\".created_at)");
 
         Assert.Equal(expected.ToString(), sql.Text);
-        Assert.Equal(-7, sql.Parameters.Get<int>(":0"));
+        Assert.Equal(-7, sql.Parameters.Get<int>("@0"));
     }
 
     [Fact]
@@ -40,7 +40,7 @@ public partial class FunctionTests
     {
         SqlStatement sql =
             Select(Datediff(DateTimePart.Day, _t.CreatedAt, CurrentTimestamp))
-            .Build();
+            .Build(Dbms.SqlServer);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -69,7 +69,7 @@ public partial class FunctionTests
                 Datepart(DateTimePart.Nanosecond, CurrentTimestamp),
                 Datepart(DateTimePart.Tzoffset, CurrentTimestamp),
                 Datepart(DateTimePart.IsoWeek, CurrentTimestamp))
-            .Build();
+            .Build(Dbms.SqlServer);
 
         StringBuilder expected = new StringBuilder()
             .Append("SELECT ")
@@ -118,7 +118,7 @@ public partial class FunctionTests
                         (2, 20),
                     ],
                     999))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -145,7 +145,7 @@ public partial class FunctionTests
                         (Null, 20),
                     ],
                     999.9))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -167,7 +167,7 @@ public partial class FunctionTests
                     _t.Code,
                     (1, "a"),
                     "z"))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -190,7 +190,7 @@ public partial class FunctionTests
                     (1, "a"),
                     (2, "b"),
                     "z"))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -216,7 +216,7 @@ public partial class FunctionTests
                     (2, "b"),
                     (3, "c"),
                     "z"))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -245,7 +245,7 @@ public partial class FunctionTests
                     (3, "c"),
                     (4, "d"),
                     "z"))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -277,7 +277,7 @@ public partial class FunctionTests
                     (4, "d"),
                     (5, "e"),
                     "z"))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -312,7 +312,7 @@ public partial class FunctionTests
                     (5, "e"),
                     (6, "f"),
                     "z"))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -350,7 +350,7 @@ public partial class FunctionTests
                     (6, "f"),
                     (7, "g"),
                     "z"))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -391,7 +391,7 @@ public partial class FunctionTests
                     (7, "g"),
                     (8, "h"),
                     "z"))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -435,7 +435,7 @@ public partial class FunctionTests
                     (8, "h"),
                     (9, "i"),
                     "z"))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -482,7 +482,7 @@ public partial class FunctionTests
                     (9, "i"),
                     (10, "j"),
                     "z"))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");

--- a/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.E.cs
+++ b/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.E.cs
@@ -31,7 +31,7 @@ public partial class FunctionTests
                 Extract(DateTimePart.DayHour, CurrentTimestamp),
                 Extract(DateTimePart.YearMonth, CurrentTimestamp)
             )
-            .Build();
+            .Build(Dbms.MySql);
 
         StringBuilder expected = new StringBuilder()
             .Append("SELECT ")
@@ -75,7 +75,7 @@ public partial class FunctionTests
                 Extract(DateTimePart.TimezoneRegion, Systimestamp),
                 Extract(DateTimePart.TimezoneAbbr, Systimestamp))
             .From(Dual)
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new StringBuilder()
             .Append("SELECT ")

--- a/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.I.cs
+++ b/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.I.cs
@@ -10,7 +10,7 @@ public partial class FunctionTests
     {
         SqlStatement sql =
             Select(Instr(_t.Name, "abc"))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -24,7 +24,7 @@ public partial class FunctionTests
     {
         SqlStatement sql =
             Select(Instr(_t.Name, "abc", 1))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -38,7 +38,7 @@ public partial class FunctionTests
     {
         SqlStatement sql =
             Select(Instr(_t.Name, "abc", 1, 2))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");

--- a/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.L.cs
+++ b/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.L.cs
@@ -10,7 +10,7 @@ public partial class FunctionTests
     {
         SqlStatement sql =
             Select(LastDay(_t.CreatedAt))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -52,7 +52,7 @@ public partial class FunctionTests
     {
         SqlStatement sql =
             Select(Lengthb(_t.Name))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");

--- a/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.M.cs
+++ b/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.M.cs
@@ -55,7 +55,7 @@ public partial class FunctionTests
                 MonthsBetween(
                     ToDate("2001/02/03", "YYYY/MM/DD"),
                     ToDate("2004/05/06", "YYYY/MM/DD")))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");

--- a/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.N.cs
+++ b/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.N.cs
@@ -24,7 +24,7 @@ public partial class FunctionTests
     {
         SqlStatement sql =
             Select(NextValueFor("seq_test"))
-            .Build();
+            .Build(Dbms.SqlServer);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -52,7 +52,7 @@ public partial class FunctionTests
     {
         SqlStatement sql =
             Select(Nvl(_t.Name, "Unknown"))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");

--- a/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.S.cs
+++ b/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.S.cs
@@ -66,7 +66,7 @@ public partial class FunctionTests
     {
         SqlStatement sql =
             Select(Substrb(_t.Name, 1))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -80,7 +80,7 @@ public partial class FunctionTests
     {
         SqlStatement sql =
             Select(Substrb(_t.Name, 1, 3))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -122,7 +122,7 @@ public partial class FunctionTests
     {
         SqlStatement sql =
             Select(Sysdate)
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -136,7 +136,7 @@ public partial class FunctionTests
     {
         SqlStatement sql =
             Select(Systimestamp)
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");

--- a/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.T.cs
+++ b/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.T.cs
@@ -150,7 +150,7 @@ public partial class FunctionTests
     {
         SqlStatement sql =
             Select(Trunc(_t.CreatedAt))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -164,7 +164,7 @@ public partial class FunctionTests
     {
         SqlStatement sql =
             Select(Trunc(_t.CreatedAt, "MONTH"))
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");

--- a/tests/SqlArtisan.Tests/ReturningTests.cs
+++ b/tests/SqlArtisan.Tests/ReturningTests.cs
@@ -126,7 +126,7 @@ public class ReturningTests
             DeleteFrom(_t)
             .Returning(_t.Code, _t.Name)
             .Into("b", "c")
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("DELETE FROM ");
@@ -145,7 +145,7 @@ public class ReturningTests
             .Where(_t.Code == 1)
             .Returning(_t.Code, _t.Name)
             .Into("b", "c")
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("DELETE FROM ");
@@ -165,7 +165,7 @@ public class ReturningTests
             .Set(_t.Code == 1, _t.Name == "a")
             .Returning(_t.Code, _t.Name)
             .Into("b", "c")
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("INSERT INTO ");
@@ -185,7 +185,7 @@ public class ReturningTests
             .Set(_t.Code == 1, _t.Name == "a")
             .Returning(_t.Code, _t.Name)
             .Into("b", "c")
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("UPDATE test_table ");
@@ -254,7 +254,7 @@ public class ReturningTests
             DeleteFrom(_t)
             .Returning(_t.Code, _t.Name)
             .Into("b", "c")
-            .Build();
+            .Build(Dbms.Oracle);
 
         Dictionary<string, BindValue> parameters = new();
         sql.Parameters.ForEach((name, bind) => parameters.Add(name, bind));

--- a/tests/SqlArtisan.Tests/SelectTests.cs
+++ b/tests/SqlArtisan.Tests/SelectTests.cs
@@ -98,7 +98,7 @@ public class SelectTests
         SqlStatement sql =
             Select(Sysdate)
             .From(Dual)
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");

--- a/tests/SqlArtisan.Tests/SetOperatorTests/MinusTests.cs
+++ b/tests/SqlArtisan.Tests/SetOperatorTests/MinusTests.cs
@@ -14,7 +14,7 @@ public class MinusTests
             Select(1)
             .Minus
             .Select(2)
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -34,7 +34,7 @@ public class MinusTests
             .From(_t)
             .Minus
             .Select(2)
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -57,7 +57,7 @@ public class MinusTests
             .Where(_t.Code == 1)
             .Minus
             .Select(2)
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -83,7 +83,7 @@ public class MinusTests
             .GroupBy(_t.Code)
             .Minus
             .Select(2)
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -112,7 +112,7 @@ public class MinusTests
             .Having(Count(_t.Code) > 0)
             .Minus
             .Select(2)
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");
@@ -139,7 +139,7 @@ public class MinusTests
             Select(1)
             .MinusAll
             .Select(2)
-            .Build();
+            .Build(Dbms.Oracle);
 
         StringBuilder expected = new();
         expected.Append("SELECT ");


### PR DESCRIPTION
## Summary

Closes #97.

Several unit tests asserted Oracle / SQL Server / MySQL tokens while building with the default `.Build()` (= PostgreSql), so the SQL they asserted could never run on the nominal dialect. This switches each to `.Build(Dbms.X)` so every assertion is faithful to the dialect it represents. **Test-quality / faithfulness change only — no library behavior change.**

## What changed

**Switched to `.Build(Dbms.Oracle)`**
`SYSDATE` / `SYSTIMESTAMP` / `DUAL`, `ADD_MONTHS`, `MONTHS_BETWEEN`, `LAST_DAY`, date `TRUNC`, `NVL`, `DECODE` (all 12), `INSTR`, `SUBSTRB`, `LENGTHB`, `MINUS` / `MINUS ALL`, `FOR UPDATE [OF/NOWAIT/SKIP LOCKED/WAIT]` (all 8), `RETURNING ... INTO`, `seq.CURRVAL`/`NEXTVAL`, `EXTRACT(... FROM SYSTIMESTAMP) FROM DUAL`.

**Switched to `.Build(Dbms.SqlServer)`**
`NEXT VALUE FOR`, `DATEADD`, `DATEDIFF`, `DATEPART`.

**Switched to `.Build(Dbms.MySql)`**
`EXTRACT` interval qualifiers (e.g. `YEAR_MONTH`).

## Notes on expected strings

- Oracle's parameter marker (`:`) and alias quote (`"`) match PostgreSql, so those assertions are **unchanged** — the switch declares intent only.
- SQL Server's `@` marker changes the two `DATEADD` parameter assertions (`:0` → `@0`, and the corresponding `Parameters.Get(...)` keys).
- PG-valid tokens are intentionally **left as default**: `TO_CHAR`/`TO_DATE`/`TO_NUMBER`/`TO_TIMESTAMP`, numeric `TRUNC`, `NEXTVAL('seq')`, `DATE_TRUNC`.

## Naming

Renamed `Dateadd_NegativeNumberSubtracts_CorrectSql` → `Dateadd_SqlServer_NegativeNumberSubtracts` to match the `<Construct>_<Dialect>_<Scenario>` convention used by its sibling and the `Merge_SqlServer_*` tests.

## Verification

- `dotnet test`: **399 passed / 0 failed**
- `dotnet build -c Release`: **0 warnings / 0 errors**
- `dotnet format --verify-no-changes`: **clean**
- Empirically confirmed via a throwaway harness: `DATEADD/SqlServer` → `@0` (valid T-SQL), `ADD_MONTHS/Oracle` keeps `:0` (marker == PostgreSql), `EXTRACT(YEAR_MONTH ...)/MySql` valid and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCWW3NexyqS3SRzkKQjSdv)_