### PR TITLE
test: Add API function smoke catalog and edge-case coverage

### DIFF
--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/SmokeCatalog.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/SmokeCatalog.cs
@@ -56,7 +56,9 @@ internal static class SmokeCatalog
 
         // --- Numeric scalars ---
         Add("Abs", () => Scalar(Abs(-5)), All);
-        Add("Round", () => Scalar(Round(123.456, 1)), All);
+        // Round a numeric column: PostgreSQL has round(numeric, int) but not
+        // round(double, int), so a double literal would fail there.
+        Add("Round", () => Select(Round(o.Amount, 1)).From(o).Where(o.Id == 1), All);
         Add("Floor", () => Scalar(Floor(1.7)), All);
         Add("Sign", () => Scalar(Sign(-5)), All);
         Add("Ceil", () => Scalar(Ceil(1.2)), Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql, Dbms.Sqlite));
@@ -100,7 +102,9 @@ internal static class SmokeCatalog
         Add("Lead", () => Window(Lead(u.Age).Over(OrderBy(u.Id))), All);
         Add("FirstValue", () => Window(FirstValue(u.Age).Over(OrderBy(u.Id))), All);
         Add("LastValue", () => Window(LastValue(u.Age).Over(OrderBy(u.Id))), All);
-        Add("NthValue", () => Window(NthValue(u.Age, 2).Over(OrderBy(u.Id))), All);
+        // SQL Server has no NTH_VALUE.
+        Add("NthValue", () => Window(NthValue(u.Age, 2).Over(OrderBy(u.Id))),
+            Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql, Dbms.Sqlite));
         Add("PercentileCont", () => Select(PercentileCont(0.5).WithinGroup(OrderBy(u.Age))).From(u),
             Only(Dbms.Oracle, Dbms.PostgreSql));
         Add("PercentileDisc", () => Select(PercentileDisc(0.5).WithinGroup(OrderBy(u.Age))).From(u),

--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/SmokeCatalog.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/SmokeCatalog.cs
@@ -1,0 +1,111 @@
+using SqlArtisan.IntegrationTests.Schema;
+using static SqlArtisan.Sql;
+
+namespace SqlArtisan.IntegrationTests.Infrastructure;
+
+/// <summary>One catalog entry: a builder that exercises a single API construct, and the engines it is valid on.</summary>
+/// <param name="Name">Label shown in the smoke report.</param>
+/// <param name="Build">Produces the <see cref="ISqlBuilder"/> to execute (always a single-column SELECT).</param>
+/// <param name="Engines">The engines the construct's emitted SQL is expected to run on.</param>
+public sealed record SmokeCase(string Name, Func<ISqlBuilder> Build, Dbms[] Engines);
+
+/// <summary>
+/// An API-coverage catalog: each public <c>Sql.*</c> function is exercised by a
+/// single-column <c>SELECT</c> against the seeded schema, tagged with the engines
+/// whose grammar accepts it. The per-engine smoke test
+/// (<c>IntegrationTestBase.Api_FunctionSmoke</c>) runs every case valid for its
+/// engine and aggregates the failures, so one matrix run reports exactly which
+/// construct fails on which engine — surfacing "emits but won't execute" bugs
+/// (cf. #165, #168) across the whole surface at once.
+///
+/// Scope note: date/time, conversion (TO_CHAR/TO_DATE/…), regexp, and sequence
+/// functions need date columns / sequence DDL and are heavily dialect-specific;
+/// they are deferred to a follow-up. CASE and set/clause builders are covered by
+/// the dedicated tests, not here.
+/// </summary>
+internal static class SmokeCatalog
+{
+    private static readonly Dbms[] All =
+        [Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql, Dbms.Sqlite, Dbms.SqlServer];
+
+    private static Dbms[] Only(params Dbms[] engines) => engines;
+
+    public static IReadOnlyList<SmokeCase> Cases { get; } = Build();
+
+    private static List<SmokeCase> Build()
+    {
+        UsersTable u = new();
+        OrdersTable o = new();
+        List<SmokeCase> cases = [];
+
+        void Add(string name, Func<ISqlBuilder> build, Dbms[] engines) =>
+            cases.Add(new SmokeCase(name, build, engines));
+
+        // Wrap a scalar expression as `SELECT <expr> FROM users WHERE id = 1`
+        // (one row; a FROM is always present so Oracle does not need DUAL).
+        ISqlBuilder Scalar(object expr) => Select(expr).From(u).Where(u.Id == 1);
+        // Wrap a window expression as `SELECT <expr> FROM users` (all rows).
+        ISqlBuilder Window(object expr) => Select(expr).From(u);
+
+        // --- Aggregates (universal) ---
+        Add("Avg", () => Select(Avg(o.Amount)).From(o), All);
+        Add("Count", () => Select(Count(u.Id)).From(u), All);
+        Add("Max", () => Select(Max(u.Age)).From(u), All);
+        Add("Min", () => Select(Min(u.Age)).From(u), All);
+        Add("Sum", () => Select(Sum(o.Amount)).From(o), All);
+
+        // --- Numeric scalars ---
+        Add("Abs", () => Scalar(Abs(-5)), All);
+        Add("Round", () => Scalar(Round(123.456, 1)), All);
+        Add("Floor", () => Scalar(Floor(1.7)), All);
+        Add("Sign", () => Scalar(Sign(-5)), All);
+        Add("Ceil", () => Scalar(Ceil(1.2)), Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql, Dbms.Sqlite));
+        Add("Ceiling", () => Scalar(Ceiling(1.2)), Only(Dbms.MySql, Dbms.PostgreSql, Dbms.Sqlite, Dbms.SqlServer));
+        Add("Power", () => Scalar(Power(2, 3)), Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql, Dbms.SqlServer));
+        Add("Sqrt", () => Scalar(Sqrt(16)), Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql, Dbms.SqlServer));
+        Add("Mod", () => Scalar(Mod(10, 3)), Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql));
+
+        // --- String scalars ---
+        Add("Upper", () => Scalar(Upper("abc")), All);
+        Add("Lower", () => Scalar(Lower("ABC")), All);
+        Add("Trim", () => Scalar(Trim(" x ")), All);
+        Add("Ltrim", () => Scalar(Ltrim(" x")), All);
+        Add("Rtrim", () => Scalar(Rtrim("x ")), All);
+        Add("Replace", () => Scalar(Replace("abc", "b", "X")), All);
+        Add("Length", () => Scalar(Length("abc")), Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql, Dbms.Sqlite));
+        Add("Substr", () => Scalar(Substr("abcdef", 2, 3)), Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql, Dbms.Sqlite));
+        Add("Concat", () => Scalar(Concat("a", "b")), Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql, Dbms.SqlServer));
+        // SQLite has no LPAD/RPAD built-in.
+        Add("Lpad", () => Scalar(Lpad("x", 3, "0")), Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql));
+        Add("Rpad", () => Scalar(Rpad("x", 3, "0")), Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql));
+        Add("Instr", () => Scalar(Instr("abc", "b")), Only(Dbms.MySql, Dbms.Oracle, Dbms.Sqlite));
+
+        // --- Conditional / null handling ---
+        Add("Coalesce", () => Scalar(Coalesce(u.Name, "x")), All);
+        Add("Nullif", () => Scalar(Nullif(1, 2)), All);
+        Add("Cast", () => Scalar(Cast(u.Age, "DECIMAL(10,2)")), All);
+        Add("Greatest", () => Scalar(Greatest(1, 2, 3)), Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql, Dbms.SqlServer));
+        Add("Least", () => Scalar(Least(1, 2, 3)), Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql, Dbms.SqlServer));
+        Add("Nvl", () => Scalar(Nvl(u.Name, "x")), Only(Dbms.Oracle));
+        Add("Decode", () => Scalar(Decode(u.Age, (30, "thirty"), "other")), Only(Dbms.Oracle));
+
+        // --- Analytic / window (universal unless noted) ---
+        Add("Rank", () => Window(Rank().Over(OrderBy(u.Age))), All);
+        Add("DenseRank", () => Window(DenseRank().Over(OrderBy(u.Age))), All);
+        Add("RowNumber", () => Window(RowNumber().Over(OrderBy(u.Age))), All);
+        Add("PercentRank", () => Window(PercentRank().Over(OrderBy(u.Age))), All);
+        Add("CumeDist", () => Window(CumeDist().Over(OrderBy(u.Age))), All);
+        Add("Ntile", () => Window(Ntile(2).Over(OrderBy(u.Age))), All);
+        Add("Lag", () => Window(Lag(u.Age).Over(OrderBy(u.Id))), All);
+        Add("Lead", () => Window(Lead(u.Age).Over(OrderBy(u.Id))), All);
+        Add("FirstValue", () => Window(FirstValue(u.Age).Over(OrderBy(u.Id))), All);
+        Add("LastValue", () => Window(LastValue(u.Age).Over(OrderBy(u.Id))), All);
+        Add("NthValue", () => Window(NthValue(u.Age, 2).Over(OrderBy(u.Id))), All);
+        Add("PercentileCont", () => Select(PercentileCont(0.5).WithinGroup(OrderBy(u.Age))).From(u),
+            Only(Dbms.Oracle, Dbms.PostgreSql));
+        Add("PercentileDisc", () => Select(PercentileDisc(0.5).WithinGroup(OrderBy(u.Age))).From(u),
+            Only(Dbms.Oracle, Dbms.PostgreSql));
+
+        return cases;
+    }
+}

