### PR TITLE
ci: Add GitHub Actions workflow to pack and publish to NuGet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Release
+
+# Publishes the three packages (SqlArtisan / SqlArtisan.Dapper /
+# SqlArtisan.TableClassGen) to nuget.org. Triggered by pushing a version tag
+# (e.g. v0.4.0-beta.1); the package version comes from Directory.Build.props,
+# not the tag, so keep the tag in sync with VersionPrefix/VersionSuffix.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  # Gate the publish on the same checks CI runs (format / build / test); a red
+  # tree must never reach nuget.org.
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore SqlArtisan.sln
+
+      - name: Verify formatting (.editorconfig)
+        run: dotnet format SqlArtisan.sln --verify-no-changes
+
+      - name: Build
+        run: dotnet build SqlArtisan.sln --no-restore -c Release
+
+      - name: Test
+        run: dotnet test tests/SqlArtisan.Tests --no-build -c Release --verbosity normal
+
+  publish:
+    needs: verify
+    runs-on: ubuntu-latest
+    # Holds the NUGET_API_KEY secret; attach required reviewers here to gate the
+    # push behind a manual approval.
+    environment: nuget
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      # Pack the three shipped projects individually — packing the solution would
+      # also try to pack the tests and benchmark.
+      - name: Pack
+        run: |
+          dotnet pack src/SqlArtisan/SqlArtisan.csproj -c Release -o artifacts
+          dotnet pack src/SqlArtisan.Dapper/SqlArtisan.Dapper.csproj -c Release -o artifacts
+          dotnet pack src/SqlArtisan.TableClassGen/SqlArtisan.TableClassGen.csproj -c Release -o artifacts
+
+      # --skip-duplicate makes re-running the workflow on the same version a no-op.
+      - name: Push to NuGet
+        run: >
+          dotnet nuget push "artifacts/*.nupkg"
+          --source https://api.nuget.org/v3/index.json
+          --api-key "${{ secrets.NUGET_API_KEY }}"
+          --skip-duplicate


### PR DESCRIPTION
## What

Adds `.github/workflows/release.yml` — an automated NuGet publish pipeline. Closes #119.

Triggered by pushing a `v*` tag (e.g. `v0.4.0-beta.1`), it:

1. **`verify`** — runs the same gate as CI (restore → `format --verify-no-changes` → build → test), so a red tree never reaches nuget.org.
2. **`publish`** (`needs: verify`) — packs the three shipped projects individually (`SqlArtisan` / `SqlArtisan.Dapper` / `SqlArtisan.TableClassGen`) and pushes them with `dotnet nuget push --skip-duplicate`.

## Notes

- The push step runs in the protected **`nuget`** GitHub Environment, which holds the **`NUGET_API_KEY`** secret (already registered).
- Packed projects are listed explicitly rather than packing the solution, which would also try to pack the tests and benchmark.
- `--skip-duplicate` makes re-running the workflow on an already-published version a no-op.
- The package version comes from `Directory.Build.props`, **not** the tag — the tag is only the trigger, so keep it in sync with `VersionPrefix`/`VersionSuffix`.

## Out of scope

- The minor version bump (`0.3.0-beta.1` → `0.4.0-beta.1`) and CHANGELOG finalization land in a follow-up.
- Symbol packages (`.snupkg`) / SourceLink were intentionally dropped for now — low value for a query builder whose output is an inspectable SQL string, and easy to add later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)