### PR TITLE
test: Smoke part 2 — CASE, date/time, conversion, regexp, date round-trip

### DIFF
--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/SmokeCatalog.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/SmokeCatalog.cs
@@ -110,6 +110,35 @@ internal static class SmokeCatalog
         Add("PercentileDisc", () => Select(PercentileDisc(0.5).WithinGroup(OrderBy(u.Age))).From(u),
             Only(Dbms.Oracle, Dbms.PostgreSql));
 
+        // --- CASE (universal) ---
+        Add("Case", () => Scalar(Case(When(u.Age > 30).Then("old"), Else("young"))), All);
+
+        // --- Date / time (operate on the created_at column) ---
+        Add("Extract", () => Scalar(Extract(DateTimePart.Year, u.CreatedAt)),
+            Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql));
+        Add("Datepart", () => Scalar(Datepart(DateTimePart.Year, u.CreatedAt)), Only(Dbms.SqlServer));
+        Add("Dateadd", () => Scalar(Dateadd(DateTimePart.Day, 1, u.CreatedAt)), Only(Dbms.SqlServer));
+        Add("Datediff", () => Scalar(Datediff(DateTimePart.Day, u.CreatedAt, u.CreatedAt)), Only(Dbms.SqlServer));
+        Add("DateTrunc", () => Scalar(DateTrunc(DateTimePart.Month, u.CreatedAt)), Only(Dbms.PostgreSql));
+        Add("AddMonths", () => Scalar(AddMonths(u.CreatedAt, 1)), Only(Dbms.Oracle));
+        Add("LastDay", () => Scalar(LastDay(u.CreatedAt)), Only(Dbms.MySql, Dbms.Oracle));
+        Add("MonthsBetween", () => Scalar(MonthsBetween(u.CreatedAt, u.CreatedAt)), Only(Dbms.Oracle));
+
+        // --- Conversion (Oracle / PostgreSQL) ---
+        Add("ToChar", () => Scalar(ToChar(u.Age, "999")), Only(Dbms.Oracle, Dbms.PostgreSql));
+        Add("ToNumber", () => Scalar(ToNumber("123")), Only(Dbms.Oracle, Dbms.PostgreSql));
+        Add("ToDate", () => Scalar(ToDate("2020-01-01", "YYYY-MM-DD")), Only(Dbms.Oracle, Dbms.PostgreSql));
+        Add("ToTimestamp", () => Scalar(ToTimestamp("2020-01-01 00:00:00", "YYYY-MM-DD HH24:MI:SS")),
+            Only(Dbms.Oracle, Dbms.PostgreSql));
+
+        // --- Regexp ---
+        Add("RegexpLike", () => Select(Count(u.Id)).From(u).Where(RegexpLike(u.Name, "A.*")),
+            Only(Dbms.MySql, Dbms.Oracle));
+        Add("RegexpReplace", () => Scalar(RegexpReplace(u.Name, "a", "b")),
+            Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql));
+        Add("RegexpSubstr", () => Scalar(RegexpSubstr(u.Name, "A")), Only(Dbms.MySql, Dbms.Oracle));
+        Add("RegexpCount", () => Scalar(RegexpCount(u.Name, "a")), Only(Dbms.Oracle));
+
         return cases;
     }
 }

--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/SmokeCatalog.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/SmokeCatalog.cs
@@ -126,7 +126,8 @@ internal static class SmokeCatalog
 
         // --- Conversion (Oracle / PostgreSQL) ---
         Add("ToChar", () => Scalar(ToChar(u.Age, "999")), Only(Dbms.Oracle, Dbms.PostgreSql));
-        Add("ToNumber", () => Scalar(ToNumber("123")), Only(Dbms.Oracle, Dbms.PostgreSql));
+        // PostgreSQL's to_number requires a format argument (Oracle allows one arg).
+        Add("ToNumber", () => Scalar(ToNumber("123", "999")), Only(Dbms.Oracle, Dbms.PostgreSql));
         Add("ToDate", () => Scalar(ToDate("2020-01-01", "YYYY-MM-DD")), Only(Dbms.Oracle, Dbms.PostgreSql));
         Add("ToTimestamp", () => Scalar(ToTimestamp("2020-01-01 00:00:00", "YYYY-MM-DD HH24:MI:SS")),
             Only(Dbms.Oracle, Dbms.PostgreSql));

--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/TestSchema.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/TestSchema.cs
@@ -19,21 +19,21 @@ internal static class TestSchema
     // SQLite, and SQL Server (INTEGER is a SQL Server synonym for INT).
     public static readonly string[] StandardDdl =
     [
-        "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(100), age INTEGER, department_id INTEGER)",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(100), age INTEGER, department_id INTEGER, created_at TIMESTAMP)",
         "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount DECIMAL(10,2))",
     ];
 
