### PR TITLE
fix: Review follow-ups — null-array guards, doc fix, and two refactors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - CTE and derived-table names are now alias-quoted at their definition (`WITH "cte" AS ...`, `... ) "x"`) and at every reference (`FROM "cte"`, `... JOIN ... "x"`), consistent with the already-quoted column references through their handles (`"cte".col` / `"x".col`). Previously the name was emitted bare, so on Oracle it case-folded (`cte` → `CTE`) while the quoted column reference stayed lowercase, yielding an unresolvable qualifier (ORA-00904) — most visibly for `CROSS APPLY` / `OUTER APPLY`, whose primary target is Oracle. Emitted SQL for CTEs changes accordingly (the name is now quoted). (#122)
 - `GroupBy(...)` with a `null` grouping item now throws a clear `ArgumentNullException` instead of a `NullReferenceException`. (#121)
+- `Rollup(...)`, `Cube(...)`, and `GroupingSets(...)` with a `null` trailing `params` array (e.g. `Rollup(a, null)`) now throw a clear `ArgumentNullException` instead of a `NullReferenceException`. (#121)
 
 ## [0.3.0-beta.1] - 2026-06-21
 ### Added

--- a/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
@@ -270,15 +270,34 @@ internal sealed class SqlBuildingBuffer : IDisposable
         return this;
     }
 
-    // Emits a single-character string literal (e.g. the LIKE ... ESCAPE char),
-    // single-quote delimited. A position whose grammar wants a literal rather than
-    // a bind parameter (ADR 0004) — MySQL rejects `ESCAPE ?` as a non-constant. The
-    // single quote is doubled on every dialect; the backslash is doubled only where
-    // the dialect treats it as a string-literal escape (MySQL).
+    // Emits a single-quote-delimited string literal for a position whose grammar
+    // wants a literal rather than a bind parameter (ADR 0004) — e.g. the LIKE ...
+    // ESCAPE char (MySQL rejects `ESCAPE ?`) or a GROUP_CONCAT ... SEPARATOR.
     internal SqlBuildingBuffer AppendStringLiteral(char value)
     {
         Append('\'');
+        AppendEscaped(value);
+        Append('\'');
+        return this;
+    }
 
+    internal SqlBuildingBuffer AppendStringLiteral(string value)
+    {
+        Append('\'');
+
+        foreach (char c in value)
+        {
+            AppendEscaped(c);
+        }
+
+        Append('\'');
+        return this;
+    }
+
+    // Doubles the single quote on every dialect; doubles the backslash only where
+    // the dialect treats it as a string-literal escape (MySQL).
+    private void AppendEscaped(char value)
+    {
         if (value == '\'')
         {
             Append("''");
@@ -291,9 +310,6 @@ internal sealed class SqlBuildingBuffer : IDisposable
         {
             Append(value);
         }
-
-        Append('\'');
-        return this;
     }
 
     internal SqlBuildingBuffer EncloseInParentheses(SqlPart part)

--- a/src/SqlArtisan/Internal/SqlPart/Clause/GroupBy/GroupByItemResolver.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/GroupBy/GroupByItemResolver.cs
@@ -43,19 +43,31 @@ internal static class GroupByItemResolver
         }
     }
 
-    // Resolves the inner elements of ROLLUP(...) / CUBE(...): each element is
-    // either an ordinary grouping expression or a Sql.Group(...) composite column.
-    internal static SqlPart[] ResolveElements(object[] elements)
+    // Resolves the elements of ROLLUP(...) / CUBE(...): a required leading element
+    // plus zero or more trailing ones, each an ordinary grouping expression or a
+    // Sql.Group(...) composite column. The leading element is taken separately so
+    // the factory can pass its `params` array straight through — a null array (the
+    // C# binding for e.g. Rollup(a, null)) then throws a clear ArgumentNullException
+    // instead of failing with an NRE when spread into a collection expression.
+    internal static SqlPart[] ResolveElements(object element, params object[] elements)
     {
-        var resolved = new SqlPart[elements.Length];
+        if (elements is null)
+        {
+            throw new ArgumentNullException(
+                nameof(elements), ExpressionResolver.NullValueMessage);
+        }
+
+        SqlPart[] resolved = new SqlPart[elements.Length + 1];
+        resolved[0] = ResolveElement(element);
 
         for (int i = 0; i < elements.Length; i++)
         {
-            resolved[i] = elements[i] is GroupingSet set
-                ? set
-                : ExpressionResolver.Resolve(elements[i]);
+            resolved[i + 1] = ResolveElement(elements[i]);
         }
 
         return resolved;
     }
+
+    private static SqlPart ResolveElement(object element) =>
+        element is GroupingSet set ? set : ExpressionResolver.Resolve(element);
 }

