### PR TITLE
test(1.0): Real-database integration test matrix (5 engines)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,6 +10,10 @@ name: Integration Tests
 on:
   workflow_call:
   workflow_dispatch:
+  # TEMPORARY (#151 validation): run the matrix on PRs to this branch so the four
+  # container engines can be verified before merge. Remove before merging.
+  pull_request:
+    branches: [main]
   schedule:
     # Nightly at 03:00 UTC.
     - cron: '0 3 * * *'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,48 @@
+name: Integration Tests
+
+# Real-database integration matrix (#151). Each engine runs SqlArtisan-built
+# statements against a live database (Testcontainers; SQLite is in-process), so
+# CI catches grammar/semantic bugs only the engine itself rejects — the kind the
+# exact-SQL unit tests cannot. Kept off the per-PR fast loop (ci.yml): the unit
+# tests are the inner loop; these gate releases (called by release.yml) and run
+# nightly, with on-demand dispatch.
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  schedule:
+    # Nightly at 03:00 UTC.
+    - cron: '0 3 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+
+    strategy:
+      # One engine per job, in parallel; a failure in one (e.g. the heavy Oracle
+      # lane) must not cancel the others — each engine's result stands alone.
+      fail-fast: false
+      matrix:
+        engine: [Sqlite, PostgreSql, MySql, SqlServer, Oracle]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore tests/SqlArtisan.IntegrationTests/SqlArtisan.IntegrationTests.csproj
+
+      - name: Test (${{ matrix.engine }})
+        run: >
+          dotnet test tests/SqlArtisan.IntegrationTests
+          -c Release
+          --filter "Engine=${{ matrix.engine }}"
+          --logger "console;verbosity=normal"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,10 +10,6 @@ name: Integration Tests
 on:
   workflow_call:
   workflow_dispatch:
-  # TEMPORARY (#151 validation): run the matrix on PRs to this branch so the four
-  # container engines can be verified before merge. Remove before merging.
-  pull_request:
-    branches: [main]
   schedule:
     # Nightly at 03:00 UTC.
     - cron: '0 3 * * *'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,14 @@ jobs:
       - name: Test
         run: dotnet test tests/SqlArtisan.Tests --no-build -c Release --verbosity normal
 
-  publish:
+  # Real-database integration matrix gates the release: the emitted SQL must
+  # actually execute on every engine before anything reaches nuget.org (#151).
+  integration:
     needs: verify
+    uses: ./.github/workflows/integration.yml
+
+  publish:
+    needs: integration
     runs-on: ubuntu-latest
     # Holds the NUGET_API_KEY secret; attach required reviewers here to gate the
     # push behind a manual approval.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Build
 - The published packages now enable Source Link (`Microsoft.SourceLink.GitHub`), a deterministic build on CI (`ContinuousIntegrationBuild`), and ship debugging symbols as a separate `.snupkg` (`DebugType=portable`) — so consumers can step straight into SqlArtisan source while debugging, and the assemblies are reproducible from this exact commit. Applies to `SqlArtisan`, `SqlArtisan.Dapper`, and `SqlArtisan.TableClassGen`. (#157)
 - Declared the core `SqlArtisan` package trim- and AOT-compatible (`IsAotCompatible`, which turns on the trim/single-file/AOT analyzers): the builder uses no reflection or dynamic codegen, so it produces zero trim/AOT warnings — verified by a native-AOT smoke test — a trust signal for container, CLI, and serverless deployments. Scoped to the core; `SqlArtisan.Dapper` depends on Dapper and is out of scope. (#158)
+### Tests
+- Added a real-database integration test matrix (`tests/SqlArtisan.IntegrationTests`) that executes SqlArtisan-built statements (SELECT/JOIN/CTE/window/GROUP BY/aggregate/UPDATE/DELETE plus per-dialect pagination, UPSERT, MERGE, and RETURNING) against all five engines — MySQL, Oracle, PostgreSQL, SQL Server (via Testcontainers) and SQLite (in-process) — catching grammar/semantic bugs only the engine itself rejects. The exact-SQL unit tests remain the fast inner loop; the integration matrix runs nightly, on demand, and gates releases. (#151)
 
 ## [0.4.0-beta.1] - 2026-06-27
 ### Added

--- a/SqlArtisan.sln
+++ b/SqlArtisan.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SqlArtisan.TableClassGen", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SqlArtisan.Dapper", "src\SqlArtisan.Dapper\SqlArtisan.Dapper.csproj", "{B8F35097-2A98-44AE-87F3-400AB15057BA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SqlArtisan.IntegrationTests", "tests\SqlArtisan.IntegrationTests\SqlArtisan.IntegrationTests.csproj", "{F49D0D7A-D0C0-4A15-AAF1-973799EC8464}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,6 +45,10 @@ Global
 		{B8F35097-2A98-44AE-87F3-400AB15057BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B8F35097-2A98-44AE-87F3-400AB15057BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B8F35097-2A98-44AE-87F3-400AB15057BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F49D0D7A-D0C0-4A15-AAF1-973799EC8464}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F49D0D7A-D0C0-4A15-AAF1-973799EC8464}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F49D0D7A-D0C0-4A15-AAF1-973799EC8464}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F49D0D7A-D0C0-4A15-AAF1-973799EC8464}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -53,5 +59,6 @@ Global
 		{F3E96DB7-F2CC-467D-A38E-73D696B5B5FD} = {F29CB8EE-C83F-493D-9F22-2EE7EFCC209D}
 		{0CF476C5-8765-4117-B6AF-438BF78A1D8C} = {A36260A0-5AEB-46AA-A77F-9CE7ABF74AA4}
 		{B8F35097-2A98-44AE-87F3-400AB15057BA} = {A36260A0-5AEB-46AA-A77F-9CE7ABF74AA4}