-    // SQL Server: NVARCHAR so Unicode text round-trips (its VARCHAR is non-Unicode).
+    // SQL Server: NVARCHAR so Unicode text round-trips (its VARCHAR is non-Unicode); DATETIME2 for the timestamp.
     public static readonly string[] SqlServerDdl =
     [
-        "CREATE TABLE users (id INTEGER PRIMARY KEY, name NVARCHAR(100), age INTEGER, department_id INTEGER)",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, name NVARCHAR(100), age INTEGER, department_id INTEGER, created_at DATETIME2)",
         "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount DECIMAL(10,2))",
     ];
 
-    // Oracle spells the same shapes NUMBER / VARCHAR2.
+    // Oracle spells the same shapes NUMBER / VARCHAR2 / DATE.
     public static readonly string[] OracleDdl =
     [
-        "CREATE TABLE users (id NUMBER(10) PRIMARY KEY, name VARCHAR2(100), age NUMBER(10), department_id NUMBER(10))",
+        "CREATE TABLE users (id NUMBER(10) PRIMARY KEY, name VARCHAR2(100), age NUMBER(10), department_id NUMBER(10), created_at DATE)",
         "CREATE TABLE orders (id NUMBER(10) PRIMARY KEY, user_id NUMBER(10), amount NUMBER(10,2))",
     ];
 
@@ -64,11 +64,12 @@ internal static class TestSchema
         }
 
         UsersTable users = new();
+        DateTime createdAt = new(2020, 3, 15, 10, 30, 0);
         foreach ((int id, string name, int age, int departmentId) in s_users)
         {
             connection.Execute(
-                InsertInto(users, users.Id, users.Name, users.Age, users.DepartmentId)
-                    .Values(id, name, age, departmentId));
+                InsertInto(users, users.Id, users.Name, users.Age, users.DepartmentId, users.CreatedAt)
+                    .Values(id, name, age, departmentId, createdAt));
         }
 
         OrdersTable orders = new();

--- a/tests/SqlArtisan.IntegrationTests/Schema/UsersTable.cs
+++ b/tests/SqlArtisan.IntegrationTests/Schema/UsersTable.cs
@@ -14,6 +14,7 @@ internal sealed class UsersTable : DbTableBase
         Name = new DbColumn(alias, "name");
         Age = new DbColumn(alias, "age");
         DepartmentId = new DbColumn(alias, "department_id");
+        CreatedAt = new DbColumn(alias, "created_at");
     }
 
     public DbColumn Id { get; }
@@ -23,4 +24,6 @@ internal sealed class UsersTable : DbTableBase
     public DbColumn Age { get; }
 
     public DbColumn DepartmentId { get; }
+
+    public DbColumn CreatedAt { get; }
 }

--- a/tests/SqlArtisan.IntegrationTests/Tests/IntegrationTestBase.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/IntegrationTestBase.cs
@@ -367,4 +367,19 @@ public abstract class IntegrationTestBase
         Assert.Equal(amount, value);
         transaction.Rollback();
     }
+
+    [Fact]
+    public void EdgeCase_DateTime_RoundTrip()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        // The seed sets every user's created_at to this value (no fractional
+        // seconds, so it round-trips on second-precision engines too).
+        DateTime value = connection
+            .Query<DateTime>(Select(u.CreatedAt).From(u).Where(u.Id == 1))
+            .Single();
+
+        Assert.Equal(new DateTime(2020, 3, 15, 10, 30, 0), value);
+    }
 }


### PR DESCRIPTION
Extends the API smoke catalog (#170) toward full coverage of the remaining function families.

## Added
- **Schema**: a `created_at` column (per-engine DDL — `TIMESTAMP` / `DATETIME2` / `DATE` — plus seed) to exercise date functions and a `DateTime` round-trip.
- **CASE** (universal): searched `CASE WHEN … THEN … ELSE … END`.
- **Date/time** (engine-tagged): `EXTRACT`, `DATEPART`, `DATEADD`, `DATEDIFF`, `DATE_TRUNC`, `ADD_MONTHS`, `LAST_DAY`, `MONTHS_BETWEEN`.
- **Conversion** (Oracle/PostgreSQL): `TO_CHAR`, `TO_NUMBER`, `TO_DATE`, `TO_TIMESTAMP`.
- **Regexp** (engine-tagged): `REGEXP_LIKE`, `REGEXP_REPLACE`, `REGEXP_SUBSTR`, `REGEXP_COUNT`.
- **Edge case**: `DateTime` round-trip (no fractional seconds, so it holds on second-precision engines).

## Verification
SQLite lane green locally (28 passed, 1 skipped). The four container lanes are validated by dispatching the matrix; the aggregate smoke report will surface any engine-marking corrections or real bugs to triage.

## Deferred (final follow-up)
Sequences (`NEXTVAL`/`CURRVAL`/`NEXT VALUE FOR` — need sequence DDL) and boolean round-trip (no portable boolean type across all five).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCtjXkyJdGn3XqZCoa8gkZ)_