### PR TITLE
style: Use target-typed new in benchmark entrants

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -194,3 +194,9 @@ indent_size = 2
 end_of_line = lf
 [*.{cmd,bat}]
 end_of_line = crlf
+
+# BenchmarkDotNet requires [Benchmark] methods (and their [GlobalSetup] /
+# [GlobalCleanup] hooks) to be instance methods, so CA1822 ("mark members as
+# static") cannot apply to the benchmark entrants.
+[tests/SqlArtisan.Benchmark/**.cs]
+dotnet_diagnostic.CA1822.severity = none

--- a/tests/SqlArtisan.Benchmark/Benchmark/EfCoreBenchmark.cs
+++ b/tests/SqlArtisan.Benchmark/Benchmark/EfCoreBenchmark.cs
@@ -15,8 +15,8 @@ public static class EfCoreBenchmark
 
     public static (string Sql, int ParameterCount) Run(BenchmarkDbContext db)
     {
-        DateTime fromDate = new DateTime(2024, 1, 1);
-        DateTime toDate = new DateTime(2025, 1, 1);
+        DateTime fromDate = new(2024, 1, 1);
+        DateTime toDate = new(2025, 1, 1);
 
         IQueryable<object> query = db.Orders
             .Where(o => o.OrderDate >= fromDate && o.OrderDate < toDate)

--- a/tests/SqlArtisan.Benchmark/Benchmark/EfCoreModel/User.cs
+++ b/tests/SqlArtisan.Benchmark/Benchmark/EfCoreModel/User.cs
@@ -14,5 +14,5 @@ public sealed class User
     [Column("created_at")]
     public DateTime CreatedAt { get; set; }
 
-    public List<Order> Orders { get; set; } = new();
+    public List<Order> Orders { get; set; } = [];
 }

--- a/tests/SqlArtisan.Benchmark/Benchmark/Linq2dbBenchmark.cs
+++ b/tests/SqlArtisan.Benchmark/Benchmark/Linq2dbBenchmark.cs
@@ -22,8 +22,8 @@ public static class Linq2dbBenchmark
 
     public static (string Sql, int ParameterCount) Run(DataConnection db)
     {
-        DateTime fromDate = new DateTime(2024, 1, 1);
-        DateTime toDate = new DateTime(2025, 1, 1);
+        DateTime fromDate = new(2024, 1, 1);
+        DateTime toDate = new(2025, 1, 1);
 
         var query =
             from u in db.GetTable<User>()


### PR DESCRIPTION
Minor follow-up housekeeping on `tests/SqlArtisan.Benchmark` (no `src/` changes).

## What & why
- **Target-typed `new`**: switch `new DateTime(...)` → `new(...)` and `new()` → `[]` in the EF Core / linq2db entrants, matching the repo's dominant idiom (438 `= new(` and 9 `[]` usages already; these files just had leftover explicit forms from when they were first added). Conforms to `dotnet_style_prefer_collection_expression = when_types_exactly_match`.
- **Silence CA1822 for the benchmark project** (`.editorconfig`): BenchmarkDotNet requires `[Benchmark]` / `[GlobalSetup]` / `[GlobalCleanup]` methods to be instance methods, so "mark members as static" is a false positive for the entrants that don't touch instance state. Path-scoped to `tests/SqlArtisan.Benchmark/**.cs`, following the repo's existing diagnostic-suppression pattern (cf. IDE0130 / CA1716). Also restores the file's missing final newline (`insert_final_newline = true`).

## Verification
- Behavior unchanged: `dotnet run -- validate` reports the same logical SQL with two bind parameters for every entrant.
- CA1822 fix verified empirically: 7 warnings surface when the rule is elevated and the glob broken, 0 with the correct glob.
- Gates: core lib 0 warnings, 404/404 unit tests pass, `dotnet format --verify-no-changes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)