+		{F49D0D7A-D0C0-4A15-AAF1-973799EC8464} = {F29CB8EE-C83F-493D-9F22-2EE7EFCC209D}
 	EndGlobalSection
 EndGlobal

--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/IDatabaseFixture.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/IDatabaseFixture.cs
@@ -1,0 +1,20 @@
+using System.Data;
+
+namespace SqlArtisan.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// A live database the integration tests run against. Each implementation owns
+/// the engine's lifecycle (a Testcontainers container, or an in-process file for
+/// SQLite), creates the test schema, and seeds the baseline data — so a test
+/// only needs an open connection of the right provider type. The provider type
+/// is what <see cref="DbmsResolver"/> keys off, so executing a SqlArtisan
+/// builder through the connection picks the correct dialect automatically.
+/// </summary>
+public interface IDatabaseFixture
+{
+    /// <summary>The engine behind this fixture, for documentation and trait filtering.</summary>
+    Dbms Dbms { get; }
+
+    /// <summary>Opens a fresh connection to the seeded database.</summary>
+    IDbConnection OpenConnection();
+}

--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/MySqlFixture.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/MySqlFixture.cs
@@ -1,0 +1,31 @@
+using System.Data;
+using MySqlConnector;
+using Testcontainers.MySql;
+
+namespace SqlArtisan.IntegrationTests.Infrastructure;
+
+/// <summary>MySQL fixture, backed by a Testcontainers <c>mysql</c> container (8.0 for window functions).</summary>
+public sealed class MySqlFixture : IAsyncLifetime, IDatabaseFixture
+{
+    private readonly MySqlContainer _container = new MySqlBuilder()
+        .WithImage("mysql:8.0")
+        .Build();
+
+    public Dbms Dbms => Dbms.MySql;
+
+    public IDbConnection OpenConnection()
+    {
+        MySqlConnection connection = new(_container.GetConnectionString());
+        connection.Open();
+        return connection;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+        using IDbConnection connection = OpenConnection();
+        TestSchema.Apply(connection, TestSchema.StandardDdl);
+    }
+
+    public Task DisposeAsync() => _container.DisposeAsync().AsTask();
+}

--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/OracleFixture.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/OracleFixture.cs
@@ -1,0 +1,33 @@
+using System.Data;
+using Oracle.ManagedDataAccess.Client;
+using Testcontainers.Oracle;
+
+namespace SqlArtisan.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Oracle fixture, backed by the Testcontainers <c>oracle</c> module's default
+/// image (gvenzl/oracle-free). The image is large and slow to start, so the
+/// Oracle lane is the heaviest entry in the matrix.
+/// </summary>
+public sealed class OracleFixture : IAsyncLifetime, IDatabaseFixture
+{
+    private readonly OracleContainer _container = new OracleBuilder().Build();
+
+    public Dbms Dbms => Dbms.Oracle;
+
+    public IDbConnection OpenConnection()
+    {
+        OracleConnection connection = new(_container.GetConnectionString());
+        connection.Open();
+        return connection;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+        using IDbConnection connection = OpenConnection();
+        TestSchema.Apply(connection, TestSchema.OracleDdl);
+    }
+
+    public Task DisposeAsync() => _container.DisposeAsync().AsTask();
+}

--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/PostgreSqlFixture.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/PostgreSqlFixture.cs
@@ -1,0 +1,31 @@
+using System.Data;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace SqlArtisan.IntegrationTests.Infrastructure;
+
+/// <summary>PostgreSQL fixture, backed by a Testcontainers <c>postgres</c> container.</summary>
+public sealed class PostgreSqlFixture : IAsyncLifetime, IDatabaseFixture
+{
+    private readonly PostgreSqlContainer _container = new PostgreSqlBuilder()
+        .WithImage("postgres:16-alpine")
+        .Build();
+
+    public Dbms Dbms => Dbms.PostgreSql;
+
+    public IDbConnection OpenConnection()
+    {
+        NpgsqlConnection connection = new(_container.GetConnectionString());
+        connection.Open();
+        return connection;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+        using IDbConnection connection = OpenConnection();
+        TestSchema.Apply(connection, TestSchema.StandardDdl);
+    }
+
+    public Task DisposeAsync() => _container.DisposeAsync().AsTask();
+}

