### PR TITLE
test: Execute remaining fluent builder variants against live engines

### DIFF
--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/StatementCatalog.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/StatementCatalog.cs
@@ -65,6 +65,37 @@ internal static class StatementCatalog
         // Optimizer-hint comment — a /*+ ... */ comment is accepted everywhere.
         Add("Hints", () => Select(Hints("/*+ test */"), u.Id).From(u), All);
 
+        // Explicit ascending order (the default direction made explicit).
+        Add("Asc", () => Select(u.Id).From(u).OrderBy(u.Id.Asc), All);
+
+        // FETCH FIRST n ROWS ONLY — Oracle 12c+ / PostgreSQL (SQL Server needs a
+        // preceding OFFSET, so it is covered by OffsetRows().FetchNext() instead).
+        Add("FetchFirst", () => Select(u.Id).From(u).OrderBy(u.Id).FetchFirst(2),
+            Only(Dbms.Oracle, Dbms.PostgreSql));
+
+        // Set operators with ALL — EXCEPT ALL (PostgreSQL / MySQL 8.0.31+) and
+        // Oracle's MINUS ALL.
+        Add("ExceptAll",
+            () => Select(u.DepartmentId).From(u).ExceptAll.Select(u.DepartmentId).From(u),
+            Only(Dbms.MySql, Dbms.PostgreSql));
+        Add("MinusAll",
+            () => Select(u.DepartmentId).From(u).MinusAll.Select(u.DepartmentId).From(u),
+            Only(Dbms.Oracle));
+
+        // FOR UPDATE lock-wait behaviours and FOR UPDATE OF.
+        Add("ForUpdateNowait",
+            () => Select(u.Id).From(u).Where(u.Id == 1).ForUpdate(Nowait),
+            Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql));
+        Add("ForUpdateSkipLocked",
+            () => Select(u.Id).From(u).Where(u.Id == 1).ForUpdate(SkipLocked),
+            Only(Dbms.MySql, Dbms.Oracle, Dbms.PostgreSql));
+        Add("ForUpdateWait",
+            () => Select(u.Id).From(u).Where(u.Id == 1).ForUpdate(Wait(3)),
+            Only(Dbms.Oracle));
+        Add("ForUpdateOf",
+            () => Select(u.Id).From(u).Where(u.Id == 1).ForUpdate(Of(u.Id)),
+            Only(Dbms.Oracle));
+
         // FOR UPDATE row locking — PostgreSQL / MySQL / Oracle.
         Add("ForUpdate",
             () => Select(u.Id).From(u).Where(u.Id == 1).ForUpdate(),

--- a/tests/SqlArtisan.IntegrationTests/Tests/IntegrationTestBase.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/IntegrationTestBase.cs
@@ -424,6 +424,46 @@ public abstract class IntegrationTestBase
     }
 
     [Fact]
+    public void Where_CompoundAnd_Filters()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        // age > 30 AND department_id = 10 → only Bob (40, dept 10).
+        long count = Convert.ToInt64(connection.ExecuteScalar(
+            Select(Count(u.Id)).From(u).Where(u.Age > 30 & u.DepartmentId == 10)));
+
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void Where_CompoundOr_Filters()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        // age > 45 OR department_id = 30 → Carol (50) and Eve (dept 30).
+        long count = Convert.ToInt64(connection.ExecuteScalar(
+            Select(Count(u.Id)).From(u).Where(u.Age > 45 | u.DepartmentId == 30)));
+
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public void Arithmetic_Operators_Compute()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        // Alice is 30: 30 * 3 / 2 - 1 = 44, exercising *, /, and -.
+        int value = connection
+            .Query<int>(Select(u.Age * 3 / 2 - 1).From(u).Where(u.Id == 1))
+            .Single();
+
+        Assert.Equal(44, value);
+    }
+
+    [Fact]
     public void Where_DateTimeParameter_Matches()
     {
         UsersTable u = new();

--- a/tests/SqlArtisan.IntegrationTests/Tests/OracleTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/OracleTests.cs
@@ -146,6 +146,31 @@ public sealed class OracleTests : IntegrationTestBase, IClassFixture<OracleFixtu
         transaction.Rollback();
     }
 