--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/SqlServerFixture.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/SqlServerFixture.cs
@@ -24,7 +24,7 @@ public sealed class SqlServerFixture : IAsyncLifetime, IDatabaseFixture
     {
         await _container.StartAsync();
         using IDbConnection connection = OpenConnection();
-        TestSchema.Apply(connection, TestSchema.StandardDdl);
+        TestSchema.Apply(connection, TestSchema.SqlServerDdl);
     }
 
     public Task DisposeAsync() => _container.DisposeAsync().AsTask();

--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/TestSchema.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/TestSchema.cs
@@ -23,6 +23,13 @@ internal static class TestSchema
         "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount DECIMAL(10,2))",
     ];
 
+    // SQL Server: NVARCHAR so Unicode text round-trips (its VARCHAR is non-Unicode).
+    public static readonly string[] SqlServerDdl =
+    [
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, name NVARCHAR(100), age INTEGER, department_id INTEGER)",
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount DECIMAL(10,2))",
+    ];
+
     // Oracle spells the same shapes NUMBER / VARCHAR2.
     public static readonly string[] OracleDdl =
     [

--- a/tests/SqlArtisan.IntegrationTests/Tests/IntegrationTestBase.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/IntegrationTestBase.cs
@@ -249,4 +249,122 @@ public abstract class IntegrationTestBase
 
         Assert.Equal(4, count);
     }
