### PR TITLE
chore: Release 0.5.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [0.5.0-beta.1] - 2026-06-30
 ### Added
 - `SqlStatement.ToString()` now returns `Text` (the parameter-marked SQL), so logging or inspecting a built statement shows the SQL instead of the type name. Parameter values are not included (they may be sensitive); read `Parameters` explicitly when you need them. (#147)
 - Added `DbTable`, an ad-hoc table reference: name a table inline (`new DbTable("users", "u")`) and read its columns by name with `Column(name)`, without declaring a typed `DbTableBase` subclass — mirroring `Cte` / `DerivedTable`. Columns are qualified by the alias (unqualified when none); usable in `SELECT` / `FROM` / `JOIN` and as an `INSERT` / `UPDATE` / `DELETE` target. (#145)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     inherit it, so a release never drifts between packages. (#118)
   -->
   <PropertyGroup>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <VersionSuffix>beta.1</VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
Prepares the `0.5.0-beta.1` release.

## What
- Bump `Directory.Build.props` `VersionPrefix` `0.4.0` → `0.5.0` (suffix stays `beta.1`).
- Finalize `CHANGELOG.md`: empty `[Unreleased]` and stamp the accumulated entries as `## [0.5.0-beta.1] - 2026-06-30`.

## Why a minor bump
The release includes a **breaking change** — `.Over()` enforcement on window/analytic functions (#150) — so under the 0.x convention the minor position is bumped (`0.4` → `0.5`). The `beta.1` suffix is kept because the 1.0 blockers (analyzer #93, API freeze #149, remaining coverage) are still open, so the API is intentionally not frozen yet.

## What ships in 0.5.0-beta.1
Highlights from the finalized changelog:
- **Added:** `SqlStatement.ToString()` returns the SQL (#147); `DbTable` ad-hoc table reference (#145); Oracle `RETURNING … INTO` typed output binding; aggregate `FILTER (WHERE ...)` (#154); PostgreSQL `DISTINCT ON` (#155).
- **Changed:** breaking `.Over()` enforcement on window/analytic functions (#150); README/`docs/` split + `llms.txt` (#143); actionable messages for incomplete expressions (#190).
- **Fixed:** `NULL` insert literal (#169); `STRING_AGG` literal separator (#168); CTE/derived-table column alias quoting on Oracle (#165).
- **Build:** Source Link, deterministic build, symbol package (#157); AOT/trim compatibility (#158).
- **Tests:** real-database integration matrix across all five engines (#151).

## Release mechanics (after merge)
Publishing is **not** part of this PR. Merging this to `main` and then pushing a `v0.5.0-beta.1` tag triggers `release.yml` (verify → integration matrix → publish to nuget.org via the `nuget` environment). The tag push is held until explicitly authorized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012NSurhtHLmhjfxrQvE34Z1)_