### PR TITLE
test: Unify dialect token placement and casing in test method names

### DIFF
--- a/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.E.cs
+++ b/tests/SqlArtisan.Tests/FunctionTests/FunctionTests.E.cs
@@ -6,7 +6,7 @@ namespace SqlArtisan.Tests;
 public partial class FunctionTests
 {
     [Fact]
-    public void Extract_MySQL_CorrectSql()
+    public void Extract_MySql_CorrectSql()
     {
         SqlStatement sql =
             Select(
@@ -95,7 +95,7 @@ public partial class FunctionTests
     }
 
     [Fact]
-    public void Extract_PostgreSQL_CorrectSql()
+    public void Extract_PostgreSql_CorrectSql()
     {
         SqlStatement sql =
             Select(

--- a/tests/SqlArtisan.Tests/SqlBuilderTests/BuildTests.cs
+++ b/tests/SqlArtisan.Tests/SqlBuilderTests/BuildTests.cs
@@ -9,7 +9,7 @@ public class BuildTests
     private readonly TestTable _t = new("t");
 
     [Fact]
-    public void Build_ForMySql_QuestionMarkParameterPrefix()
+    public void Build_MySql_QuestionMarkParameterPrefix()
     {
         SqlStatement sql =
             Select(_t.Name)
@@ -28,7 +28,7 @@ public class BuildTests
     }
 
     [Fact]
-    public void Build_ForOracle_ColonParameterPrefix()
+    public void Build_Oracle_ColonParameterPrefix()
     {
         SqlStatement sql =
             Select(_t.Name)
@@ -47,7 +47,7 @@ public class BuildTests
     }
 
     [Fact]
-    public void Build_ForPostgreSql_ColonParameterPrefix()
+    public void Build_PostgreSql_ColonParameterPrefix()
     {
         SqlStatement sql =
             Select(_t.Name)
@@ -66,7 +66,7 @@ public class BuildTests
     }
 
     [Fact]
-    public void Build_ForSQLite_ColonParameterPrefix()
+    public void Build_Sqlite_ColonParameterPrefix()
     {
         SqlStatement sql =
             Select(_t.Name)
@@ -85,7 +85,7 @@ public class BuildTests
     }
 
     [Fact]
-    public void Build_ForSqlServer_AtSignParameterPrefix()
+    public void Build_SqlServer_AtSignParameterPrefix()
     {
         SqlStatement sql =
             Select(_t.Name)

--- a/tests/SqlArtisan.Tests/StringAggregationTests.cs
+++ b/tests/SqlArtisan.Tests/StringAggregationTests.cs
@@ -24,7 +24,7 @@ public class StringAggregationTests
     }
 
     [Fact]
-    public void StringAgg_InlineOrderBy_PostgreSql_CorrectSql()
+    public void StringAgg_PostgreSql_InlineOrderBy_CorrectSql()
     {
         // Arrange
         string expected = "SELECT STRING_AGG(name, :0 ORDER BY name)";
@@ -38,7 +38,7 @@ public class StringAggregationTests
     }
 
     [Fact]
-    public void StringAgg_WithinGroup_SqlServer_CorrectSql()
+    public void StringAgg_SqlServer_WithinGroup_CorrectSql()
     {
         // Arrange
         string expected =
@@ -56,7 +56,7 @@ public class StringAggregationTests
     // --- LISTAGG (Oracle) -----------------------------------------------------
 
     [Fact]
-    public void Listagg_WithinGroup_Oracle_CorrectSql()
+    public void Listagg_Oracle_WithinGroup_CorrectSql()
     {
         // Arrange
         string expected =
@@ -88,7 +88,7 @@ public class StringAggregationTests
     }
 
     [Fact]
-    public void GroupConcat_PositionalSeparator_Sqlite_CorrectSql()
+    public void GroupConcat_Sqlite_PositionalSeparator_CorrectSql()
     {
         // Arrange
         string expected = "SELECT GROUP_CONCAT(name, :0)";
@@ -103,7 +103,7 @@ public class StringAggregationTests
     }
 
     [Fact]
-    public void GroupConcat_SeparatorKeyword_MySql_CorrectSql()
+    public void GroupConcat_MySql_SeparatorKeyword_CorrectSql()
     {
         // Arrange
         string expected = "SELECT GROUP_CONCAT(name SEPARATOR ', ')";
@@ -118,7 +118,7 @@ public class StringAggregationTests
     }
 
     [Fact]
-    public void GroupConcat_SeparatorWithQuote_MySql_EscapesLiteral()
+    public void GroupConcat_MySql_SeparatorWithQuote_EscapesLiteral()
     {
         // Arrange
         string expected = @"SELECT GROUP_CONCAT(name SEPARATOR ''' \\')";
@@ -133,7 +133,7 @@ public class StringAggregationTests
     }
 
     [Fact]
-    public void GroupConcat_OrderBySeparator_MySql_CorrectSql()
+    public void GroupConcat_MySql_OrderBySeparator_CorrectSql()
     {
         // Arrange
         string expected =
@@ -149,7 +149,7 @@ public class StringAggregationTests
     }
 
     [Fact]
-    public void GroupConcat_Distinct_MySql_CorrectSql()
+    public void GroupConcat_MySql_Distinct_CorrectSql()
     {
         // Arrange
         string expected = "SELECT GROUP_CONCAT(DISTINCT name)";
@@ -163,7 +163,7 @@ public class StringAggregationTests
     }
 
     [Fact]
-    public void GroupConcat_DistinctSeparator_MySql_CorrectSql()
+    public void GroupConcat_MySql_DistinctSeparator_CorrectSql()
     {
         // Arrange
         string expected = "SELECT GROUP_CONCAT(DISTINCT name SEPARATOR ' | ')";
@@ -178,7 +178,7 @@ public class StringAggregationTests
     }
 
     [Fact]
-    public void GroupConcat_OrderByDefaultSeparator_MySql_CorrectSql()
+    public void GroupConcat_MySql_OrderByDefaultSeparator_CorrectSql()
     {
         // Arrange
         string expected = "SELECT GROUP_CONCAT(name ORDER BY name)";
@@ -192,7 +192,7 @@ public class StringAggregationTests
     }
 
     [Fact]
-    public void GroupConcat_DistinctOrderBySeparator_MySql_CorrectSql()
+    public void GroupConcat_MySql_DistinctOrderBySeparator_CorrectSql()
     {
         // Arrange
         string expected =

--- a/tests/SqlArtisan.Tests/UpsertTests.cs
+++ b/tests/SqlArtisan.Tests/UpsertTests.cs
@@ -8,7 +8,7 @@ public class UpsertTests
     private readonly TestTable _t = new();
 
     [Fact]
-    public void OnConflict_DoUpdateSet_PostgreSql_UsesUppercaseExcluded()
+    public void OnConflict_PostgreSql_DoUpdateSet_UsesUppercaseExcluded()
     {
         // Arrange
         StringBuilder expected = new();
@@ -30,7 +30,7 @@ public class UpsertTests
     }
 
     [Fact]
-    public void OnConflict_DoUpdateSet_Sqlite_UsesLowercaseExcluded()
+    public void OnConflict_Sqlite_DoUpdateSet_UsesLowercaseExcluded()
     {
         // Arrange
         StringBuilder expected = new();


### PR DESCRIPTION
## Summary

Follow-up cleanup from the #97 review. Normalizes test method names to a single canonical grammar:

```
<Subject>[_<Dbms>][_<Condition>]_<Expectation>
```

Test method names only — **no behavior or assertion change**. All 399 tests still pass.

## What changed (20 renames)

- **Move the DBMS token directly after the subject** (was sometimes in the condition slot): `StringAgg_*`, `Listagg_*`, `GroupConcat_*`, and `OnConflict_DoUpdateSet_{PostgreSql,Sqlite}_*`.
  - e.g. `StringAgg_WithinGroup_SqlServer_CorrectSql` → `StringAgg_SqlServer_WithinGroup_CorrectSql`
- **Drop the `For` prefix** on the `Build_*` parameter-marker tests.
  - e.g. `Build_ForOracle_ColonParameterPrefix` → `Build_Oracle_ColonParameterPrefix`
- **Spell DBMS tokens exactly as the `Dbms` enum** (`MySQL`→`MySql`, `PostgreSQL`→`PostgreSql`, `SQLite`→`Sqlite`).
  - e.g. `Extract_MySQL_CorrectSql` → `Extract_MySql_CorrectSql`

`Resolve_*_Returns<Dbms>` (where the DBMS is genuinely the asserted value) and descriptive scenario tails (`Merge_SqlServer_WhenMatchedThenDelete`) are intentionally left as-is.

## Verification

- `dotnet test`: **399 passed / 0 failed** (count unchanged)
- `dotnet format --verify-no-changes`: **clean**

The grammar this enforces is documented in #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)