### PR TITLE
feat: Support the ESCAPE clause for LIKE / NOT LIKE (#123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added support for the `ESCAPE` clause on `LIKE` / `NOT LIKE`: chain `.Escape(escapeChar)` onto a `Like(...)` / `NotLike(...)` condition (e.g. `Like("100%_off").Escape('!')`) to match wildcards (`%`, `_`) literally, supported identically across all dialects. (#123)
+
 ### Changed
 - Reworked the benchmark suite into a fair builder comparison (every entrant emits SQL plus bind parameters for the same query), added linq2db and a labeled EF Core reference, and refreshed the README Performance section. (#79)
 

--- a/README.md
+++ b/README.md
@@ -1171,6 +1171,21 @@ SqlStatement sql =
 // OR (REGEXP_LIKE(name, :2))
 ```
 
+To match a wildcard (`%` or `_`) literally, chain `.Escape(...)` onto a `Like` / `NotLike` condition to emit a standard `ESCAPE` clause (supported identically across all dialects):
+
+```csharp
+UsersTable u = new();
+SqlStatement sql =
+    Select(u.Name)
+    .From(u)
+    .Where(u.Name.Like("100%_off").Escape('!'))
+    .Build();
+
+// SELECT name
+// FROM users
+// WHERE name LIKE :0 ESCAPE :1
+```
+
 ##### BETWEEN Condition
 ```csharp
 UsersTable u = new();

--- a/src/SqlArtisan/Internal/SqlPart/Condition/PatternMatchingCondition/LikeCondition.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Condition/PatternMatchingCondition/LikeCondition.cs
@@ -1,4 +1,6 @@
-﻿namespace SqlArtisan.Internal;
+﻿using static SqlArtisan.Internal.ExpressionResolver;
+
+namespace SqlArtisan.Internal;
 
 public sealed class LikeCondition : SqlCondition
 {
@@ -10,6 +12,9 @@ public sealed class LikeCondition : SqlCondition
         _leftSide = leftSide;
         _rightSide = rightSide;
     }
+
+    public LikeEscapeCondition Escape(object escapeChar) =>
+        new(_leftSide, _rightSide, Resolve(escapeChar));
 
     internal override void Format(SqlBuildingBuffer buffer) => buffer
         .Append(_leftSide)

--- a/src/SqlArtisan/Internal/SqlPart/Condition/PatternMatchingCondition/LikeEscapeCondition.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Condition/PatternMatchingCondition/LikeEscapeCondition.cs
@@ -1,0 +1,25 @@
+﻿namespace SqlArtisan.Internal;
+
+public sealed class LikeEscapeCondition : SqlCondition
+{
+    private readonly SqlExpression _leftSide;
+    private readonly SqlExpression _rightSide;
+    private readonly SqlExpression _escapeChar;
+
+    internal LikeEscapeCondition(
+        SqlExpression leftSide,
+        SqlExpression rightSide,
+        SqlExpression escapeChar)
+    {
+        _leftSide = leftSide;
+        _rightSide = rightSide;
+        _escapeChar = escapeChar;
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append(_leftSide)
+        .Append($" {Keywords.Like} ")
+        .Append(_rightSide)
+        .Append($" {Keywords.Escape} ")
+        .Append(_escapeChar);
+}

--- a/src/SqlArtisan/Internal/SqlPart/Condition/PatternMatchingCondition/NotLikeCondition.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Condition/PatternMatchingCondition/NotLikeCondition.cs
@@ -1,4 +1,6 @@
-﻿namespace SqlArtisan.Internal;
+﻿using static SqlArtisan.Internal.ExpressionResolver;
+
+namespace SqlArtisan.Internal;
 
 public sealed class NotLikeCondition : SqlCondition
 {
@@ -10,6 +12,9 @@ public sealed class NotLikeCondition : SqlCondition
         _leftSide = leftSide;
         _rightSide = rightSide;
     }
+
+    public NotLikeEscapeCondition Escape(object escapeChar) =>
+        new(_leftSide, _rightSide, Resolve(escapeChar));
 
     internal override void Format(SqlBuildingBuffer buffer) => buffer
         .Append(_leftSide)

--- a/src/SqlArtisan/Internal/SqlPart/Condition/PatternMatchingCondition/NotLikeEscapeCondition.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Condition/PatternMatchingCondition/NotLikeEscapeCondition.cs
@@ -1,0 +1,25 @@
+﻿namespace SqlArtisan.Internal;
+
+public sealed class NotLikeEscapeCondition : SqlCondition
+{
+    private readonly SqlExpression _leftSide;
+    private readonly SqlExpression _rightSide;
+    private readonly SqlExpression _escapeChar;
+
+    internal NotLikeEscapeCondition(
+        SqlExpression leftSide,
+        SqlExpression rightSide,
+        SqlExpression escapeChar)
+    {
+        _leftSide = leftSide;
+        _rightSide = rightSide;
+        _escapeChar = escapeChar;
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append(_leftSide)
+        .Append($" {Keywords.Not} {Keywords.Like} ")
+        .Append(_rightSide)
+        .Append($" {Keywords.Escape} ")
+        .Append(_escapeChar);
+}

--- a/src/SqlArtisan/Internal/SqlPart/Keywords.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Keywords.cs
@@ -42,6 +42,7 @@ internal static class Keywords
     internal const string Duplicate = "DUPLICATE";
     internal const string Else = "ELSE";
     internal const string End = "END";
+    internal const string Escape = "ESCAPE";
     internal const string Except = "EXCEPT";
     internal const string Exists = "EXISTS";
     internal const string Extract = "EXTRACT";

--- a/tests/SqlArtisan.Tests/ConditionTests/LikeTests.cs
+++ b/tests/SqlArtisan.Tests/ConditionTests/LikeTests.cs
@@ -18,4 +18,22 @@ public class LikeTests
     [Fact]
     public void NotLike_String_CorrectSql() =>
         _assert.Equal(_t.Name.NotLike("%abc%"), "\"t\".name NOT LIKE :0", 1, "%abc%");
+
+    [Fact]
+    public void Like_WithEscape_CorrectSql() =>
+        _assert.Equal(
+            _t.Name.Like("100%_off").Escape('!'),
+            "\"t\".name LIKE :0 ESCAPE :1",
+            2,
+            "100%_off",
+            '!');
+
+    [Fact]
+    public void NotLike_WithEscape_CorrectSql() =>
+        _assert.Equal(
+            _t.Name.NotLike("100%_off").Escape('!'),
+            "\"t\".name NOT LIKE :0 ESCAPE :1",
+            2,
+            "100%_off",
+            '!');
 }


### PR DESCRIPTION
Closes #123.

## Summary

Adds a standard `ESCAPE` clause to `LIKE` / `NOT LIKE` so wildcards (`%`, `_`) in user input can be matched literally.

```csharp
.Where(u.Name.Like("100%_off").Escape('!'))      // name LIKE :0 ESCAPE :1
.Where(u.Name.NotLike("100%_off").Escape('!'))   // name NOT LIKE :0 ESCAPE :1
```

Supported identically across all 5 dialects (the only difference is the parameter marker, handled by the dialect layer).

## Design

- **`.Escape(...)` chain, not an overload.** `ESCAPE` is an independent clause appended to `LIKE`, not an overload of it (unlike `ROUND(x)` vs `ROUND(x, n)`, which are genuinely distinct SQL signatures). The chain mirrors SQL token order — `LIKE 'pat' ESCAPE '!'` → `.Like("pat").Escape('!')` — staying faithful to the project's "the SQL you write is the SQL that runs" philosophy.
- **Dedicated terminal return types.** `Escape()` returns `LikeEscapeCondition` / `NotLikeEscapeCondition`, which expose no further `Escape()`. A double `.Escape().Escape()` is therefore a compile error by construction, rather than something checked at runtime.
- `LikeCondition` / `NotLikeCondition` remain valid standalone conditions (ESCAPE is optional), so no node branches on `Dbms`.

## Changes

| File | Change |
|---|---|
| `Keywords.cs` | Add `Escape = "ESCAPE"` (alphabetical) |
| `LikeCondition.cs` / `NotLikeCondition.cs` | Add `Escape(object)` returning the terminal type |
| `LikeEscapeCondition.cs` / `NotLikeEscapeCondition.cs` | New terminal conditions emitting `… LIKE :0 ESCAPE :1` |
| `LikeTests.cs` | `Like_WithEscape_CorrectSql` / `NotLike_WithEscape_CorrectSql` |
| `CHANGELOG.md` / `README.md` | User-facing docs |

## Verification

- `dotnet build -c Release` (core): **0 warnings, 0 errors**
- `dotnet test`: **406 passed** (incl. 2 new)
- `dotnet format --verify-no-changes`: clean
- Harness across PostgreSQL / SQL Server / MySQL / Oracle / SQLite: correct emit with each dialect's parameter marker (`:` / `@` / `?`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013FJUMCWNqa69q2D7UrvygB)_