--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/SqlServerFixture.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/SqlServerFixture.cs
@@ -1,0 +1,31 @@
+using System.Data;
+using Microsoft.Data.SqlClient;
+using Testcontainers.MsSql;
+
+namespace SqlArtisan.IntegrationTests.Infrastructure;
+
+/// <summary>SQL Server fixture, backed by a Testcontainers <c>mssql/server</c> container.</summary>
+public sealed class SqlServerFixture : IAsyncLifetime, IDatabaseFixture
+{
+    private readonly MsSqlContainer _container = new MsSqlBuilder()
+        .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+        .Build();
+
+    public Dbms Dbms => Dbms.SqlServer;
+
+    public IDbConnection OpenConnection()
+    {
+        SqlConnection connection = new(_container.GetConnectionString());
+        connection.Open();
+        return connection;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _container.StartAsync();
+        using IDbConnection connection = OpenConnection();
+        TestSchema.Apply(connection, TestSchema.StandardDdl);
+    }
+
+    public Task DisposeAsync() => _container.DisposeAsync().AsTask();
+}

--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/SqliteFixture.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/SqliteFixture.cs
@@ -1,0 +1,43 @@
+using System.Data;
+using Microsoft.Data.Sqlite;
+
+namespace SqlArtisan.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// SQLite fixture. SQLite is in-process — no container — so it backs the matrix
+/// with a temporary database file created and seeded once per test class.
+/// </summary>
+public sealed class SqliteFixture : IAsyncLifetime, IDatabaseFixture
+{
+    private readonly string _databasePath =
+        Path.Combine(Path.GetTempPath(), $"sqlartisan_it_{Guid.NewGuid():N}.db");
+
+    public Dbms Dbms => Dbms.Sqlite;
+
+    private string ConnectionString => $"Data Source={_databasePath}";
+
+    public IDbConnection OpenConnection()
+    {
+        SqliteConnection connection = new(ConnectionString);
+        connection.Open();
+        return connection;
+    }
+
+    public Task InitializeAsync()
+    {
+        using IDbConnection connection = OpenConnection();
+        TestSchema.Apply(connection, TestSchema.StandardDdl);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(_databasePath))
+        {
+            File.Delete(_databasePath);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/TestSchema.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/TestSchema.cs
@@ -1,0 +1,75 @@
+using System.Data;
+using Dapper;
+using SqlArtisan.Dapper;
+using SqlArtisan.IntegrationTests.Schema;
+using static SqlArtisan.Sql;
+
+namespace SqlArtisan.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// The shared test schema (two small tables) plus the baseline seed data, applied
+/// by every fixture after the engine is up. DDL is inherently dialectal — SqlArtisan
+/// does not build DDL — so the <c>CREATE TABLE</c> text lives here, per engine. The
+/// seed rows, by contrast, are inserted through SqlArtisan itself, so seeding doubles
+/// as INSERT-execution coverage on every engine.
+/// </summary>
+internal static class TestSchema
+{
+    // INTEGER / VARCHAR / DECIMAL are accepted verbatim by PostgreSQL, MySQL,
+    // SQLite, and SQL Server (INTEGER is a SQL Server synonym for INT).
+    public static readonly string[] StandardDdl =
+    [
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(100), age INTEGER, department_id INTEGER)",
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount DECIMAL(10,2))",
+    ];
+
+    // Oracle spells the same shapes NUMBER / VARCHAR2.
+    public static readonly string[] OracleDdl =
+    [
+        "CREATE TABLE users (id NUMBER(10) PRIMARY KEY, name VARCHAR2(100), age NUMBER(10), department_id NUMBER(10))",
+        "CREATE TABLE orders (id NUMBER(10) PRIMARY KEY, user_id NUMBER(10), amount NUMBER(10,2))",
+    ];
+
+    private static readonly (int Id, string Name, int Age, int DepartmentId)[] s_users =
+    [
+        (1, "Alice", 30, 10),
+        (2, "Bob", 40, 10),
+        (3, "Carol", 50, 20),
+        (4, "Dave", 25, 20),
+        (5, "Eve", 35, 30),
+    ];
+
+    private static readonly (int Id, int UserId, decimal Amount)[] s_orders =
+    [
+        (1, 1, 100.00m),
+        (2, 1, 200.00m),
+        (3, 2, 50.00m),
+        (4, 3, 300.00m),
+        (5, 5, 75.00m),
+    ];
+
+    /// <summary>Creates the tables (using <paramref name="ddl"/>) and seeds the baseline rows.</summary>
+    public static void Apply(IDbConnection connection, string[] ddl)
+    {
+        foreach (string statement in ddl)
+        {
+            connection.Execute(statement);
+        }
+
+        UsersTable users = new();
+        foreach ((int id, string name, int age, int departmentId) in s_users)
+        {
+            connection.Execute(
+                InsertInto(users, users.Id, users.Name, users.Age, users.DepartmentId)
+                    .Values(id, name, age, departmentId));
+        }
+
+        OrdersTable orders = new();
+        foreach ((int id, int userId, decimal amount) in s_orders)
+        {
+            connection.Execute(
+                InsertInto(orders, orders.Id, orders.UserId, orders.Amount)
+                    .Values(id, userId, amount));
+        }
+    }
+}

--- a/tests/SqlArtisan.IntegrationTests/Schema/OrdersTable.cs
+++ b/tests/SqlArtisan.IntegrationTests/Schema/OrdersTable.cs
@@ -1,0 +1,21 @@
+namespace SqlArtisan.IntegrationTests.Schema;
+
+/// <summary>
+/// The <c>orders</c> table used across the integration matrix, joined to
+/// <see cref="UsersTable"/> by <c>user_id</c>.
+/// </summary>
+internal sealed class OrdersTable : DbTableBase
+{
+    public OrdersTable(string alias = "") : base("orders", alias)
+    {
+        Id = new DbColumn(alias, "id");
+        UserId = new DbColumn(alias, "user_id");
+        Amount = new DbColumn(alias, "amount");
+    }
+
+    public DbColumn Id { get; }
+
+    public DbColumn UserId { get; }
+
+    public DbColumn Amount { get; }
+}

