### PR TITLE
feat: Add scalar subquery in expression position (#156)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,6 @@ name: Integration Tests
 on:
   workflow_call:
   workflow_dispatch:
-  pull_request:
   schedule:
     # Nightly at 03:00 UTC.
     - cron: '0 3 * * *'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,6 +10,7 @@ name: Integration Tests
 on:
   workflow_call:
   workflow_dispatch:
+  pull_request:
   schedule:
     # Nightly at 03:00 UTC.
     - cron: '0 3 * * *'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Scalar subqueries in expression position: a `SELECT` builder can now be used directly as a value — in a `SELECT` list, a `WHERE` comparison, or arithmetic — without an explicit wrapper. Chain `.As("alias")` for an aliased scalar subquery. Correlated subqueries (referencing outer-table columns) work naturally. (#156)
 
 ## [0.5.0-beta.1] - 2026-06-30
 ### Added

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -236,6 +236,53 @@ SqlStatement sql =
 // AND (NOT EXISTS (SELECT "c".id FROM users "c"))
 ```
 
+### Scalar Subquery
+
+A `SELECT` builder can be used directly as a scalar value — in a `SELECT` list, a `WHERE` comparison, or arithmetic. Chain `.As("alias")` for an aliased column.
+
+```csharp
+UsersTable u = new("u");
+UsersTable s = new("s");
+
+// In a SELECT list with alias
+SqlStatement sql =
+    Select(
+        u.Name,
+        Select(Max(s.Age)).From(s).As("max_age"))
+    .From(u)
+    .Build();
+
+// SELECT "u".name, (SELECT MAX("s".age) FROM users "s") "max_age"
+// FROM users "u"
+```
+
+```csharp
+// In a WHERE comparison
+SqlStatement sql =
+    Select(u.Name)
+    .From(u)
+    .Where(u.Age > Select(Avg(s.Age)).From(s))
+    .Build();
+
+// SELECT "u".name
+// FROM users "u"
+// WHERE "u".age > (SELECT AVG("s".age) FROM users "s")
+```
+
+```csharp
+// Correlated subquery
+SqlStatement sql =
+    Select(u.Name)
+    .From(u)
+    .Where(u.Age > Select(Max(s.Age)).From(s).Where(s.Name == u.Name))
+    .Build();
+
+// SELECT "u".name
+// FROM users "u"
+// WHERE "u".age > (SELECT MAX("s".age) FROM users "s"
+// WHERE "s".name = "u".name)
+```
+
 ### Dynamic Condition
 
 SqlArtisan allows you to dynamically include or exclude conditions using a helper like `ConditionIf`. This is useful when parts of your `WHERE` clause depend on runtime logic.

--- a/llms.txt
+++ b/llms.txt
@@ -17,7 +17,7 @@ be rewritten across dialects.
 ## Reference
 
 - [Query Statements](https://raw.githubusercontent.com/h-tacayama/SqlArtisan/main/docs/query-statements.md): SELECT (clauses, JOIN, set operators, pagination, FOR UPDATE), INSERT (multi-row, SET-like, INSERT…SELECT, UPSERT, MERGE), UPDATE, DELETE, WITH/CTE, RETURNING.
-- [Expressions](https://raw.githubusercontent.com/h-tacayama/SqlArtisan/main/docs/expressions.md): NULL, arithmetic, conditions, CASE, CAST, window functions, string aggregation, sequences.
+- [Expressions](https://raw.githubusercontent.com/h-tacayama/SqlArtisan/main/docs/expressions.md): NULL, arithmetic, conditions, CASE, CAST, window functions, string aggregation, scalar subqueries, sequences.
 - [Functions](https://raw.githubusercontent.com/h-tacayama/SqlArtisan/main/docs/functions.md): Built-in function catalog — numeric, character, date/time, conversion, aggregate, string aggregation, window/analytic — plus bind-parameter types.
 
 ## Optional

--- a/src/SqlArtisan/Internal/SqlBuilder/Select/ISubquery.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Select/ISubquery.cs
@@ -6,4 +6,13 @@ namespace SqlArtisan.Internal;
 public interface ISubquery
 {
     internal void Format(SqlBuildingBuffer buffer);
+
+    /// <summary>
+    /// Aliases this subquery as a scalar expression for use in a <c>SELECT</c>
+    /// list: <c>(SELECT ...) AS "alias"</c>.
+    /// </summary>
+    /// <param name="alias">The column alias.</param>
+    /// <returns>An aliased scalar-subquery expression.</returns>
+    public ExpressionAlias As(string alias) =>
+        new(new ScalarSubquery(this), alias);
 }

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Select/SelectItemResolver.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Select/SelectItemResolver.cs
@@ -26,6 +26,10 @@ internal static class SelectItemResolver
         {
             return alias;
         }
+        else if (selectItem is ISubquery subquery)
+        {
+            return new ScalarSubquery(subquery);
+        }
         else if (IsBindable(selectItem))
         {
             return new BindValue(selectItem);

--- a/src/SqlArtisan/Internal/SqlPart/Expression/ExpressionResolver.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/ExpressionResolver.cs
@@ -53,6 +53,10 @@ internal static class ExpressionResolver
         {
             return expr;
         }
+        else if (item is ISubquery subquery)
+        {
+            return new ScalarSubquery(subquery);
+        }
         else if (IsBindable(item))
         {
             return new BindValue(item);

--- a/src/SqlArtisan/Internal/SqlPart/Expression/ScalarSubquery.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/ScalarSubquery.cs
@@ -1,0 +1,9 @@
+namespace SqlArtisan.Internal;
+
+public sealed class ScalarSubquery(ISubquery subquery) : SqlExpression
+{
+    private readonly SqlPartAgent _subquery = new(subquery.Format);
+
+    internal override void Format(SqlBuildingBuffer buffer) =>
+        buffer.EncloseInParentheses(_subquery);
+}

--- a/tests/SqlArtisan.Tests/SubqueryTests.cs
+++ b/tests/SqlArtisan.Tests/SubqueryTests.cs
@@ -141,4 +141,128 @@ public class SubqueryTests
             _t.Code.In(Select(Hints("/*+ ANY HINT */"), Distinct, _s.Code)),
             expected.ToString());
     }
+
+    [Fact]
+    public void ScalarSubquery_InSelectList_CorrectSql()
+    {
+        SqlStatement sql =
+            Select(
+                _t.Name,
+                Select(Max(_s.Code)).From(_s))
+            .From(_t)
+            .Build();
+
+        StringBuilder expected = new();
+        expected.Append("SELECT ");
+        expected.Append("\"t\".name, ");
+        expected.Append("(SELECT MAX(\"s\".code) FROM test_table \"s\") ");
+        expected.Append("FROM ");
+        expected.Append("test_table \"t\"");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
+    public void ScalarSubquery_WithAlias_CorrectSql()
+    {
+        SqlStatement sql =
+            Select(
+                _t.Name,
+                Select(Max(_s.Code)).From(_s).As("max_code"))
+            .From(_t)
+            .Build();
+
+        StringBuilder expected = new();
+        expected.Append("SELECT ");
+        expected.Append("\"t\".name, ");
+        expected.Append("(SELECT MAX(\"s\".code) FROM test_table \"s\") \"max_code\" ");
+        expected.Append("FROM ");
+        expected.Append("test_table \"t\"");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
+    public void ScalarSubquery_InWhereComparison_CorrectSql()
+    {
+        SqlStatement sql =
+            Select(_t.Name)
+            .From(_t)
+            .Where(_t.Code > Select(Avg(_s.Code)).From(_s))
+            .Build();
+
+        StringBuilder expected = new();
+        expected.Append("SELECT ");
+        expected.Append("\"t\".name ");
+        expected.Append("FROM ");
+        expected.Append("test_table \"t\" ");
+        expected.Append("WHERE ");
+        expected.Append("\"t\".code > (SELECT AVG(\"s\".code) FROM test_table \"s\")");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
+    public void ScalarSubquery_InArithmetic_CorrectSql()
+    {
+        SqlStatement sql =
+            Select(
+                (_t.Code - Select(Avg(_s.Code)).From(_s)).As("diff"))
+            .From(_t)
+            .Build();
+
+        StringBuilder expected = new();
+        expected.Append("SELECT ");
+        expected.Append("(\"t\".code - (SELECT AVG(\"s\".code) FROM test_table \"s\")) \"diff\" ");
+        expected.Append("FROM ");
+        expected.Append("test_table \"t\"");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
+    public void ScalarSubquery_Correlated_CorrectSql()
+    {
+        SqlStatement sql =
+            Select(_t.Name)
+            .From(_t)
+            .Where(_t.Code > Select(Max(_s.Code)).From(_s).Where(_s.Name == _t.Name))
+            .Build();
+
+        StringBuilder expected = new();
+        expected.Append("SELECT ");
+        expected.Append("\"t\".name ");
+        expected.Append("FROM ");
+        expected.Append("test_table \"t\" ");
+        expected.Append("WHERE ");
+        expected.Append("\"t\".code > ");
+        expected.Append("(SELECT MAX(\"s\".code) FROM test_table \"s\" ");
+        expected.Append("WHERE \"s\".name = \"t\".name)");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
+    public void ScalarSubquery_WithBindParameters_CorrectSql()
+    {
+        SqlStatement sql =
+            Select(_t.Name)
+            .From(_t)
+            .Where(_t.Code > Select(Max(_s.Code)).From(_s).Where(_s.Code > 10))
+            .Build();
+
+        StringBuilder expected = new();
+        expected.Append("SELECT ");
+        expected.Append("\"t\".name ");
+        expected.Append("FROM ");
+        expected.Append("test_table \"t\" ");
+        expected.Append("WHERE ");
+        expected.Append("\"t\".code > ");
+        expected.Append("(SELECT MAX(\"s\".code) FROM test_table \"s\" ");
+        expected.Append("WHERE \"s\".code > :0)");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+        Assert.Equal(1, sql.Parameters.Count);
+        Assert.Equal(10, sql.Parameters.Get<object>(":0"));
+    }
 }


### PR DESCRIPTION
## Summary

- Add `ScalarSubquery` class that wraps `ISubquery` as a `SqlExpression`, enabling SELECT builders to be used directly as scalar values in SELECT lists, WHERE comparisons, and arithmetic expressions
- Auto-wrap `ISubquery` in `ExpressionResolver` and `SelectItemResolver` so `Select(...)` works naturally without explicit conversion
- Add `.As(string)` default interface method on `ISubquery` for aliased scalar subqueries in SELECT lists

## Test plan

- [x] 6 new unit tests in `SubqueryTests.cs` (SELECT list, alias, WHERE comparison, arithmetic, correlated, bind parameters)
- [x] SQLite integration tests pass locally (62/62)
- [x] CI integration tests: PostgreSQL, SQL Server, Oracle, SQLite all green
- [ ] CI integration tests on this PR (pull_request trigger added temporarily — remove before merge)

Closes #156
