### PR TITLE
test: Complete function smoke coverage (Exists, NotExists, Trunc, Lengthb, Substrb)

### DIFF
--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/SmokeCatalog.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/SmokeCatalog.cs
@@ -81,10 +81,17 @@ internal static class SmokeCatalog
         Add("Lpad", () => Scalar(Lpad("x", 3, "0")), Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql));
         Add("Rpad", () => Scalar(Rpad("x", 3, "0")), Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql));
         Add("Instr", () => Scalar(Instr("abc", "b")), Only(Dbms.MySql, Dbms.Oracle, Dbms.Sqlite));
+        // LENGTHB / SUBSTRB are Oracle byte-semantics builtins.
+        Add("Lengthb", () => Scalar(Lengthb("abc")), Only(Dbms.Oracle));
+        Add("Substrb", () => Scalar(Substrb("abcdef", 2)), Only(Dbms.Oracle));
+        // Numeric TRUNC: Oracle/PostgreSQL/SQLite (MySQL spells it TRUNCATE; SQL Server has no TRUNC).
+        Add("Trunc", () => Scalar(Trunc(123.456)), Only(Dbms.Oracle, Dbms.PostgreSql, Dbms.Sqlite));
 
         // --- Conditional / null handling ---
         Add("Coalesce", () => Scalar(Coalesce(u.Name, "x")), All);
         Add("Nullif", () => Scalar(Nullif(1, 2)), All);
+        Add("Exists", () => Select(Count(u.Id)).From(u).Where(Exists(Select(o.Id).From(o))), All);
+        Add("NotExists", () => Select(Count(u.Id)).From(u).Where(NotExists(Select(o.Id).From(o).Where(o.Id == -1))), All);
         Add("Cast", () => Scalar(Cast(u.Age, "DECIMAL(10,2)")), All);
         Add("Greatest", () => Scalar(Greatest(1, 2, 3)), Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql, Dbms.SqlServer));
         Add("Least", () => Scalar(Least(1, 2, 3)), Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql, Dbms.SqlServer));


### PR DESCRIPTION
Closes the **function-coverage gap (gap 1)**: the remaining value-returning `Sql.*` functions are now exercised against real engines.

## Added to the smoke catalog
- `Exists` / `NotExists` (all engines, via `WHERE EXISTS (...)`)
- `Trunc` (Oracle / PostgreSQL / SQLite — MySQL spells it `TRUNCATE`, SQL Server has no `TRUNC`)
- `Lengthb` / `Substrb` (Oracle byte-semantics builtins)

`ConditionIf` is a C#-side builder helper (returns the condition or an empty one), not a SQL construct, so it's covered by unit tests rather than DB smoke.

With this, the catalog covers the value-returning function surface; the remaining `Sql.*` factories are clause/statement builders (CTE, GROUP BY extensions, APPLY/LATERAL, FOR UPDATE, …), addressed next as statement/clause execution coverage (gap 2).

This also strengthens the function × engine support matrix that a future opt-in analyzer (#93) could seed from.

## Verification
SQLite lane green locally (smoke includes Exists/NotExists/Trunc). Full matrix validated in CI via dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCtjXkyJdGn3XqZCoa8gkZ)_