--- a/tests/SqlArtisan.IntegrationTests/Schema/UsersTable.cs
+++ b/tests/SqlArtisan.IntegrationTests/Schema/UsersTable.cs
@@ -1,0 +1,26 @@
+namespace SqlArtisan.IntegrationTests.Schema;
+
+/// <summary>
+/// The <c>users</c> table used across the integration matrix. The schema is
+/// deliberately minimal and type-portable (integers and a short string) so the
+/// per-engine DDL stays trivial; the point is to execute SqlArtisan-built
+/// statements against a real engine, not to exercise exotic column types.
+/// </summary>
+internal sealed class UsersTable : DbTableBase
+{
+    public UsersTable(string alias = "") : base("users", alias)
+    {
+        Id = new DbColumn(alias, "id");
+        Name = new DbColumn(alias, "name");
+        Age = new DbColumn(alias, "age");
+        DepartmentId = new DbColumn(alias, "department_id");
+    }
+
+    public DbColumn Id { get; }
+
+    public DbColumn Name { get; }
+
+    public DbColumn Age { get; }
+
+    public DbColumn DepartmentId { get; }
+}

--- a/tests/SqlArtisan.IntegrationTests/SqlArtisan.IntegrationTests.csproj
+++ b/tests/SqlArtisan.IntegrationTests/SqlArtisan.IntegrationTests.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Dapper" Version="2.1.66" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="MySqlConnector" Version="2.4.0" />
+    <PackageReference Include="Npgsql" Version="9.0.3" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.8.0" />
+    <PackageReference Include="Testcontainers.MsSql" Version="3.10.0" />
+    <PackageReference Include="Testcontainers.MySql" Version="3.10.0" />
+    <PackageReference Include="Testcontainers.Oracle" Version="3.10.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="3.10.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SqlArtisan.Dapper\SqlArtisan.Dapper.csproj" />
+    <ProjectReference Include="..\..\src\SqlArtisan\SqlArtisan.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/tests/SqlArtisan.IntegrationTests/Tests/IntegrationTestBase.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/IntegrationTestBase.cs
@@ -29,9 +29,8 @@ public abstract class IntegrationTestBase
         UsersTable u = new();
         using IDbConnection connection = _fixture.OpenConnection();
 
-        List<string> names = connection
-            .Query<string>(Select(u.Name).From(u).Where(u.Age > 35).OrderBy(u.Name))
-            .ToList();
+        IEnumerable<string> names = connection
+            .Query<string>(Select(u.Name).From(u).Where(u.Age > 35).OrderBy(u.Name));
 
         Assert.Equal(new[] { "Bob", "Carol" }, names);
     }
@@ -70,11 +69,10 @@ public abstract class IntegrationTestBase
         UsersTable u = new();
         using IDbConnection connection = _fixture.OpenConnection();
 
-        List<int> rowNumbers = connection
-            .Query<int>(Select(RowNumber().Over(PartitionBy(u.DepartmentId).OrderBy(u.Age))).From(u))
-            .ToList();
+        IEnumerable<int> rowNumbers = connection
+            .Query<int>(Select(RowNumber().Over(PartitionBy(u.DepartmentId).OrderBy(u.Age))).From(u));
 
-        Assert.Equal(5, rowNumbers.Count);
+        Assert.Equal(5, rowNumbers.Count());
         Assert.Equal(2, rowNumbers.Max());
     }
 
@@ -84,14 +82,13 @@ public abstract class IntegrationTestBase
         UsersTable u = new();
         using IDbConnection connection = _fixture.OpenConnection();
 
-        List<int> departments = connection
+        IEnumerable<int> departments = connection
             .Query<int>(
                 Select(u.DepartmentId)
                     .From(u)
                     .GroupBy(u.DepartmentId)
                     .Having(Count(u.Id) >= 2)
-                    .OrderBy(u.DepartmentId))
-            .ToList();
+                    .OrderBy(u.DepartmentId));
 
         Assert.Equal(new[] { 10, 20 }, departments);
     }