+
+    [Fact]
+    public void Api_FunctionSmoke()
+    {
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        List<string> failures = [];
+        int total = 0;
+        foreach (SmokeCase smokeCase in SmokeCatalog.Cases)
+        {
+            if (!smokeCase.Engines.Contains(_fixture.Dbms))
+            {
+                continue;
+            }
+
+            total++;
+            try
+            {
+                connection.Query<object>(smokeCase.Build()).ToList();
+            }
+            catch (Exception ex)
+            {
+                failures.Add($"{smokeCase.Name}: {ex.Message.Split('\n')[0].Trim()}");
+            }
+        }
+
+        Assert.True(
+            failures.Count == 0,
+            $"{_fixture.Dbms} function smoke: {failures.Count}/{total} failed:\n  "
+                + string.Join("\n  ", failures));
+    }
+
+    [Fact]
+    public void EdgeCase_NullValue_CoalesceReturnsFallback()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        // NULLIF(name, name) is always NULL, so COALESCE must fall through to the
+        // fallback. (Produces the NULL in SQL rather than inserting one — see #169.)
+        string value = connection
+            .Query<string>(
+                Select(Coalesce(Nullif(u.Name, u.Name), "fallback")).From(u).Where(u.Id == 1))
+            .Single();
+
+        Assert.Equal("fallback", value);
+    }
+
+    [Fact]
+    public void EdgeCase_SpecialCharacters_RoundTrip()
+    {
+        UsersTable u = new();
+        const string tricky = "O'Brien \"q\" %_\\ end";
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        connection.Execute(
+            InsertInto(u, u.Id, u.Name, u.Age, u.DepartmentId).Values(111, tricky, 20, 99),
+            transaction);
+
+        string value = connection
+            .Query<string>(Select(u.Name).From(u).Where(u.Id == 111), transaction)
+            .Single();
+
+        Assert.Equal(tricky, value);
+        transaction.Rollback();
+    }
+
+    [Fact]
+    public void EdgeCase_Unicode_RoundTrip()
+    {
+        UsersTable u = new();
+        const string unicode = "日本語café";
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        connection.Execute(
+            InsertInto(u, u.Id, u.Name, u.Age, u.DepartmentId).Values(112, unicode, 20, 99),
+            transaction);
+
+        string value = connection
+            .Query<string>(Select(u.Name).From(u).Where(u.Id == 112), transaction)
+            .Single();
+
+        Assert.Equal(unicode, value);
+        transaction.Rollback();
+    }
+
+    [Fact]
+    public void EdgeCase_EmptyResult_ReturnsNoRows()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        bool any = connection.Query<int>(Select(u.Id).From(u).Where(u.Id == -1)).Any();
+
+        Assert.False(any);
+    }
+
+    [Fact]
+    public void EdgeCase_DecimalPrecision_RoundTrip()
+    {
+        OrdersTable o = new();
+        const decimal amount = 12345.67m;
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        connection.Execute(
+            InsertInto(o, o.Id, o.UserId, o.Amount).Values(900, 1, amount),
+            transaction);
+
+        decimal value = connection
+            .Query<decimal>(Select(o.Amount).From(o).Where(o.Id == 900), transaction)
+            .Single();
+
+        Assert.Equal(amount, value);
+        transaction.Rollback();
+    }
 }