--- a/src/SqlArtisan/Internal/SqlPart/Clause/GroupBy/GroupingSetsGrouping.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/GroupBy/GroupingSetsGrouping.cs
@@ -11,15 +11,22 @@ public sealed class GroupingSetsGrouping : GroupingElement
 {
     private readonly GroupingSet[] _sets;
 
-    internal GroupingSetsGrouping(GroupingSet[] sets)
+    // The leading set is taken separately so the factory can pass its `params`
+    // array straight through: a null array (the C# binding for e.g.
+    // GroupingSets(set, null)) throws a clear ArgumentNullException instead of
+    // failing with an NRE when spread into a collection expression. The required
+    // leading set also guarantees at least one grouping set.
+    internal GroupingSetsGrouping(GroupingSet set, params GroupingSet[] sets)
     {
-        if (sets.Length == 0)
+        if (sets is null)
         {
-            throw new ArgumentException(
-                "GROUPING SETS requires at least one grouping set.");
+            throw new ArgumentNullException(
+                nameof(sets), ExpressionResolver.NullValueMessage);
         }
 
-        _sets = sets;
+        _sets = new GroupingSet[sets.Length + 1];
+        _sets[0] = set;
+        Array.Copy(sets, 0, _sets, 1, sets.Length);
     }
 
     internal override void Format(SqlBuildingBuffer buffer) =>

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Separator/SeparatorClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Separator/SeparatorClause.cs
@@ -20,14 +20,5 @@ public sealed class SeparatorClause : SqlPart
     internal override void Format(SqlBuildingBuffer buffer) => buffer
         .Append(Keywords.Separator)
         .AppendSpace()
-        .Append('\'')
-        .Append(Escape(_separator))
-        .Append('\'');
-
-    // MySQL string literals treat both the single quote and (in the default SQL
-    // mode) the backslash as special, so double each to emit a safe literal.
-    private static string Escape(string value) =>
-        value
-            .Replace("\\", "\\\\", StringComparison.Ordinal)
-            .Replace("'", "''", StringComparison.Ordinal);
+        .AppendStringLiteral(_separator);
 }

--- a/src/SqlArtisan/Internal/SqlPart/TableReference/TableReference.cs
+++ b/src/SqlArtisan/Internal/SqlPart/TableReference/TableReference.cs
@@ -14,6 +14,23 @@ public abstract class TableReference : SqlPart
         _name = name;
     }
 
-    internal override void Format(SqlBuildingBuffer buffer) =>
-        buffer.Append(_name);
+    // Whether the name is alias-quoted when rendered. A reference whose name also
+    // qualifies column references — a CTE or derived table — must quote it so the
+    // two agree; otherwise a bare name case-folds on Oracle (`x` -> `X`) while the
+    // quoted column reference does not, breaking resolution (ORA-00904). Real table
+    // names stay bare (DbTableBase quotes only its separate alias). Overriding this
+    // flag is the single place a subclass opts into quoting.
+    private protected virtual bool QuoteName => false;
+
+    internal override void Format(SqlBuildingBuffer buffer)
+    {
+        if (QuoteName)
+        {
+            buffer.EncloseInAliasQuotes(_name);
+        }
+        else
+        {
+            buffer.Append(_name);
+        }
+    }
 }

--- a/src/SqlArtisan/Sql/Sql.C.cs
+++ b/src/SqlArtisan/Sql/Sql.C.cs
@@ -519,7 +519,7 @@ public static partial class Sql
     /// <remarks>MySQL and SQLite do not support it; emitted as written for the
     /// database to reject.</remarks>
     public static CubeGrouping Cube(object element, params object[] elements) =>
-        new(GroupByItemResolver.ResolveElements([element, .. elements]));
+        new(GroupByItemResolver.ResolveElements(element, elements));
 
     /// <summary>
     /// The <c>CUME_DIST()</c> analytic function (cumulative distribution of the current

--- a/src/SqlArtisan/Sql/Sql.G.cs
+++ b/src/SqlArtisan/Sql/Sql.G.cs
@@ -158,5 +158,5 @@ public static partial class Sql
     /// not, where it is emitted as written for the database to reject.</remarks>
     public static GroupingSetsGrouping GroupingSets(
         GroupingSet set,
-        params GroupingSet[] sets) => new([set, .. sets]);
+        params GroupingSet[] sets) => new(set, sets);
 }

--- a/src/SqlArtisan/Sql/Sql.R.cs
+++ b/src/SqlArtisan/Sql/Sql.R.cs
@@ -192,7 +192,7 @@ public static partial class Sql
     /// statement for the database to reject.
     /// </remarks>
     public static RollupGrouping Rollup(object element, params object[] elements) =>
-        new(GroupByItemResolver.ResolveElements([element, .. elements]));
+        new(GroupByItemResolver.ResolveElements(element, elements));
 
     /// <summary>
     /// The <c>ROUND(expr)</c> function: rounds <paramref name="expr"/> to the

--- a/src/SqlArtisan/SqlPart/TableReference/CteBase.cs
+++ b/src/SqlArtisan/SqlPart/TableReference/CteBase.cs
@@ -21,8 +21,6 @@ public abstract class CteBase(string name) : TableReference(name)
 
     // The CTE name is quoted wherever it is referenced (e.g. `FROM "cte"`) to
     // match the quoted `WITH "cte" AS ...` definition and the quoted column