--- a/tests/SqlArtisan.IntegrationTests/Tests/IntegrationTestBase.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/IntegrationTestBase.cs
@@ -1,0 +1,161 @@
+using System.Data;
+using SqlArtisan.Dapper;
+using SqlArtisan.IntegrationTests.Infrastructure;
+using SqlArtisan.IntegrationTests.Schema;
+using static SqlArtisan.Sql;
+
+namespace SqlArtisan.IntegrationTests.Tests;
+
+/// <summary>
+/// The dialect-agnostic core of the matrix: representative statements that are
+/// valid on every engine. Each test builds with SqlArtisan and executes against
+/// the real database, asserting it runs and returns the expected result — the
+/// confidence the exact-SQL unit tests cannot give. Engine-specific syntax
+/// (pagination, UPSERT, MERGE, RETURNING) lives in the per-engine subclasses.
+///
+/// Read tests rely on the baseline seed (5 users, 5 orders); mutating tests run
+/// inside a rolled-back transaction so they never disturb that baseline,
+/// keeping the suite order-independent.
+/// </summary>
+public abstract class IntegrationTestBase
+{
+    private readonly IDatabaseFixture _fixture;
+
+    protected IntegrationTestBase(IDatabaseFixture fixture) => _fixture = fixture;
+
+    [Fact]
+    public void SelectWhere_FiltersAndBindsParameter()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        List<string> names = connection
+            .Query<string>(Select(u.Name).From(u).Where(u.Age > 35).OrderBy(u.Name))
+            .ToList();
+
+        Assert.Equal(new[] { "Bob", "Carol" }, names);
+    }
+
+    [Fact]
+    public void InnerJoin_MatchesRows()
+    {
+        OrdersTable o = new("o");
+        UsersTable u = new("u");
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        long count = Convert.ToInt64(connection.ExecuteScalar(
+            Select(Count(o.Id)).From(o).InnerJoin(u).On(o.UserId == u.Id)));
+
+        Assert.Equal(5, count);
+    }
+
+    [Fact]
+    public void Cte_FiltersThenSelects()
+    {
+        UsersTable u = new();
+        Cte seniors = new("seniors");
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        long count = Convert.ToInt64(connection.ExecuteScalar(
+            With(seniors.As(Select(u.Id.As(seniors.Column("id"))).From(u).Where(u.Age >= 40)))
+                .Select(Count(seniors.Column("id")))
+                .From(seniors)));
+
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public void WindowFunction_RowNumber_Executes()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        List<int> rowNumbers = connection
+            .Query<int>(Select(RowNumber().Over(PartitionBy(u.DepartmentId).OrderBy(u.Age))).From(u))
+            .ToList();
+
+        Assert.Equal(5, rowNumbers.Count);
+        Assert.Equal(2, rowNumbers.Max());
+    }
+
+    [Fact]
+    public void GroupByHaving_FiltersGroups()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        List<int> departments = connection
+            .Query<int>(
+                Select(u.DepartmentId)
+                    .From(u)
+                    .GroupBy(u.DepartmentId)
+                    .Having(Count(u.Id) >= 2)
+                    .OrderBy(u.DepartmentId))
+            .ToList();
+
+        Assert.Equal(new[] { 10, 20 }, departments);
+    }
+
+    [Fact]
+    public void ScalarFunction_Upper_Executes()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        string name = connection
+            .Query<string>(Select(Upper(u.Name)).From(u).Where(u.Id == 1))
+            .Single();
+
+        Assert.Equal("ALICE", name);
+    }
+
+    [Fact]
+    public void Aggregate_Sum_Executes()
+    {
+        OrdersTable o = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        decimal total = Convert.ToDecimal(connection.ExecuteScalar(Select(Sum(o.Amount)).From(o)));
+
+        Assert.Equal(725m, total);
+    }
+
+    [Fact]
+    public void Update_ModifiesRow()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        connection.Execute(
+            InsertInto(u, u.Id, u.Name, u.Age, u.DepartmentId).Values(100, "Temp", 20, 99),
+            transaction);
+        connection.Execute(Update(u).Set(u.Name == "Updated").Where(u.Id == 100), transaction);
+
+        string name = connection
+            .Query<string>(Select(u.Name).From(u).Where(u.Id == 100), transaction)
+            .Single();
+
+        Assert.Equal("Updated", name);
+        transaction.Rollback();
+    }
+
+    [Fact]
+    public void Delete_RemovesRow()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        connection.Execute(
+            InsertInto(u, u.Id, u.Name, u.Age, u.DepartmentId).Values(101, "Temp", 20, 99),
+            transaction);
+        connection.Execute(DeleteFrom(u).Where(u.Id == 101), transaction);
+
+        long remaining = Convert.ToInt64(connection.ExecuteScalar(
+            Select(Count(u.Id)).From(u).Where(u.Id == 101), transaction));
+
+        Assert.Equal(0, remaining);
+        transaction.Rollback();
+    }
+}

--- a/tests/SqlArtisan.IntegrationTests/Tests/IntegrationTestBase.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/IntegrationTestBase.cs
@@ -55,8 +55,11 @@ public abstract class IntegrationTestBase
         Cte seniors = new("seniors");
         using IDbConnection connection = _fixture.OpenConnection();
 
+        // The CTE projects `id` without re-aliasing, so the column name folds
+        // identically at definition and reference on every engine. Re-aliasing
+        // (`.As(seniors.Column("id"))`) is broken on Oracle — see #165.
         long count = Convert.ToInt64(connection.ExecuteScalar(
-            With(seniors.As(Select(u.Id.As(seniors.Column("id"))).From(u).Where(u.Age >= 40)))
+            With(seniors.As(Select(u.Id).From(u).Where(u.Age >= 40)))
                 .Select(Count(seniors.Column("id")))
                 .From(seniors)));
 

--- a/tests/SqlArtisan.IntegrationTests/Tests/MySqlTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/MySqlTests.cs
@@ -19,9 +19,8 @@ public sealed class MySqlTests : IntegrationTestBase, IClassFixture<MySqlFixture
         UsersTable u = new();
         using IDbConnection connection = _fixture.OpenConnection();
 
