### PR TITLE
fix: Whole-codebase audit follow-ups (consistency, robustness, docs)

### DIFF
--- a/src/SqlArtisan.TableClassGen/Domain/Model/CaseConverter.cs
+++ b/src/SqlArtisan.TableClassGen/Domain/Model/CaseConverter.cs
@@ -1,7 +1,14 @@
+using System.Text;
+
 namespace SqlArtisan.TableClassGen;
 
 internal static class CaseConverter
 {
+    // Converts a database name to a PascalCase C# identifier. Splits on any
+    // character that cannot appear in an identifier — underscores plus DB-allowed
+    // punctuation such as Oracle's '$' and '#' — so those never leak into the
+    // result, prefixes an underscore when the name would otherwise start with a
+    // digit, and falls back to "_" for a name that is entirely separators.
     public static string SnakeToPascalCase(string snakeCase)
     {
         if (string.IsNullOrEmpty(snakeCase))
@@ -9,15 +16,34 @@ internal static class CaseConverter
             return snakeCase;
         }
 
-        string[] parts = snakeCase.Split('_', StringSplitOptions.RemoveEmptyEntries);
+        StringBuilder result = new(snakeCase.Length + 1);
+        bool startOfWord = true;
 
-        if (parts.Length == 0)
+        foreach (char c in snakeCase)
         {
-            return string.Empty;
+            if (char.IsLetterOrDigit(c))
+            {
+                result.Append(startOfWord
+                    ? char.ToUpperInvariant(c)
+                    : char.ToLowerInvariant(c));
+                startOfWord = false;
+            }
+            else
+            {
+                startOfWord = true;
+            }
         }
 
-        return string.Concat(
-            parts.Select(
-                part => $"{char.ToUpperInvariant(part[0])}{part.Substring(1).ToLowerInvariant()}"));
+        if (result.Length == 0)
+        {
+            return "_";
+        }
+
+        if (char.IsDigit(result[0]))
+        {
+            result.Insert(0, '_');
+        }
+
+        return result.ToString();
     }
 }

