### PR TITLE
docs: Document unit-test conventions as a path-scoped rule

### DIFF
--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -1,0 +1,36 @@
+---
+description: Unit test conventions for SqlArtisan (naming, dialect, assertions)
+paths:
+  - "tests/**/*.cs"
+---
+
+# Writing unit tests
+
+- **Name** every test `<Subject>[_<Dbms>][_<Condition>]_<Expectation>`:
+  - `<Subject>` — the function / construct / method under test.
+  - `<Dbms>` — *only* for dialect-specific tests; placed immediately after the
+    subject and spelled exactly as the `Dbms` enum (`MySql`, `Oracle`,
+    `PostgreSql`, `Sqlite`, `SqlServer`). No `For` prefix; never `MySQL`/`SQLite`.
+  - `<Condition>` — the input / scenario (`NumericValue`, `WithWhere`,
+    `DistinctSeparator`); omit when there is nothing to qualify.
+  - `<Expectation>` — required tail: `CorrectSql` (exact SQL-string assertion),
+    `ThrowsArgumentException` / `ThrowsArgumentNullException`, `Returns<X>`
+    (Dapper), or a specific behavior (`UsesRowAlias`, `EscapesLiteral`).
+  - e.g. `Abs_NumericValue_CorrectSql`, `Extract_Oracle_CorrectSql`,
+    `Returning_NoArguments_ThrowsArgumentException`.
+- **Build with the dialect the SQL targets.** A test that asserts
+  dialect-specific tokens (Oracle `SYSDATE`, SQL Server `DATEADD`, MySQL
+  `GROUP_CONCAT`, …) must `.Build(Dbms.X)`, never the default `.Build()` —
+  otherwise it asserts SQL that cannot run on the nominal (PostgreSql) dialect.
+  Markers / quotes per dialect: Oracle / PostgreSql / Sqlite use `:`-params and
+  `"`-quotes (the asserted string is unchanged when only the dialect is
+  declared); SQL Server uses `@`; MySQL uses `?` and backticks (update the
+  expected string accordingly). PG-valid tokens (`TO_CHAR`, numeric `TRUNC`,
+  `NEXTVAL('seq')`, `DATE_TRUNC`, …) stay on the default `.Build()`.
+- **Assert the exact SQL** built with a `StringBuilder`; also assert
+  `sql.Parameters` whenever a literal becomes a bind value (literals render as
+  `:0`, `:1`, … and land in `Parameters`).
+- `FunctionTests.{A..W}.cs` mirror `Sql.{A..W}.cs`; put a function's tests in the
+  file for its leading letter (`public partial class FunctionTests`).
+- Run `dotnet test tests/SqlArtisan.Tests` and `dotnet format SqlArtisan.sln`
+  after changing tests; both gate CI.

--- a/.claude/skills/add-sql-function/SKILL.md
+++ b/.claude/skills/add-sql-function/SKILL.md
@@ -113,7 +113,8 @@ Rules:
 Add `[Fact]`(s) to `tests/SqlArtisan.Tests/FunctionTests/FunctionTests.<Letter>.cs`
 (create it as `public partial class FunctionTests` if missing). Build the expected
 SQL with a `StringBuilder` and assert the **exact** string — mirror the existing
