### PR TITLE
chore: Release 0.3.0-beta.1 (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [0.3.0-beta.1] - 2026-06-21
 ### Added
 - Added support for the `MERGE` statement (Oracle / SQL Server, and PostgreSQL 15+): `MergeInto(...).Using(...).On(...)` with per-dialect `WhenMatched` / `WhenNotMatched` / `WhenNotMatchedBySource` branches; SQL Server output is automatically terminated with the required semicolon. (#89)
 - Added support for per-dialect string aggregation: `StringAgg()` (PostgreSQL/SQL Server), `Listagg()` (Oracle), and `GroupConcat()` (MySQL/SQLite). (#88)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,16 @@
 <Project>
 
   <!--
+    Single source of truth for the shipped package version. Bump here only; the
+    three packable projects (SqlArtisan / SqlArtisan.Dapper / SqlArtisan.TableClassGen)
+    inherit it, so a release never drifts between packages. (#118)
+  -->
+  <PropertyGroup>
+    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionSuffix>beta.1</VersionSuffix>
+  </PropertyGroup>
+
+  <!--
     Enable the broader "Recommended" set of .NET code-quality analyzers for the
     shipped core library. Warnings only (never errors): analyzer rule sets differ
     across SDK builds, so promoting them to errors would make CI non-deterministic.

--- a/src/SqlArtisan.Dapper/SqlArtisan.Dapper.csproj
+++ b/src/SqlArtisan.Dapper/SqlArtisan.Dapper.csproj
@@ -5,8 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-    <VersionPrefix>0.2.0</VersionPrefix>
-    <VersionSuffix>beta.1</VersionSuffix>
     <Copyright>Copyright (c) h.tacayama 2025</Copyright>
 
     <Authors>h.tacayama</Authors>

--- a/src/SqlArtisan.TableClassGen/SqlArtisan.TableClassGen.csproj
+++ b/src/SqlArtisan.TableClassGen/SqlArtisan.TableClassGen.csproj
@@ -8,8 +8,6 @@
     <EnableDefaultCompileItems>true</EnableDefaultCompileItems>
     <IsPublishable>true</IsPublishable>
 
-    <VersionPrefix>0.2.0</VersionPrefix>
-    <VersionSuffix>beta.1</VersionSuffix>
     <Copyright>Copyright (c) h.tacayama 2025</Copyright>
 
     <Authors>h.tacayama</Authors>

--- a/src/SqlArtisan/SqlArtisan.csproj
+++ b/src/SqlArtisan/SqlArtisan.csproj
@@ -5,8 +5,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-    <VersionPrefix>0.2.0</VersionPrefix>
-    <VersionSuffix>beta.4</VersionSuffix>
     <Copyright>Copyright (c) h.tacayama 2025</Copyright>
 
     <Authors>h.tacayama</Authors>


### PR DESCRIPTION
## Overview

Release preparation to publish the `[Unreleased]` changes as the **`0.3.0-beta.1`** prerelease. Because the XML documentation work (#120) is not yet complete, this ships as a beta rather than a stable release. Closes #124, closes #118.

The `0.2 → 0.3` minor bump is driven by a breaking change in `[Unreleased]`: the `Datepart` enum was renamed to `DateTimePart` (#99). On 0.x, breaking changes are signaled with a minor bump.

## Changes

- **Centralize the version (#118)**: `Directory.Build.props` is now the single source of truth, setting `VersionPrefix=0.3.0` / `VersionSuffix=beta.1`. Removed the per-project entries that had drifted across the three `.csproj` files (`0.2.0-beta.4` / `beta.1` / `beta.1`).
- **CHANGELOG.md**: Finalized `[Unreleased]` as `[0.3.0-beta.1] - 2026-06-21` and added a fresh empty `[Unreleased]` section.

## Verification

- `dotnet build -c Release`: 0 warnings / 0 errors
- `dotnet test`: 404 passed / 0 failed
- `dotnet format --verify-no-changes`: clean
- `dotnet pack -c Release`: confirmed all three packages match at `0.3.0-beta.1`
  - `SqlArtisan.0.3.0-beta.1.nupkg`
  - `SqlArtisan.Dapper.0.3.0-beta.1.nupkg`
  - `SqlArtisan.TableClassGen.0.3.0-beta.1.nupkg`

## Out of scope for this PR (manual, after merge)

- `dotnet nuget push` to publish to nuget.org (to be automated in #119)
- Create and push the `v0.3.0-beta.1` tag
- (Optional) Create a GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)