### PR TITLE
docs: Soften README performance hook to a non-superlative claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ SqlStatement sql =
 // SELECT id, name, created_at FROM users WHERE (id > :0) AND (name LIKE :1) AND (status_id = :2)
 ```
 
-All the convenience, minimal overhead: the **lowest-allocation, fastest** builder [benchmarked](#performance). Focus on the query, not the plumbing.
+All the convenience, minimal overhead: an **allocation-light, fast** builder [benchmarked](#performance). Focus on the query, not the plumbing.
 
 ---
 


### PR DESCRIPTION
## What

Reword the Why-section hook in the README from a superlative to a non-superlative claim:

> - the **lowest-allocation, fastest** builder
> + an **allocation-light, fast** builder

## Why

- **Future-proof / honest.** "the lowest-allocation, fastest builder" is a standing superlative that could quietly go stale as other builders improve — at which point the hook becomes false. "an allocation-light, fast builder" states the property without the out-of-date risk.
- **The measured claim stays where it's backed.** The superlative wording in the **Performance** section is left as-is: it is tied to a dated, reproducible benchmark snapshot, so it reads as a statement about that measurement rather than an eternal claim.
- **Vocabulary consistency.** `allocation-light` / `fast` matches the tagline and the sanctioned hook words in `.claude/rules/docs-style.md`, so no style-guide change is needed. (`an`, not `a`, since `allocation-light` begins with a vowel sound.)

## Scope

- README hook line only (`+1 / -1`). No SQL examples affected.
- Performance section body intentionally unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)