-tests:
+tests. Follow the full test conventions in `.claude/rules/unit-tests.md`
+(naming grammar, dialect-specific `Build`, parameter assertions):
 
 ```csharp
 [Fact]
@@ -126,6 +127,27 @@ public void <Name>_<Scenario>_CorrectSql()
     StringBuilder expected = new();
     expected.Append("SELECT ");
     expected.Append("<SQL_TOKEN>(\"t\".code)");
+
+    Assert.Equal(expected.ToString(), sql.Text);
+}
+```
+
+If the function emits **dialect-specific** tokens (e.g. Oracle `SYSDATE`,
+SQL Server `DATEADD`), build with the matching dialect and name the test
+`<Name>_<Dbms>_<Scenario>` — the default `.Build()` is PostgreSql and would
+assert SQL that cannot run on the nominal dialect:
+
+```csharp
+[Fact]
+public void <Name>_Oracle_CorrectSql()
+{
+    SqlStatement sql =
+        Select(<Name>(_t.CreatedAt))
+        .Build(Dbms.Oracle);
+
+    StringBuilder expected = new();
+    expected.Append("SELECT ");
+    expected.Append("<SQL_TOKEN>(\"t\".created_at)");
 
     Assert.Equal(expected.ToString(), sql.Text);
 }

--- a/.claude/skills/add-sql-function/SKILL.md
+++ b/.claude/skills/add-sql-function/SKILL.md
@@ -132,30 +132,10 @@ public void <Name>_<Scenario>_CorrectSql()
 }
 ```
 
-If the function emits **dialect-specific** tokens (e.g. Oracle `SYSDATE`,
-SQL Server `DATEADD`), build with the matching dialect and name the test
-`<Name>_<Dbms>_<Scenario>` — the default `.Build()` is PostgreSql and would
-assert SQL that cannot run on the nominal dialect:
-
-```csharp
-[Fact]
-public void <Name>_Oracle_CorrectSql()
-{
-    SqlStatement sql =
-        Select(<Name>(_t.CreatedAt))
-        .Build(Dbms.Oracle);
-
-    StringBuilder expected = new();
-    expected.Append("SELECT ");
-    expected.Append("<SQL_TOKEN>(\"t\".created_at)");
-
-    Assert.Equal(expected.ToString(), sql.Text);
-}
-```
-
-Cover: the basic case, each overload (e.g. multi-arg, `DISTINCT`, optional arg
-present/absent), and assert `sql.Parameters` when a literal becomes a bind value
-(literals render as `:0`, `:1`, … and land in `Parameters`).
+Cover the basic case and each overload (e.g. multi-arg, `DISTINCT`, optional arg
+present/absent). For dialect-specific tokens (e.g. Oracle `SYSDATE`, SQL Server
+`DATEADD`), the rule's "build with the dialect the SQL targets" section applies —
+use `.Build(Dbms.X)` and the `<Name>_<Dbms>_<Scenario>` name.
 
 ## DBMS-specific syntax
 

--- a/.claude/skills/add-sql-function/SKILL.md
+++ b/.claude/skills/add-sql-function/SKILL.md
@@ -110,32 +110,11 @@ Rules:
 
 ## 4. Test
 
-Add `[Fact]`(s) to `tests/SqlArtisan.Tests/FunctionTests/FunctionTests.<Letter>.cs`
-(create it as `public partial class FunctionTests` if missing). Build the expected
-SQL with a `StringBuilder` and assert the **exact** string — mirror the existing
-tests. Follow the full test conventions in `.claude/rules/unit-tests.md`
-(naming grammar, dialect-specific `Build`, parameter assertions):
-
-```csharp
-[Fact]
-public void <Name>_<Scenario>_CorrectSql()
-{
-    SqlStatement sql =
-        Select(<Name>(_t.Code))
-        .Build();
-
-    StringBuilder expected = new();
-    expected.Append("SELECT ");
-    expected.Append("<SQL_TOKEN>(\"t\".code)");
-
-    Assert.Equal(expected.ToString(), sql.Text);
-}
-```
-
-Cover the basic case and each overload (e.g. multi-arg, `DISTINCT`, optional arg
-present/absent). For dialect-specific tokens (e.g. Oracle `SYSDATE`, SQL Server
-`DATEADD`), the rule's "build with the dialect the SQL targets" section applies —
-use `.Build(Dbms.X)` and the `<Name>_<Dbms>_<Scenario>` name.
+Add `[Fact]`(s) to `FunctionTests.<Letter>.cs` (a `public partial class
+FunctionTests`) covering the basic case and each overload (multi-arg, `DISTINCT`,
+optional arg present/absent). Mirror the existing tests and follow
+`.claude/rules/unit-tests.md` for the conventions — naming, dialect-specific
+`Build(Dbms.X)`, and exact-SQL `StringBuilder` + `Parameters` assertions.
 
 ## DBMS-specific syntax
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,8 +87,9 @@ reference implementations.
   stay adjacent and explicit interface implementations sort by their simple
   name. Within an interface definition, declare members alphabetically too. This
   is mechanical and keeps builders consistent as they grow.
