### PR TITLE
test: Add sequence integration coverage (NEXTVAL / CURRVAL / NEXT VALUE FOR)

### DIFF
--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/PostgreSqlFixture.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/PostgreSqlFixture.cs
@@ -24,7 +24,7 @@ public sealed class PostgreSqlFixture : IAsyncLifetime, IDatabaseFixture
     {
         await _container.StartAsync();
         using IDbConnection connection = OpenConnection();
-        TestSchema.Apply(connection, TestSchema.StandardDdl);
+        TestSchema.Apply(connection, TestSchema.PostgreSqlDdl);
     }
 
     public Task DisposeAsync() => _container.DisposeAsync().AsTask();

--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/TestSchema.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/TestSchema.cs
@@ -17,10 +17,19 @@ internal static class TestSchema
 {
     // INTEGER / VARCHAR / DECIMAL are accepted verbatim by PostgreSQL, MySQL,
     // SQLite, and SQL Server (INTEGER is a SQL Server synonym for INT).
+    // Used by MySQL and SQLite, which have no sequences. INTEGER / VARCHAR /
+    // DECIMAL are accepted verbatim across these engines.
     public static readonly string[] StandardDdl =
     [
         "CREATE TABLE users (id INTEGER PRIMARY KEY, name VARCHAR(100), age INTEGER, department_id INTEGER, created_at TIMESTAMP)",
         "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount DECIMAL(10,2))",
+    ];
+
+    // PostgreSQL = the standard tables plus a sequence (exercised by NEXTVAL/CURRVAL).
+    public static readonly string[] PostgreSqlDdl =
+    [
+        .. StandardDdl,
+        "CREATE SEQUENCE test_seq",
     ];
 
     // SQL Server: NVARCHAR so Unicode text round-trips (its VARCHAR is non-Unicode); DATETIME2 for the timestamp.
@@ -28,6 +37,7 @@ internal static class TestSchema
     [
         "CREATE TABLE users (id INTEGER PRIMARY KEY, name NVARCHAR(100), age INTEGER, department_id INTEGER, created_at DATETIME2)",
         "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount DECIMAL(10,2))",
+        "CREATE SEQUENCE test_seq START WITH 1 INCREMENT BY 1",
     ];
 
     // Oracle spells the same shapes NUMBER / VARCHAR2 / DATE.
@@ -35,6 +45,7 @@ internal static class TestSchema
     [
         "CREATE TABLE users (id NUMBER(10) PRIMARY KEY, name VARCHAR2(100), age NUMBER(10), department_id NUMBER(10), created_at DATE)",
         "CREATE TABLE orders (id NUMBER(10) PRIMARY KEY, user_id NUMBER(10), amount NUMBER(10,2))",
+        "CREATE SEQUENCE test_seq",
     ];
 
     private static readonly (int Id, string Name, int Age, int DepartmentId)[] s_users =

--- a/tests/SqlArtisan.IntegrationTests/Tests/OracleTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/OracleTests.cs
@@ -42,6 +42,22 @@ public sealed class OracleTests : IntegrationTestBase, IClassFixture<OracleFixtu
     }
 
     [Fact]
+    public void Sequence_NextvalCurrval_Executes()
+    {
+        UsersTable u = new();
+        var seq = Sequence("test_seq");
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        // Oracle's pseudo-column form: test_seq.NEXTVAL / test_seq.CURRVAL.
+        long next = Convert.ToInt64(connection.ExecuteScalar(
+            Select(seq.Nextval).From(u).Where(u.Id == 1)));
+        long current = Convert.ToInt64(connection.ExecuteScalar(
+            Select(seq.Currval).From(u).Where(u.Id == 1)));
+
+        Assert.Equal(next, current);
+    }
+
+    [Fact]
     public void Merge_UpsertViaMerge_Executes()
     {
         UsersTable t = new("t");

--- a/tests/SqlArtisan.IntegrationTests/Tests/PostgreSqlTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/PostgreSqlTests.cs
@@ -26,6 +26,22 @@ public sealed class PostgreSqlTests : IntegrationTestBase, IClassFixture<Postgre
     }
 
     [Fact]
+    public void Sequence_NextvalCurrval_Executes()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        // One row, so NEXTVAL is called once; CURRVAL then reads it back in the
+        // same session.
+        long next = Convert.ToInt64(connection.ExecuteScalar(
+            Select(Nextval("test_seq")).From(u).Where(u.Id == 1)));
+        long current = Convert.ToInt64(connection.ExecuteScalar(
+            Select(Currval("test_seq")).From(u).Where(u.Id == 1)));
+
+        Assert.Equal(next, current);
+    }
+
+    [Fact]
     public void Upsert_OnConflictDoUpdate_Executes()
     {
         UsersTable u = new();

--- a/tests/SqlArtisan.IntegrationTests/Tests/SqlServerTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/SqlServerTests.cs
@@ -26,6 +26,18 @@ public sealed class SqlServerTests : IntegrationTestBase, IClassFixture<SqlServe
     }
 
     [Fact]
+    public void Sequence_NextValueFor_Executes()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        long next = Convert.ToInt64(connection.ExecuteScalar(
+            Select(NextValueFor("test_seq")).From(u).Where(u.Id == 1)));
+
+        Assert.True(next >= 1);
+    }
+
+    [Fact]
     public void Merge_UpsertViaMerge_Executes()
     {
         UsersTable t = new("t");


### PR DESCRIPTION
Closes a remaining integration gap: the sequence functions were untested against real engines.

## Added
- A `test_seq` sequence in the DDL of each engine that has sequences (PostgreSQL, Oracle, SQL Server).
- Per-engine sequence tests:
  - **PostgreSQL** — `NEXTVAL('test_seq')` then `CURRVAL('test_seq')` (same session), asserting they agree.
  - **Oracle** — `test_seq.NEXTVAL` / `test_seq.CURRVAL` via `Sequence("test_seq").Nextval` / `.Currval`.
  - **SQL Server** — `NEXT VALUE FOR test_seq`.

MySQL and SQLite have no sequences and are unchanged.

## Verification
SQLite lane green locally (unaffected). The three sequence engines are validated in CI via dispatch.

## Remaining gap
Boolean round-trip (the last deferred item) — handled separately due to Oracle's lack of a native boolean type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCtjXkyJdGn3XqZCoa8gkZ)_