### PR TITLE
style: Use bodyless declaration for empty ArithmeticOperator subclasses (#204)

### DIFF
--- a/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/AdditionOperator.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/AdditionOperator.cs
@@ -3,6 +3,4 @@ namespace SqlArtisan.Internal;
 public sealed class AdditionOperator(
     SqlExpression leftSide,
     SqlExpression rightSide) :
-    ArithmeticOperator(leftSide, Operators.Plus, rightSide)
-{
-}
+    ArithmeticOperator(leftSide, Operators.Plus, rightSide);

--- a/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/DivisionOperator.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/DivisionOperator.cs
@@ -3,6 +3,4 @@ namespace SqlArtisan.Internal;
 public sealed class DivisionOperator(
     SqlExpression leftSide,
     SqlExpression rightSide) :
-    ArithmeticOperator(leftSide, Operators.Slash, rightSide)
-{
-}
+    ArithmeticOperator(leftSide, Operators.Slash, rightSide);

--- a/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/ModulusOperator.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/ModulusOperator.cs
@@ -3,6 +3,4 @@ namespace SqlArtisan.Internal;
 public sealed class ModulusOperator(
     SqlExpression leftSide,
     SqlExpression rightSide) :
-    ArithmeticOperator(leftSide, Operators.Percent, rightSide)
-{
-}
+    ArithmeticOperator(leftSide, Operators.Percent, rightSide);

--- a/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/MultiplicationOperator.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/MultiplicationOperator.cs
@@ -3,6 +3,4 @@ namespace SqlArtisan.Internal;
 public sealed class MultiplicationOperator(
     SqlExpression leftSide,
     SqlExpression rightSide) :
-    ArithmeticOperator(leftSide, Operators.Asterisk, rightSide)
-{
-}
+    ArithmeticOperator(leftSide, Operators.Asterisk, rightSide);

--- a/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/SubtractionOperator.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/SubtractionOperator.cs
@@ -3,6 +3,4 @@ namespace SqlArtisan.Internal;
 public sealed class SubtractionOperator(
     SqlExpression leftSide,
     SqlExpression rightSide) :
-    ArithmeticOperator(leftSide, Operators.Minus, rightSide)
-{
-}
+    ArithmeticOperator(leftSide, Operators.Minus, rightSide);


### PR DESCRIPTION
## Summary

Replace the empty `{ }` body with a `;` (C# 12 primary-constructor bodyless form) on the five concrete arithmetic operator classes, matching the JSON operator classes shipped in #152.

- `AdditionOperator`
- `SubtractionOperator`
- `MultiplicationOperator`
- `DivisionOperator`
- `ModulusOperator`

Each only forwards to the `ArithmeticOperator` base constructor and has no members, so the bodyless form is equivalent (identical IL) and removes the empty braces.

Closes #204

## Out of scope

Empty marker / narrowing interfaces (`IInsertBuilderSet`, etc.) have no primary constructor, so the `;` form does not apply to them.

## Test plan

- [x] `dotnet build src/SqlArtisan/SqlArtisan.csproj -c Release` — 0 warnings
- [x] `dotnet test tests/SqlArtisan.Tests` — 517/517 pass
- [x] `dotnet format --verify-no-changes` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5ZxeCUZfXxgxHXhSNs2za

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5ZxeCUZfXxgxHXhSNs2za)_