-        List<int> ids = connection
-            .Query<int>(Select(u.Id).From(u).OrderBy(u.Id).Limit(2).Offset(1))
-            .ToList();
+        IEnumerable<int> ids = connection
+            .Query<int>(Select(u.Id).From(u).OrderBy(u.Id).Limit(2).Offset(1));
 
         Assert.Equal(new[] { 2, 3 }, ids);
     }

--- a/tests/SqlArtisan.IntegrationTests/Tests/MySqlTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/MySqlTests.cs
@@ -1,0 +1,49 @@
+using System.Data;
+using SqlArtisan.Dapper;
+using SqlArtisan.IntegrationTests.Infrastructure;
+using SqlArtisan.IntegrationTests.Schema;
+using static SqlArtisan.Sql;
+
+namespace SqlArtisan.IntegrationTests.Tests;
+
+[Trait("Engine", "MySql")]
+public sealed class MySqlTests : IntegrationTestBase, IClassFixture<MySqlFixture>
+{
+    private readonly MySqlFixture _fixture;
+
+    public MySqlTests(MySqlFixture fixture) : base(fixture) => _fixture = fixture;
+
+    [Fact]
+    public void Pagination_LimitOffset_Executes()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        List<int> ids = connection
+            .Query<int>(Select(u.Id).From(u).OrderBy(u.Id).Limit(2).Offset(1))
+            .ToList();
+
+        Assert.Equal(new[] { 2, 3 }, ids);
+    }
+
+    [Fact]
+    public void Upsert_OnDuplicateKeyUpdate_Executes()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        connection.Execute(
+            InsertInto(u, u.Id, u.Name)
+                .Values(1, "AliceUpdated")
+                .OnDuplicateKeyUpdate(u.Name == Excluded(u.Name)),
+            transaction);
+
+        string name = connection
+            .Query<string>(Select(u.Name).From(u).Where(u.Id == 1), transaction)
+            .Single();
+
+        Assert.Equal("AliceUpdated", name);
+        transaction.Rollback();
+    }
+}

--- a/tests/SqlArtisan.IntegrationTests/Tests/OracleTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/OracleTests.cs
@@ -19,9 +19,8 @@ public sealed class OracleTests : IntegrationTestBase, IClassFixture<OracleFixtu
         UsersTable u = new();
         using IDbConnection connection = _fixture.OpenConnection();
 
-        List<int> ids = connection
-            .Query<int>(Select(u.Id).From(u).OrderBy(u.Id).OffsetRows(1).FetchNext(2))
-            .ToList();
+        IEnumerable<int> ids = connection
+            .Query<int>(Select(u.Id).From(u).OrderBy(u.Id).OffsetRows(1).FetchNext(2));
 
         Assert.Equal(new[] { 2, 3 }, ids);
     }

--- a/tests/SqlArtisan.IntegrationTests/Tests/OracleTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/OracleTests.cs
@@ -1,0 +1,51 @@
+using System.Data;
+using SqlArtisan.Dapper;
+using SqlArtisan.IntegrationTests.Infrastructure;
+using SqlArtisan.IntegrationTests.Schema;
+using static SqlArtisan.Sql;
+
+namespace SqlArtisan.IntegrationTests.Tests;
+
+[Trait("Engine", "Oracle")]
+public sealed class OracleTests : IntegrationTestBase, IClassFixture<OracleFixture>
+{
+    private readonly OracleFixture _fixture;
+
+    public OracleTests(OracleFixture fixture) : base(fixture) => _fixture = fixture;
+
+    [Fact]
+    public void Pagination_OffsetFetch_Executes()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        List<int> ids = connection
+            .Query<int>(Select(u.Id).From(u).OrderBy(u.Id).OffsetRows(1).FetchNext(2))
+            .ToList();
+
+        Assert.Equal(new[] { 2, 3 }, ids);
+    }
+
+    [Fact]
+    public void Merge_UpsertViaMerge_Executes()
+    {
+        UsersTable t = new("t");
+        UsersTable s = new("s");
+        UsersTable c = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        connection.Execute(
+            MergeInto(t)
+                .Using(s)
+                .On(t.Id == s.Id)
+                .WhenMatched().ThenUpdateSet(t.Name == s.Name)
+                .WhenNotMatched().ThenInsert(c.Id, c.Name).Values(s.Id, s.Name),
+            transaction);
+
+        long count = Convert.ToInt64(connection.ExecuteScalar(Select(Count(c.Id)).From(c), transaction));
+
+        Assert.Equal(5, count);
+        transaction.Rollback();
+    }
+}

--- a/tests/SqlArtisan.IntegrationTests/Tests/OracleTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/OracleTests.cs
@@ -25,6 +25,23 @@ public sealed class OracleTests : IntegrationTestBase, IClassFixture<OracleFixtu
         Assert.Equal(new[] { 2, 3 }, ids);
     }
 