--- a/src/SqlArtisan/Internal/SqlPart/Clause/GroupBy/CubeGrouping.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/GroupBy/CubeGrouping.cs
@@ -10,13 +10,10 @@ public sealed class CubeGrouping : GroupingElement
 {
     private readonly SqlPart[] _elements;
 
+    // A non-empty element list is guaranteed by Sql.Cube, whose required leading
+    // element the resolver always carries through; the constructor trusts that.
     internal CubeGrouping(SqlPart[] elements)
     {
-        if (elements.Length == 0)
-        {
-            throw new ArgumentException("CUBE requires at least one element.");
-        }
-
         _elements = elements;
     }
 

--- a/src/SqlArtisan/Internal/SqlPart/Clause/GroupBy/RollupGrouping.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/GroupBy/RollupGrouping.cs
@@ -12,13 +12,10 @@ public sealed class RollupGrouping : GroupingElement
 {
     private readonly SqlPart[] _elements;
 
+    // A non-empty element list is guaranteed by Sql.Rollup, whose required leading
+    // element the resolver always carries through; the constructor trusts that.
     internal RollupGrouping(SqlPart[] elements)
     {
-        if (elements.Length == 0)
-        {
-            throw new ArgumentException("ROLLUP requires at least one element.");
-        }
-
         _elements = elements;
     }
 

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Separator/SeparatorClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Separator/SeparatorClause.cs
@@ -13,8 +13,9 @@ public sealed class SeparatorClause : SqlPart
 
     internal SeparatorClause(string separator)
     {
-        _separator = separator
-            ?? throw new ArgumentNullException(nameof(separator));
+        ArgumentNullException.ThrowIfNull(separator);
+
+        _separator = separator;
     }
 
     internal override void Format(SqlBuildingBuffer buffer) => buffer

--- a/src/SqlArtisan/Sql/Sql.A.cs
+++ b/src/SqlArtisan/Sql/Sql.A.cs
@@ -20,27 +20,6 @@ public static partial class Sql
     public static AbsFunction Abs(object expr) => new(Resolve(expr));
 
     /// <summary>
-    /// Conditionally includes a <see cref="SqlCondition"/>: returns
-    /// <paramref name="condition"/> when <paramref name="when"/> is
-    /// <see langword="true"/>, otherwise an empty condition that emits nothing.
-    /// </summary>
-    /// <remarks>
-    /// Use this to drop a predicate out of a <c>WHERE</c> clause based on a runtime
-    /// flag without breaking the fluent chain.
-    /// </remarks>
-    /// <param name="when">When <see langword="true"/>, the condition is included; when
-    /// <see langword="false"/>, it is omitted.</param>
-    /// <param name="condition">The condition to include when <paramref name="when"/> is
-    /// <see langword="true"/>.</param>
-    /// <returns><paramref name="condition"/> when <paramref name="when"/> is
-    /// <see langword="true"/>; otherwise an empty <see cref="SqlCondition"/> that emits
-    /// nothing.</returns>
-    public static SqlCondition ConditionIf(
-        bool when,
-        SqlCondition condition) =>
-        when ? condition : new EmptyCondition();
-
-    /// <summary>
     /// The <c>ADD_MONTHS(<paramref name="dateTime"/>, <paramref name="months"/>)</c>
     /// function (the date/time shifted forward by the given number of months).
     /// </summary>

--- a/src/SqlArtisan/Sql/Sql.C.cs
+++ b/src/SqlArtisan/Sql/Sql.C.cs
@@ -494,6 +494,27 @@ public static partial class Sql
             Resolve(others));
 
     /// <summary>
+    /// Conditionally includes a <see cref="SqlCondition"/>: returns
+    /// <paramref name="condition"/> when <paramref name="when"/> is
+    /// <see langword="true"/>, otherwise an empty condition that emits nothing.
+    /// </summary>
+    /// <remarks>
+    /// Use this to drop a predicate out of a <c>WHERE</c> clause based on a runtime
+    /// flag without breaking the fluent chain.
+    /// </remarks>
+    /// <param name="when">When <see langword="true"/>, the condition is included; when
+    /// <see langword="false"/>, it is omitted.</param>
+    /// <param name="condition">The condition to include when <paramref name="when"/> is
+    /// <see langword="true"/>.</param>
+    /// <returns><paramref name="condition"/> when <paramref name="when"/> is
+    /// <see langword="true"/>; otherwise an empty <see cref="SqlCondition"/> that emits
+    /// nothing.</returns>
+    public static SqlCondition ConditionIf(
+        bool when,
+        SqlCondition condition) =>
+        when ? condition : new EmptyCondition();
+
+    /// <summary>
     /// The <c>COUNT(<paramref name="expr"/>)</c> aggregate function (the number of
     /// non-<c>NULL</c> values in the group).
     /// </summary>

--- a/src/SqlArtisan/Sql/Sql.D.cs
+++ b/src/SqlArtisan/Sql/Sql.D.cs
@@ -8,7 +8,7 @@ public static partial class Sql
 {
     /// <summary>
     /// The <c>DATEADD(<paramref name="datepart"/>, <paramref name="number"/>, <paramref name="dateTime"/>)</c>
-    /// function (SQL Server): <paramref name="dateTime"/> shifted by
+    /// function: <paramref name="dateTime"/> shifted by
     /// <paramref name="number"/> units of <paramref name="datepart"/>. Pass a
     /// negative <paramref name="number"/> to subtract.
     /// </summary>
@@ -33,7 +33,7 @@ public static partial class Sql
 
     /// <summary>
     /// The <c>DATEDIFF(<paramref name="datepart"/>, <paramref name="startDate"/>, <paramref name="endDate"/>)</c>
-    /// function (SQL Server): the number of <paramref name="datepart"/> boundaries
+    /// function: the number of <paramref name="datepart"/> boundaries
     /// crossed between <paramref name="startDate"/> and <paramref name="endDate"/>.
     /// </summary>
     /// <param name="datepart">The unit of the boundaries to count.</param>
@@ -70,7 +70,7 @@ public static partial class Sql
 
     /// <summary>
     /// The <c>DATE_TRUNC('<paramref name="datepart"/>', <paramref name="source"/>)</c>
-    /// function (PostgreSQL): <paramref name="source"/> truncated down to
+    /// function: <paramref name="source"/> truncated down to
     /// <paramref name="datepart"/> precision.
     /// </summary>
     /// <param name="datepart">The precision to truncate to.</param>

--- a/src/SqlArtisan/Sql/Sql.G.cs
+++ b/src/SqlArtisan/Sql/Sql.G.cs
@@ -52,7 +52,7 @@ public static partial class Sql
         new(Resolve(expr), positionalSeparator: Resolve(separator));
 
     /// <summary>
-    /// The <c>GROUP_CONCAT(expr ORDER BY ...)</c> string aggregate (MySQL) with
+    /// The <c>GROUP_CONCAT(expr ORDER BY ...)</c> string aggregate with
     /// inline ordering and the default comma separator.
     /// </summary>
     /// <param name="expr">The value aggregated into the concatenated string.</param>
@@ -66,8 +66,8 @@ public static partial class Sql
         new(Resolve(expr), orderByClause: orderByClause);
 
     /// <summary>
-    /// The <c>GROUP_CONCAT(expr SEPARATOR separator)</c> string aggregate
-    /// (MySQL), where <paramref name="separatorClause"/> is built with
+    /// The <c>GROUP_CONCAT(expr SEPARATOR separator)</c> string aggregate,
+    /// where <paramref name="separatorClause"/> is built with
     /// <c>Sql.Separator(...)</c>.
     /// </summary>
     /// <param name="expr">The value aggregated into the concatenated string.</param>
@@ -82,7 +82,7 @@ public static partial class Sql
 
     /// <summary>
     /// The <c>GROUP_CONCAT(expr ORDER BY ... SEPARATOR separator)</c> string
-    /// aggregate (MySQL) with inline ordering and an explicit
+    /// aggregate with inline ordering and an explicit
     /// <c>Sql.Separator(...)</c>.
     /// </summary>
     /// <param name="expr">The value aggregated into the concatenated string.</param>

--- a/src/SqlArtisan/Sql/Sql.I.cs
+++ b/src/SqlArtisan/Sql/Sql.I.cs
@@ -31,13 +31,14 @@ public static partial class Sql
 
     /// <summary>
     /// The <c>INSTR(<paramref name="source"/>, <paramref name="substring"/>)</c>
-    /// function (Oracle): the 1-based position of the first occurrence of
+    /// function: the 1-based position of the first occurrence of
     /// <paramref name="substring"/> within <paramref name="source"/>, or 0 when
     /// not found.
     /// </summary>
     /// <param name="source">The string to search in.</param>
     /// <param name="substring">The substring to search for.</param>
     /// <returns>The INSTR construct.</returns>
+    /// <remarks>Oracle syntax.</remarks>
     public static InstrFunction Instr(
         object source,
         object substring) => new(

--- a/src/SqlArtisan/Sql/Sql.L.cs
+++ b/src/SqlArtisan/Sql/Sql.L.cs
@@ -10,6 +10,8 @@ public static partial class Sql
     /// <paramref name="expr"/> from the row one position before the current row
     /// in the window.
     /// </summary>
+    /// <param name="expr">The value evaluated for each row of the window.</param>
+    /// <returns>An <see cref="AnalyticLagFunction"/> emitting <c>LAG(expr)</c>.</returns>
     public static AnalyticLagFunction Lag(object expr) =>
         new(Resolve(expr));
 
@@ -18,6 +20,9 @@ public static partial class Sql
     /// <paramref name="expr"/> from the row <paramref name="offset"/> positions
     /// before the current row.
     /// </summary>
+    /// <param name="expr">The value evaluated for each row of the window.</param>
+    /// <param name="offset">The number of rows to look back from the current row.</param>
+    /// <returns>An <see cref="AnalyticLagFunction"/> emitting <c>LAG(expr, offset)</c>.</returns>
     /// <remarks>The offset is emitted as an integer literal.</remarks>
     public static AnalyticLagFunction Lag(object expr, int offset) =>
         new(Resolve(expr), offset);
@@ -28,6 +33,10 @@ public static partial class Sql
     /// before the current row, or <paramref name="defaultValue"/> when that row
     /// falls outside the partition.
     /// </summary>
+    /// <param name="expr">The value evaluated for each row of the window.</param>
+    /// <param name="offset">The number of rows to look back from the current row.</param>
+    /// <param name="defaultValue">The value returned when the offset row falls outside the partition.</param>
+    /// <returns>An <see cref="AnalyticLagFunction"/> emitting <c>LAG(expr, offset, default)</c>.</returns>
     /// <remarks>The offset is emitted as an integer literal; the default value is
     /// parameterized.</remarks>
     public static AnalyticLagFunction Lag(
@@ -39,7 +48,7 @@ public static partial class Sql
             Resolve(defaultValue));
 
     /// <summary>
-    /// The <c>LAST_DAY(<paramref name="date"/>)</c> function (Oracle): the date
+    /// The <c>LAST_DAY(<paramref name="date"/>)</c> function: the date
     /// of the last day of the month containing <paramref name="date"/>.
     /// </summary>
     /// <param name="date">The date whose month's last day is returned.</param>
@@ -52,6 +61,8 @@ public static partial class Sql
     /// The <c>LAST_VALUE(expr)</c> analytic function: the value of
     /// <paramref name="expr"/> from the last row of the window frame.
     /// </summary>
+    /// <param name="expr">The value evaluated for each row of the window.</param>
+    /// <returns>An <see cref="AnalyticLastValueFunction"/> emitting <c>LAST_VALUE(expr)</c>.</returns>
     /// <remarks>The default frame ends at the current row, so an explicit frame
     /// (e.g. <c>ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING</c>) is
     /// usually intended.</remarks>
@@ -63,6 +74,8 @@ public static partial class Sql
     /// <paramref name="expr"/> from the row one position after the current row
     /// in the window.
     /// </summary>
+    /// <param name="expr">The value evaluated for each row of the window.</param>
+    /// <returns>An <see cref="AnalyticLeadFunction"/> emitting <c>LEAD(expr)</c>.</returns>
     public static AnalyticLeadFunction Lead(object expr) =>
         new(Resolve(expr));
 
@@ -71,6 +84,9 @@ public static partial class Sql
     /// <paramref name="expr"/> from the row <paramref name="offset"/> positions
     /// after the current row.
     /// </summary>
+    /// <param name="expr">The value evaluated for each row of the window.</param>
+    /// <param name="offset">The number of rows to look ahead from the current row.</param>
+    /// <returns>An <see cref="AnalyticLeadFunction"/> emitting <c>LEAD(expr, offset)</c>.</returns>
     /// <remarks>The offset is emitted as an integer literal.</remarks>
     public static AnalyticLeadFunction Lead(object expr, int offset) =>
         new(Resolve(expr), offset);
@@ -81,6 +97,10 @@ public static partial class Sql
     /// after the current row, or <paramref name="defaultValue"/> when that row
     /// falls outside the partition.
     /// </summary>
+    /// <param name="expr">The value evaluated for each row of the window.</param>
+    /// <param name="offset">The number of rows to look ahead from the current row.</param>
+    /// <param name="defaultValue">The value returned when the offset row falls outside the partition.</param>
+    /// <returns>An <see cref="AnalyticLeadFunction"/> emitting <c>LEAD(expr, offset, default)</c>.</returns>
     /// <remarks>The offset is emitted as an integer literal; the default value is
     /// parameterized.</remarks>
     public static AnalyticLeadFunction Lead(
@@ -110,7 +130,7 @@ public static partial class Sql
         new(Resolve(source));
 
     /// <summary>
-    /// The <c>LENGTHB(<paramref name="source"/>)</c> function (Oracle): the
+    /// The <c>LENGTHB(<paramref name="source"/>)</c> function: the
     /// length of <paramref name="source"/> in bytes.
     /// </summary>
     /// <param name="source">The string whose byte length is measured.</param>
@@ -120,7 +140,7 @@ public static partial class Sql
         new(Resolve(source));
 
     /// <summary>
-    /// The <c>LISTAGG(expr, separator)</c> string aggregate (Oracle). Complete
+    /// The <c>LISTAGG(expr, separator)</c> string aggregate. Complete
     /// it with <c>.WithinGroup(OrderBy(...))</c> to supply Oracle's mandatory
     /// ordering.
     /// </summary>
@@ -128,6 +148,7 @@ public static partial class Sql
     /// <param name="separator">The separator placed between values.</param>
     /// <returns>A <see cref="ListaggFunction"/> emitting
     /// <c>LISTAGG(expr, separator)</c>.</returns>
+    /// <remarks>Oracle syntax.</remarks>
     public static ListaggFunction Listagg(object expr, object separator) =>
         new(Resolve(expr), Resolve(separator));
 

--- a/src/SqlArtisan/Sql/Sql.M.cs
+++ b/src/SqlArtisan/Sql/Sql.M.cs
@@ -49,7 +49,7 @@ public static partial class Sql
 
     /// <summary>
     /// The <c>MONTHS_BETWEEN(<paramref name="date1"/>, <paramref name="date2"/>)</c>
-    /// function (Oracle): the number of months between <paramref name="date1"/>
+    /// function: the number of months between <paramref name="date1"/>
     /// and <paramref name="date2"/>.
     /// </summary>
     /// <param name="date1">The later date.</param>

--- a/src/SqlArtisan/SqlBuilder/DbmsResolver.cs
+++ b/src/SqlArtisan/SqlBuilder/DbmsResolver.cs
@@ -38,13 +38,11 @@ public static class DbmsResolver
     /// </summary>
     /// <param name="typeFullName">The connection's fully qualified type name (e.g. <c>Npgsql.NpgsqlConnection</c>), matched case-insensitively.</param>
     /// <param name="dbms">The engine the connection type talks to.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="typeFullName"/> is null, empty, or whitespace.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="typeFullName"/> is null.</exception>
+    /// <exception cref="ArgumentException"><paramref name="typeFullName"/> is empty or whitespace.</exception>
     public static void RegisterProvider(string typeFullName, Dbms dbms)
     {
-        if (string.IsNullOrWhiteSpace(typeFullName))
-        {
-            throw new ArgumentNullException(nameof(typeFullName));
-        }
+        ArgumentException.ThrowIfNullOrWhiteSpace(typeFullName);
 
         s_providerMap.TryAdd(typeFullName, dbms);
     }


### PR DESCRIPTION
Addresses every finding from the comprehensive pre-release codebase audit. Four commits, one per concern (please **preserve the commits** — rebase or merge, not squash).

The audit found the codebase in excellent shape — no bugs, invalid SQL, ADR violations, or typos. These are the consistency/robustness/doc items it surfaced.

## 1. Sanitize generated identifiers (`5cf43f9`) — correctness (codegen)

`TableClassGen`'s `CaseConverter.SnakeToPascalCase` passed through any character a DB name allows but a C# identifier does not — a leading digit (`1st_col` → `1stCol`), Oracle's `$` / `#` (`col$x` → `Col$x`), or an all-underscore name (→ empty) produced **uncompilable** generated code. Now it splits on any non-identifier character, prefixes `_` when the result would start with a digit, and falls back to `_` for an all-separator name. Typical `snake_case` names are unchanged (verified: `user_name`→`UserName`, `1st_col`→`_1stCol`, `col$x`→`ColX`, `___`→`_`).

## 2. Move ConditionIf to its leading-letter file (`9bb6199`)

`Sql.ConditionIf` lived in `Sql.A.cs`; the convention (CLAUDE.md) is one file per the function name's leading letter. Moved to `Sql.C.cs`. Public API unchanged (`Sql` is a static partial class).

## 3. Consistent constructor precondition guards (`62e5cf4`)

- `RollupGrouping`/`CubeGrouping` dropped an unreachable empty-element check (the factory's required leading element guarantees a non-empty array).
- `SeparatorClause` uses `ArgumentNullException.ThrowIfNull` (analyzer-preferred, CA1510) instead of the lone `?? throw` form.
- `DbmsResolver.RegisterProvider` uses `ArgumentException.ThrowIfNullOrWhiteSpace`, so an empty/whitespace name throws `ArgumentException` (not `ArgumentNullException`); exception docs split to match.

## 4. Normalize XML docs (`185cdd1`) — docs

- `Lag`/`Lead`/`LastValue` gained the `<param>`/`<returns>` their analytic and scalar siblings already carried (the rest were already complete).
- Dialect availability now lives only in `<remarks>`: dropped inline `(Oracle)`/`(SQL Server)`/`(MySQL)`/`(PostgreSQL)` parentheticals from `Dateadd`/`Datediff`/`DateTrunc`, `GroupConcat`, `Instr`, `LastDay`, `Lengthb`, `Listagg`, `MonthsBetween`.

## Verification

- `dotnet build` (core, `AnalysisMode=Recommended`): **0 warnings** (CS1574 included — all `<see cref>` resolve)
- `dotnet test`: **446/446**
- `dotnet format --verify-no-changes`: clean
- `CaseConverter` edge cases verified empirically

🤖 Generated with [Claude Code](https://claude.com/claude-code)