-- Tests build expected SQL with a `StringBuilder` and assert equality — mirror
-  that pattern.
+- Unit test conventions (naming grammar, dialect-specific `Build`, exact-SQL
+  assertions) live in `.claude/rules/unit-tests.md` — auto-loaded when editing
+  `tests/**`.
 - Update `CHANGELOG.md` for user-visible changes; the README is the canonical
   user-facing documentation.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,21 +50,12 @@ violation.
 
 ## How to add a new SQL function (the most common task)
 
-Touch all four, keeping the alphabetical convention:
-
-1. **Node class** — `src/SqlArtisan/Internal/SqlPart/Expression/Function/<Category>/<Name>Function.cs`:
-   `public sealed class <Name>Function : SqlExpression`, `internal` constructor,
-   `internal override void Format(SqlBuildingBuffer buffer)` that emits via the
-   fluent buffer (`.Append`, `.OpenParenthesis()`, `.PrependComma()`, etc.).
-2. **Keyword** — add the SQL token to `Keywords.cs` (keep alphabetical).
-3. **Public factory** — add a `public static <Name>Function <Name>(object ...)`
-   method to `Sql.<Letter>.cs`, wrapping args with
-   `ExpressionResolver.Resolve(...)`.
-4. **Test** — add `[Fact]`s to `FunctionTests.<Letter>.cs` asserting the exact
-   `SqlStatement.Text` (and parameters where relevant).
-
-Follow `AbsFunction` (single arg) and `AddMonthsFunction` (multi arg) as
-reference implementations.
+Adding a function touches **four** places, all kept alphabetical: the node class
+(`Internal/SqlPart/Expression/Function/<Category>/<Name>Function.cs`), the keyword
+in `Keywords.cs`, the public factory in `Sql.<Letter>.cs`, and the test in
+`FunctionTests.<Letter>.cs`. The **`add-sql-function` skill** walks through all
+four with templates and reference implementations (`AbsFunction`,
+`AddMonthsFunction`, …) — follow it for the full procedure.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

Captures the unit-test conventions in a path-scoped rule and removes duplicated procedure from `CLAUDE.md`, so the always-loaded memory stays short while the rules load only when relevant.

## What changed

- **New `.claude/rules/unit-tests.md`** with `paths: ["tests/**/*.cs"]` frontmatter — auto-loads only when editing tests. Documents:
  - the `<Subject>[_<Dbms>][_<Condition>]_<Expectation>` naming grammar (with DBMS spelled exactly as the `Dbms` enum, placed right after the subject),
  - building dialect-specific assertions with the matching `.Build(Dbms.X)` (the #97 rule), including the per-dialect marker/quote table,
  - exact-SQL `StringBuilder` assertions and `Parameters` checks.
- **`CLAUDE.md`**: trimmed the inline test bullet to a one-line pointer to the rule; condensed the "How to add a new SQL function" section to a map that defers the full walkthrough to the `add-sql-function` skill (DRY — the templates/steps live only in the skill).
- **`add-sql-function` skill**: updated the Test step to reference the rule and show the dialect-specific `Build` pattern (the old template hard-coded the default `.Build()`).

Docs/tooling only — no source or test changes.

## Background

`.claude/rules/*.md` with a `paths` frontmatter is auto-discovered by Claude Code and loads only when files matching the globs are read (genuine context savings, unlike `@import` which loads at launch). This keeps cross-cutting constraints in `CLAUDE.md`, area-specific conventions in path-scoped rules, and procedures in skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCWW3NexyqS3SRzkKQjSdv)_