--- a/tests/SqlArtisan.IntegrationTests/Tests/SqliteTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/SqliteTests.cs
@@ -66,6 +66,26 @@ public sealed class SqliteTests : IntegrationTestBase, IClassFixture<SqliteFixtu
         transaction.Rollback();
     }
 
+    [Fact(Skip = "Known bug #169: InsertInto(...).Values(null) throws "
+        + "NullReferenceException instead of binding SQL NULL. Engine-independent "
+        + "(fails at build time). Un-skip when #169 is fixed.")]
+    public void Insert_NullValue_KnownBug()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        connection.Execute(
+            InsertInto(u, u.Id, u.Name, u.Age, u.DepartmentId).Values(110, null!, 20, 99),
+            transaction);
+
+        long nulls = Convert.ToInt64(connection.ExecuteScalar(
+            Select(Count(u.Id)).From(u).Where(u.Id == 110), transaction));
+
+        Assert.Equal(1, nulls);
+        transaction.Rollback();
+    }
+
     [Fact]
     public void StringAggregation_GroupConcat_Executes()
     {


### PR DESCRIPTION
Raises integration confidence from "representative" toward "API-exhaustive" (#151), per the goal of catching dialect bugs the unit tests can't.

## Function smoke catalog
`Infrastructure/SmokeCatalog.cs` — a data-driven catalog where each `Sql.*` function is exercised by a single-column `SELECT` against the seeded schema, tagged with the engines whose grammar accepts it. The per-engine `Api_FunctionSmoke` test runs every applicable case and **aggregates** failures, so one matrix run reports exactly which construct fails on which engine.

Covered (~36): aggregates (AVG/COUNT/MAX/MIN/SUM); numeric (ABS/ROUND/FLOOR/SIGN/CEIL/CEILING/POWER/SQRT/MOD); string (UPPER/LOWER/TRIM/LTRIM/RTRIM/REPLACE/LENGTH/SUBSTR/CONCAT/LPAD/RPAD/INSTR); conditional (COALESCE/NULLIF/CAST/GREATEST/LEAST/NVL/DECODE); analytic (RANK/DENSE_RANK/ROW_NUMBER/PERCENT_RANK/CUME_DIST/NTILE/LAG/LEAD/FIRST_VALUE/LAST_VALUE/NTH_VALUE/PERCENTILE_CONT/PERCENTILE_DISC), each tagged with supported engines.

## Edge cases (shared, all engines)
COALESCE over NULL (via `NULLIF`), special-character and Unicode round-trips through bound parameters (injection-safety), empty result set, decimal-precision round-trip.

## Bug found
`InsertInto(...).Values(null)` throws `NullReferenceException` instead of binding SQL `NULL` — filed as **#169**, parked as the skipped `SqliteTests.Insert_NullValue_KnownBug`.

## Verification
SQLite lane green locally (27 passed, 1 skipped). The four container lanes are validated by dispatching the matrix against this branch; the aggregate smoke report will surface any per-engine gaps to triage.

## Deferred (follow-up)
Date/time, conversion (`TO_CHAR`/`TO_DATE`/…), regexp, and sequence functions (need date columns / sequence DDL); `CASE` builder; broader type round-trips (date, boolean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCtjXkyJdGn3XqZCoa8gkZ)_