### PR TITLE
feat: Override SqlStatement.ToString() to return the SQL text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- `SqlStatement.ToString()` now returns `Text` (the parameter-marked SQL), and the type carries `[DebuggerDisplay]`, so logging or inspecting a built statement shows the SQL instead of the type name. Parameter values are not included (they may be sensitive); read `Parameters` explicitly when you need them. (#147)
+- `SqlStatement.ToString()` now returns `Text` (the parameter-marked SQL), so logging or inspecting a built statement shows the SQL instead of the type name. Parameter values are not included (they may be sensitive); read `Parameters` explicitly when you need them. (#147)
 ### Added
 - Added `DbTable`, an ad-hoc table reference: name a table inline (`new DbTable("users", "u")`) and read its columns by name with `Column(name)`, without declaring a typed `DbTableBase` subclass — mirroring `Cte` / `DerivedTable`. Columns are qualified by the alias (unqualified when none); usable in `SELECT` / `FROM` / `JOIN` and as an `INSERT` / `UPDATE` / `DELETE` target. (#145)
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- `SqlStatement.ToString()` now returns `Text` (the parameter-marked SQL), and the type carries `[DebuggerDisplay]`, so logging or inspecting a built statement shows the SQL instead of the type name. Parameter values are not included (they may be sensitive); read `Parameters` explicitly when you need them. (#147)
+### Added
 - Added `DbTable`, an ad-hoc table reference: name a table inline (`new DbTable("users", "u")`) and read its columns by name with `Column(name)`, without declaring a typed `DbTableBase` subclass — mirroring `Cte` / `DerivedTable`. Columns are qualified by the alias (unqualified when none); usable in `SELECT` / `FROM` / `JOIN` and as an `INSERT` / `UPDATE` / `DELETE` target. (#145)
 ### Changed
 - Split the API reference out of the README into `docs/` to keep the README a lean landing page (it ships in the NuGet package and renders on nuget.org). The README now carries a capability-map index; usage examples, expressions, and the function catalog moved to `docs/query-statements.md`, `docs/expressions.md`, and `docs/functions.md`, indexed by `docs/README.md`. README→docs links are absolute GitHub URLs since nuget.org does not resolve relative links. Added `llms.txt` as an LLM-friendly index for AI coding tools. (#143)

--- a/src/SqlArtisan/SqlBuilder/SqlStatement.cs
+++ b/src/SqlArtisan/SqlBuilder/SqlStatement.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using SqlArtisan.Internal;
 
 namespace SqlArtisan;
@@ -6,7 +5,6 @@ namespace SqlArtisan;
 /// <summary>
 /// A built SQL statement: the rendered text and the parameters it binds.
 /// </summary>
-[DebuggerDisplay("{Text}")]
 public sealed class SqlStatement
 {
     internal SqlStatement(string text, List<KeyValuePair<string, BindValue>> parameters)

--- a/src/SqlArtisan/SqlBuilder/SqlStatement.cs
+++ b/src/SqlArtisan/SqlBuilder/SqlStatement.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using SqlArtisan.Internal;
 
 namespace SqlArtisan;
@@ -5,6 +6,7 @@ namespace SqlArtisan;
 /// <summary>
 /// A built SQL statement: the rendered text and the parameters it binds.
 /// </summary>
+[DebuggerDisplay("{Text}")]
 public sealed class SqlStatement
 {
     internal SqlStatement(string text, List<KeyValuePair<string, BindValue>> parameters)
@@ -22,4 +24,12 @@ public sealed class SqlStatement
     /// Gets the parameters bound by <see cref="Text"/>.
     /// </summary>
     public SqlParameters Parameters { get; }
+
+    /// <summary>
+    /// Returns <see cref="Text"/> — the SQL with parameter markers. Parameter
+    /// <em>values</em> are not included (they may hold sensitive data); read
+    /// <see cref="Parameters"/> explicitly when you need them.
+    /// </summary>
+    /// <returns>The rendered SQL text.</returns>
+    public override string ToString() => Text;
 }

--- a/tests/SqlArtisan.Tests/SqlStatementTests.cs
+++ b/tests/SqlArtisan.Tests/SqlStatementTests.cs
@@ -1,0 +1,33 @@
+using static SqlArtisan.Sql;
+
+namespace SqlArtisan.Tests;
+
+public class SqlStatementTests
+{
+    private readonly TestTable _t = new("t");
+
+    [Fact]
+    public void ToString_WithParameters_ReturnsText()
+    {
+        SqlStatement sql =
+            Select(_t.Name)
+            .From(_t)
+            .Where(_t.Code == 1)
+            .Build();
+
+        Assert.Equal(sql.Text, sql.ToString());
+        Assert.Equal("SELECT \"t\".name FROM test_table \"t\" WHERE \"t\".code = :0", sql.ToString());
+    }
+
+    [Fact]
+    public void ToString_NoParameters_ReturnsText()
+    {
+        SqlStatement sql =
+            Select(_t.Name)
+            .From(_t)
+            .Build();
+
+        Assert.Equal(sql.Text, sql.ToString());
+        Assert.Equal("SELECT \"t\".name FROM test_table \"t\"", sql.ToString());
+    }
+}


### PR DESCRIPTION
Closes #147

## Summary

Make a built statement self-describing when logged or inspected. `SqlStatement.ToString()` was the default (returned `"SqlArtisan.SqlStatement"`), so `Console.WriteLine(sql)` / `logger.LogDebug("{Stmt}", sql)` / the debugger showed the type name instead of the SQL.

```csharp
SqlStatement sql = Select(u.Id).From(u).Where(u.Id == 10).Build();
Console.WriteLine(sql);            // SELECT id FROM users WHERE id = :0
```

- `ToString()` → `Text` (the parameter-marked SQL). The debugger also shows the SQL via `ToString()`.

## Design

- **Parameter values are deliberately excluded.** Values can hold PII/secrets, so folding them into `ToString()` would leak them on a casual `LogDebug(sql)` (same reasoning as EF Core gating values behind `EnableSensitiveDataLogging`). The faithful artifact for "reproduce the same query" is `Text` + `Parameters`; read `Parameters` explicitly when you need the values.
- **No `ILogger` in the core.** SqlArtisan core is a pure, I/O-free builder with static entry points (no DI seam) — adding logging would mean global mutable logger state and a new dependency. Automatic logging, if ever wanted, belongs at the execution boundary (`SqlArtisan.Dapper`), not here.
- **No value-dumping / inline-SQL helper** in scope (PII + dialect-literal-formatting + SQLi concerns).

## Verification

- `dotnet build` — **0 warnings / 0 errors**.
- `dotnet test` — **457 passed**, incl. 2 new `SqlStatementTests` (`ToString() == Text` with and without parameters; exact-SQL).
- `dotnet format --verify-no-changes` — clean.

## Docs

- `CHANGELOG.md` — `[Unreleased]` → Added.
- XML doc on `ToString()` notes that values are not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)