+    [Fact] // Oracle's in-clause DELETE WHERE: the matched rows are updated, then
+           // the just-updated rows satisfying the predicate are removed.
+    public void Merge_DeleteWhere_RemovesUpdatedRows()
+    {
+        UsersTable t = new("t");
+        UsersTable s = new("s");
+        UsersTable c = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        // Every user matches; the UPDATE's DELETE WHERE then removes the updated
+        // rows aged >= 50 (Carol), leaving four.
+        connection.Execute(
+            MergeInto(t)
+                .Using(s)
+                .On(t.Id == s.Id)
+                .WhenMatched().ThenUpdateSet(t.Name == s.Name).DeleteWhere(t.Age >= 50),
+            transaction);
+
+        long count = Convert.ToInt64(connection.ExecuteScalar(Select(Count(c.Id)).From(c), transaction));
+
+        Assert.Equal(4, count);
+        transaction.Rollback();
+    }
+
     [Fact]
     public void StringAggregation_Listagg_Executes()
     {

--- a/tests/SqlArtisan.IntegrationTests/Tests/PostgreSqlTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/PostgreSqlTests.cs
@@ -64,6 +64,26 @@ public sealed class PostgreSqlTests : IntegrationTestBase, IClassFixture<Postgre
     }
 
     [Fact]
+    public void Upsert_OnConflictDoNothing_Executes()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        // id 1 already exists; DO NOTHING leaves the original row untouched.
+        connection.Execute(
+            InsertInto(u, u.Id, u.Name).Values(1, "ShouldNotApply").OnConflict(u.Id).DoNothing(),
+            transaction);
+
+        string name = connection
+            .Query<string>(Select(u.Name).From(u).Where(u.Id == 1), transaction)
+            .Single();
+
+        Assert.Equal("Alice", name);
+        transaction.Rollback();
+    }
+
+    [Fact]
     public void Returning_OnInsert_ReadsBackRow()
     {
         UsersTable u = new();

--- a/tests/SqlArtisan.IntegrationTests/Tests/SqliteTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/SqliteTests.cs
@@ -48,6 +48,26 @@ public sealed class SqliteTests : IntegrationTestBase, IClassFixture<SqliteFixtu
     }
 
     [Fact]
+    public void Upsert_OnConflictDoNothing_Executes()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        // id 1 already exists; DO NOTHING leaves the original row untouched.
+        connection.Execute(
+            InsertInto(u, u.Id, u.Name).Values(1, "ShouldNotApply").OnConflict(u.Id).DoNothing(),
+            transaction);
+
+        string name = connection
+            .Query<string>(Select(u.Name).From(u).Where(u.Id == 1), transaction)
+            .Single();
+
+        Assert.Equal("Alice", name);
+        transaction.Rollback();
+    }
+
+    [Fact]
     public void Returning_OnInsert_ReadsBackRow()
     {
         UsersTable u = new();


### PR DESCRIPTION
## Summary

Closes the last single-construct execution gaps, found by a mechanical cross-reference of **every public builder member** against integration-test usage. These ran only in the exact-SQL unit tests, never against a live engine.

## Changes

- **Shared tests** (every engine):
  - Compound `WHERE` with `&` (AND) and `|` (OR).
  - Arithmetic operators (`*`, `/`, `-`; `+` was already covered).
- **Per-engine statement smoke** (engine-tagged):
  - Explicit `ASC` ordering.
  - `FETCH FIRST n ROWS ONLY` (Oracle / PostgreSQL).
  - `EXCEPT ALL` (PostgreSQL / MySQL) and Oracle `MINUS ALL`.
  - `FOR UPDATE` lock variants: `NOWAIT` / `SKIP LOCKED` (Oracle / PostgreSQL / MySQL), `WAIT n` and `OF column` (Oracle).
- **Engine-specific**:
  - `INSERT ... ON CONFLICT DO NOTHING` (PostgreSQL, SQLite).
  - Oracle's MERGE in-clause `DELETE WHERE`.

## Verification

- Local: SQLite lane passes (59 tests), `dotnet format` clean.
- CI integration matrix on the head commit: **all five engines green** — including the version-dependent constructs (Oracle 23 `MINUS ALL` / `WAIT`, MySQL 8.0.31+ `EXCEPT ALL`, `SKIP LOCKED`).

No product code changes — test coverage only. With this, every public construct, builder member, API entry point, and representative data-value/DML shape is exercised against a live engine at least once. The remaining gaps — exhaustive value-space coverage, engine version differences, and construct × construct combinations — are inherent and cannot be enumerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCtjXkyJdGn3XqZCoa8gkZ)_