### PR TITLE
style: Enforce target-typed new and collection expressions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -92,7 +92,8 @@ dotnet_style_readonly_field = true:suggestion
 # Expression-level preferences
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_collection_initializer = true:suggestion
-dotnet_style_prefer_collection_expression = when_types_exactly_match
+dotnet_style_prefer_collection_expression = when_types_exactly_match:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
 dotnet_style_explicit_tuple_names = true:suggestion
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion

--- a/src/SqlArtisan.TableClassGen/Domain/Model/CaseConverter.cs
+++ b/src/SqlArtisan.TableClassGen/Domain/Model/CaseConverter.cs
@@ -9,7 +9,7 @@ internal static class CaseConverter
             return snakeCase;
         }
 
-        string[] parts = snakeCase.Split(new[] { '_' }, StringSplitOptions.RemoveEmptyEntries);
+        string[] parts = snakeCase.Split(['_'], StringSplitOptions.RemoveEmptyEntries);
 
         if (parts.Length == 0)
         {


### PR DESCRIPTION
Promotes two style rules to `warning` so the verbose construction forms are caught by CI's existing `dotnet format --verify-no-changes` gate, rather than slipping through (as they did for the EF Core / linq2db benchmark entrants).

## .editorconfig
- `csharp_style_implicit_object_creation_when_type_is_apparent = true:warning` — `new TypeName(...)` → `new(...)` (IDE0090)
- `dotnet_style_prefer_collection_expression = when_types_exactly_match:warning` — `new[] { ... }` / `new()` → `[...]` (IDE0028 / IDE0300)

This is where the project already centralizes style (CLAUDE.md: "Style is enforced by `.editorconfig`. Match it."), so no separate prose rule is needed.

## Blast radius: minimal
- **Zero** target-typed-new (IDE0090) violations — the repo already uses `new(...)` consistently.
- **One** collection-initializer straggler: `CaseConverter.cs:12` `new[] { '_' }` → `['_']` (behavior-identical; same `Split(char[], StringSplitOptions)` overload).

## Verification
- `dotnet format --verify-no-changes` → exit 0 (clean).
- Enforcement confirmed empirically: injecting `new StringBuilder()` now raises `warning IDE0090`.
- Solution builds, 404/404 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)