+    [Fact(Skip = "Known bug #165: a re-aliased CTE column is alias-quoted at its "
+        + "definition but referenced unquoted, so Oracle folds the reference to "
+        + "uppercase and raises ORA-00904. Un-skip when #165 is fixed.")]
+    public void Cte_AliasedColumn_KnownOracleBug()
+    {
+        UsersTable u = new();
+        Cte seniors = new("seniors");
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        long count = Convert.ToInt64(connection.ExecuteScalar(
+            With(seniors.As(Select(u.Id.As(seniors.Column("id"))).From(u).Where(u.Age >= 40)))
+                .Select(Count(seniors.Column("id")))
+                .From(seniors)));
+
+        Assert.Equal(2, count);
+    }
+
     [Fact]
     public void Merge_UpsertViaMerge_Executes()
     {

--- a/tests/SqlArtisan.IntegrationTests/Tests/PostgreSqlTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/PostgreSqlTests.cs
@@ -1,0 +1,69 @@
+using System.Data;
+using SqlArtisan.Dapper;
+using SqlArtisan.IntegrationTests.Infrastructure;
+using SqlArtisan.IntegrationTests.Schema;
+using static SqlArtisan.Sql;
+
+namespace SqlArtisan.IntegrationTests.Tests;
+
+[Trait("Engine", "PostgreSql")]
+public sealed class PostgreSqlTests : IntegrationTestBase, IClassFixture<PostgreSqlFixture>
+{
+    private readonly PostgreSqlFixture _fixture;
+
+    public PostgreSqlTests(PostgreSqlFixture fixture) : base(fixture) => _fixture = fixture;
+
+    [Fact]
+    public void Pagination_LimitOffset_Executes()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        List<int> ids = connection
+            .Query<int>(Select(u.Id).From(u).OrderBy(u.Id).Limit(2).Offset(1))
+            .ToList();
+
+        Assert.Equal(new[] { 2, 3 }, ids);
+    }
+
+    [Fact]
+    public void Upsert_OnConflictDoUpdate_Executes()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        connection.Execute(
+            InsertInto(u, u.Id, u.Name)
+                .Values(1, "AliceUpdated")
+                .OnConflict(u.Id)
+                .DoUpdateSet(u.Name == Excluded(u.Name)),
+            transaction);
+
+        string name = connection
+            .Query<string>(Select(u.Name).From(u).Where(u.Id == 1), transaction)
+            .Single();
+
+        Assert.Equal("AliceUpdated", name);
+        transaction.Rollback();
+    }
+
+    [Fact]
+    public void Returning_OnInsert_ReadsBackRow()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        int id = connection
+            .Query<int>(
+                InsertInto(u, u.Id, u.Name, u.Age, u.DepartmentId)
+                    .Values(200, "New", 20, 1)
+                    .Returning(u.Id),
+                transaction)
+            .Single();
+
+        Assert.Equal(200, id);
+        transaction.Rollback();
+    }
+}

--- a/tests/SqlArtisan.IntegrationTests/Tests/PostgreSqlTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/PostgreSqlTests.cs
@@ -19,9 +19,8 @@ public sealed class PostgreSqlTests : IntegrationTestBase, IClassFixture<Postgre
         UsersTable u = new();
         using IDbConnection connection = _fixture.OpenConnection();
 
-        List<int> ids = connection
-            .Query<int>(Select(u.Id).From(u).OrderBy(u.Id).Limit(2).Offset(1))
-            .ToList();
+        IEnumerable<int> ids = connection
+            .Query<int>(Select(u.Id).From(u).OrderBy(u.Id).Limit(2).Offset(1));
 
         Assert.Equal(new[] { 2, 3 }, ids);
     }

--- a/tests/SqlArtisan.IntegrationTests/Tests/SqlServerTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/SqlServerTests.cs
@@ -19,9 +19,8 @@ public sealed class SqlServerTests : IntegrationTestBase, IClassFixture<SqlServe
         UsersTable u = new();
         using IDbConnection connection = _fixture.OpenConnection();
 
-        List<int> ids = connection
-            .Query<int>(Select(u.Id).From(u).OrderBy(u.Id).OffsetRows(1).FetchNext(2))
-            .ToList();
+        IEnumerable<int> ids = connection
+            .Query<int>(Select(u.Id).From(u).OrderBy(u.Id).OffsetRows(1).FetchNext(2));
 
         Assert.Equal(new[] { 2, 3 }, ids);
     }

--- a/tests/SqlArtisan.IntegrationTests/Tests/SqlServerTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/SqlServerTests.cs
@@ -1,0 +1,51 @@
+using System.Data;
+using SqlArtisan.Dapper;
+using SqlArtisan.IntegrationTests.Infrastructure;
+using SqlArtisan.IntegrationTests.Schema;
+using static SqlArtisan.Sql;
+
+namespace SqlArtisan.IntegrationTests.Tests;
+
+[Trait("Engine", "SqlServer")]
+public sealed class SqlServerTests : IntegrationTestBase, IClassFixture<SqlServerFixture>
+{
+    private readonly SqlServerFixture _fixture;
+
+    public SqlServerTests(SqlServerFixture fixture) : base(fixture) => _fixture = fixture;
+
+    [Fact]
+    public void Pagination_OffsetFetch_Executes()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        List<int> ids = connection
+            .Query<int>(Select(u.Id).From(u).OrderBy(u.Id).OffsetRows(1).FetchNext(2))
+            .ToList();
+
+        Assert.Equal(new[] { 2, 3 }, ids);
+    }
+
+    [Fact]
+    public void Merge_UpsertViaMerge_Executes()
+    {
+        UsersTable t = new("t");
+        UsersTable s = new("s");
+        UsersTable c = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        connection.Execute(
+            MergeInto(t)
+                .Using(s)
+                .On(t.Id == s.Id)
+                .WhenMatched().ThenUpdateSet(t.Name == s.Name)
+                .WhenNotMatched().ThenInsert(c.Id, c.Name).Values(s.Id, s.Name),
+            transaction);
+
+        long count = Convert.ToInt64(connection.ExecuteScalar(Select(Count(c.Id)).From(c), transaction));
+
+        Assert.Equal(5, count);
+        transaction.Rollback();
+    }
+}