-    // references (`"cte".col`); a bare name would fold case on Oracle and break
-    // those references (ORA-00904).
-    internal override void Format(SqlBuildingBuffer buffer) =>
-        buffer.EncloseInAliasQuotes(_name);
+    // references (`"cte".col`). See TableReference.QuoteName.
+    private protected override bool QuoteName => true;
 }

--- a/src/SqlArtisan/SqlPart/TableReference/DerivedTable.cs
+++ b/src/SqlArtisan/SqlPart/TableReference/DerivedTable.cs
@@ -5,8 +5,8 @@ namespace SqlArtisan;
 /// <summary>
 /// Names a derived table inline — a <c>CROSS APPLY</c> / <c>LATERAL</c> source
 /// (or any <c>FROM</c> / <c>JOIN</c> relation) — without declaring a dedicated
-/// subclass, and renders as that bare name. Its columns are referenced by
-/// name through <see cref="Column(string)"/>. For columns referenced repeatedly,
+/// subclass, and renders as that alias-quoted name (e.g. <c>"x"</c>). Its columns
+/// are referenced by name through <see cref="Column(string)"/>. For columns referenced repeatedly,
 /// subclass <see cref="DerivedTableBase"/> and expose them as typed members
 /// instead.
 /// </summary>

--- a/src/SqlArtisan/SqlPart/TableReference/DerivedTableBase.cs
+++ b/src/SqlArtisan/SqlPart/TableReference/DerivedTableBase.cs
@@ -11,9 +11,6 @@ namespace SqlArtisan;
 public abstract class DerivedTableBase(string name) : TableReference(name)
 {
     // The alias is quoted at its definition site (`... ) "x"`) to match how a
-    // reference to it renders (`"x".col`). A bare alias folds case on Oracle
-    // (`x` -> `X`) while the quoted reference stays `x`, so an outer column
-    // reference would fail to resolve (ORA-00904).
-    internal override void Format(SqlBuildingBuffer buffer) =>
-        buffer.EncloseInAliasQuotes(_name);
+    // reference to it renders (`"x".col`). See TableReference.QuoteName.
+    private protected override bool QuoteName => true;
 }

--- a/tests/SqlArtisan.Tests/GroupByTests.cs
+++ b/tests/SqlArtisan.Tests/GroupByTests.cs
@@ -433,4 +433,25 @@ public class GroupByTests
         Assert.Throws<ArgumentNullException>(() =>
             Select(_t.Code).From(_t).GroupBy(null!));
     }
+
+    [Fact]
+    public void Rollup_WithNullElements_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => Rollup(_t.Code, null!));
+    }
+
+    [Fact]
+    public void Cube_WithNullElements_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => Cube(_t.Code, null!));
+    }
+
+    [Fact]
+    public void GroupingSets_WithNullSets_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => GroupingSets(Group(_t.Code), null!));
+    }
 }


### PR DESCRIPTION
Addresses the four findings from the `/code-review max` pass over PR #139. Four commits, one per finding (please **preserve the commits** — rebase or merge, not squash).

## 1. Null `params` array → `ArgumentNullException`, not NRE (`cc1f272`) — correctness

`Rollup(a, null)` / `Cube(a, null)` / `GroupingSets(set, null)` bound the trailing `null` as a **null params array**, which then threw `NullReferenceException` when spread into the `[element, .. elements]` collection expression — before any resolver ran. This is the same null-misuse class the `GroupBy` guard already handled.

Fix: take the leading element separately and pass the params array straight through to a guarded `ResolveElements` / `GroupingSetsGrouping` constructor, which rejects a null array with the project-standard `ArgumentNullException`. **3 regression tests added.**

## 2. DerivedTable doc drift (`764836b`) — docs

The XML `<summary>` still said the inline `DerivedTable` "renders as that bare name", but PR #139 made it render alias-quoted (`) "x"`). Corrected (the README prose was already fixed in #139; this NuGet-facing comment was missed).

## 3. Share the string-literal escaper (`7a179cf`) — refactor

`SeparatorClause` re-implemented the same single-quote / backslash doubling now in `SqlBuildingBuffer.AppendStringLiteral`. Added a `string` overload and had `SeparatorClause` delegate, so the escaping rule has one owner. Behavior unchanged for `SEPARATOR` (MySQL-only, where the dialect flag doubles the backslash exactly as the old hardcoded path did).

## 4. Centralize name quoting behind `QuoteName` (`f3fe17d`) — refactor/altitude

`CteBase` and `DerivedTableBase` each overrode `Format` with an identical `EncloseInAliasQuotes` call. Moved the bare-vs-quoted decision into `TableReference.Format`, gated by a single `QuoteName` virtual the two subclasses now just flip to `true` — one enforcement point, so a future table-reference type makes a deliberate choice instead of silently inheriting bare rendering and regressing the Oracle case-folding bug (ORA-00904).

## Verification

- `dotnet build` (core, `AnalysisMode=Recommended`): **0 warnings**
- `dotnet test`: **446/446** (+3 null-guard regression tests)
- `dotnet format --verify-no-changes`: clean
- Empirically confirmed: the three null cases now throw `ArgumentNullException` (not NRE), happy paths unchanged, and `ESCAPE` / `SEPARATOR` literal escaping stays dialect-correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)