### PR TITLE
build(1.0): Source Link, deterministic build, symbols, and AOT/trim compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Split the API reference out of the README into `docs/` to keep the README a lean landing page (it ships in the NuGet package and renders on nuget.org). The README now carries a capability-map index; usage examples, expressions, and the function catalog moved to `docs/query-statements.md`, `docs/expressions.md`, and `docs/functions.md`, indexed by `docs/README.md`. README→docs links are absolute GitHub URLs since nuget.org does not resolve relative links. Added `llms.txt` as an LLM-friendly index for AI coding tools. (#143)
 - Documented the `GREATEST` / `LEAST` functions, which were public but absent from the function reference. (#143)
+### Build
+- The published packages now enable Source Link (`Microsoft.SourceLink.GitHub`), a deterministic build on CI (`ContinuousIntegrationBuild`), and ship debugging symbols as a separate `.snupkg` (`DebugType=portable`) — so consumers can step straight into SqlArtisan source while debugging, and the assemblies are reproducible from this exact commit. Applies to `SqlArtisan`, `SqlArtisan.Dapper`, and `SqlArtisan.TableClassGen`. (#157)
+- Declared the core `SqlArtisan` package trim- and AOT-compatible (`IsAotCompatible`, which turns on the trim/single-file/AOT analyzers): the builder uses no reflection or dynamic codegen, so it produces zero trim/AOT warnings — verified by a native-AOT smoke test — a trust signal for container, CLI, and serverless deployments. Scoped to the core; `SqlArtisan.Dapper` depends on Dapper and is out of scope. (#158)
 
 ## [0.4.0-beta.1] - 2026-06-27
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,4 +20,47 @@
     <AnalysisMode>Recommended</AnalysisMode>
   </PropertyGroup>
 
+  <!--
+    Debuggable, trustworthy packages (#157). Source Link maps the shipped
+    assemblies back to this exact commit on GitHub so consumers can step into
+    SqlArtisan source; symbols ship as a separate .snupkg with portable PDBs.
+    These apply to every project — harmless for the non-packed tests/benchmark,
+    which are simply never packed. (.NET 8's SDK bundles the Source Link
+    infrastructure but not the GitHub host package, so it is referenced below.)
+  -->
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
+
+  <!-- Build-time only (PrivateAssets=all): never flows to consumers as a dependency. -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <!--
+    Deterministic build: a given commit always produces byte-identical output, so
+    the published assemblies are verifiably reproducible from source. Scoped to CI
+    (GitHub Actions sets GITHUB_ACTIONS=true) because ContinuousIntegrationBuild
+    normalizes source paths, which would break local debugging.
+  -->
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <!--
+    AOT / trimming compatibility for the core (#158). The builder uses no
+    reflection or dynamic codegen (enum handling is `value is Enum`), so it is
+    trim/AOT-safe. IsAotCompatible turns on the trim, single-file, and AOT
+    analyzers and declares the contract via the IsTrimmable assembly flag; a clean
+    build is the proof. Scoped to the core only — SqlArtisan.Dapper depends on
+    Dapper and is out of scope.
+  -->
+  <PropertyGroup Condition="'$(MSBuildProjectName)' == 'SqlArtisan'">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Closes #157, closes #158. Both are mechanical build/packaging changes for the 1.0 release, centralized in `Directory.Build.props`.

## #157 — Source Link, deterministic build, symbol package
Applies to `SqlArtisan`, `SqlArtisan.Dapper`, `SqlArtisan.TableClassGen`:
- Reference `Microsoft.SourceLink.GitHub` (`PrivateAssets=all`, never flows to consumers) and set `PublishRepositoryUrl` / `EmbedUntrackedSources` so consumers can step into SqlArtisan source while debugging.
- `IncludeSymbols` + `SymbolPackageFormat=snupkg` + `DebugType=portable` to ship symbols as a separate `.snupkg`.
- `ContinuousIntegrationBuild` for a deterministic build, scoped to CI (`GITHUB_ACTIONS=true`) so local source paths stay debuggable.

> Note: the .NET 8 SDK bundles the Source Link infrastructure but **not** the GitHub host package, so the explicit `PackageReference` is required — `PublishRepositoryUrl` alone produces no source link mapping.

## #158 — AOT & trimming compatibility for the core
Scoped to core `SqlArtisan` only (`SqlArtisan.Dapper` depends on Dapper, out of scope):
- `IsAotCompatible=true`, which enables the trim / single-file / AOT analyzers and the `IsTrimmable` assembly flag. The builder uses no reflection or dynamic codegen (enum handling is `value is Enum`), so it builds clean.

## Verification (all run empirically)
- **Source Link**: `sourcelink test` passes — PDB documents map to `raw.githubusercontent.com/h-tacayama/SqlArtisan/<commit>/*`; `.snupkg` generated; nuspec carries the repository commit SHA.
- **AOT**: a native-AOT smoke app referencing the core publishes with **0 IL2xxx/IL3xxx trim/AOT warnings** and the resulting native binary emits correct per-dialect SQL across all five DBMS.
- **Tests**: 457 passed, 0 failed.
- **Format gate**: `dotnet format --verify-no-changes` clean.

> Sandbox caveat: local builds emit a `Source control information is not available` warning because this environment's `origin` is a local-proxy URL, not github.com. It does not occur in real CI (`actions/checkout` sets origin to github.com), where Source Link was confirmed working by pointing the build at the github remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCtjXkyJdGn3XqZCoa8gkZ)_