--- a/tests/SqlArtisan.IntegrationTests/Tests/SqliteTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/SqliteTests.cs
@@ -1,0 +1,69 @@
+using System.Data;
+using SqlArtisan.Dapper;
+using SqlArtisan.IntegrationTests.Infrastructure;
+using SqlArtisan.IntegrationTests.Schema;
+using static SqlArtisan.Sql;
+
+namespace SqlArtisan.IntegrationTests.Tests;
+
+[Trait("Engine", "Sqlite")]
+public sealed class SqliteTests : IntegrationTestBase, IClassFixture<SqliteFixture>
+{
+    private readonly SqliteFixture _fixture;
+
+    public SqliteTests(SqliteFixture fixture) : base(fixture) => _fixture = fixture;
+
+    [Fact]
+    public void Pagination_LimitOffset_Executes()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        List<int> ids = connection
+            .Query<int>(Select(u.Id).From(u).OrderBy(u.Id).Limit(2).Offset(1))
+            .ToList();
+
+        Assert.Equal(new[] { 2, 3 }, ids);
+    }
+
+    [Fact]
+    public void Upsert_OnConflictDoUpdate_Executes()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        connection.Execute(
+            InsertInto(u, u.Id, u.Name)
+                .Values(1, "AliceUpdated")
+                .OnConflict(u.Id)
+                .DoUpdateSet(u.Name == Excluded(u.Name)),
+            transaction);
+
+        string name = connection
+            .Query<string>(Select(u.Name).From(u).Where(u.Id == 1), transaction)
+            .Single();
+
+        Assert.Equal("AliceUpdated", name);
+        transaction.Rollback();
+    }
+
+    [Fact]
+    public void Returning_OnInsert_ReadsBackRow()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        int id = connection
+            .Query<int>(
+                InsertInto(u, u.Id, u.Name, u.Age, u.DepartmentId)
+                    .Values(200, "New", 20, 1)
+                    .Returning(u.Id),
+                transaction)
+            .Single();
+
+        Assert.Equal(200, id);
+        transaction.Rollback();
+    }
+}

--- a/tests/SqlArtisan.IntegrationTests/Tests/SqliteTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/SqliteTests.cs
@@ -19,9 +19,8 @@ public sealed class SqliteTests : IntegrationTestBase, IClassFixture<SqliteFixtu
         UsersTable u = new();
         using IDbConnection connection = _fixture.OpenConnection();
 
-        List<int> ids = connection
-            .Query<int>(Select(u.Id).From(u).OrderBy(u.Id).Limit(2).Offset(1))
-            .ToList();
+        IEnumerable<int> ids = connection
+            .Query<int>(Select(u.Id).From(u).OrderBy(u.Id).Limit(2).Offset(1));
 
         Assert.Equal(new[] { 2, 3 }, ids);
     }


### PR DESCRIPTION
Closes #151.

Verifies SqlArtisan-built statements actually **execute** on each engine — catching grammar/semantic bugs only the database rejects (window functions, MERGE, per-dialect pagination, …) — the confidence the exact-SQL unit tests cannot give.

## What's added
- **New `tests/SqlArtisan.IntegrationTests` project.** Each test runs a builder through the `SqlArtisan.Dapper` connection extensions, exercising the full path: builder → `DbmsResolver` (dialect inferred from the connection type) → dialect → real DB. Mutating tests run inside a rolled-back transaction, so the suite is order-independent.
- **Engines:** MySQL, Oracle, PostgreSQL, SQL Server via Testcontainers; SQLite in-process.
- **Coverage:** a shared dialect-agnostic suite (`IntegrationTestBase` — SELECT/JOIN/CTE/window/GROUP BY+HAVING/aggregate/scalar/UPDATE/DELETE) plus per-engine classes for pagination, UPSERT (`ON CONFLICT` / `ON DUPLICATE KEY UPDATE` / `MERGE`), and RETURNING where the dialect supports it. An `Engine=` trait gates each lane.
- **CI:** a reusable `integration.yml` runs a per-engine matrix (`fail-fast: false`) nightly and on demand; `release.yml` calls it so the publish job is gated on a green matrix. `ci.yml` (per-PR fast loop) is unchanged — unit tests stay the inner loop, integration gates releases.

## Verification
All five engine lanes were validated green in CI on this PR (the matrix was temporarily run on `pull_request` for that; the trigger has since been removed, so the matrix now runs nightly / on demand / as a release gate).

The matrix also did its job and caught a real Oracle bug — a re-aliased CTE column referenced unquoted raises `ORA-00904` on Oracle only. Filed as **#165**; the shared CTE test now uses an Oracle-safe form, and a skipped `OracleTests.Cte_AliasedColumn_KnownOracleBug` reproduces #165 (un-skip when fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)