### PR TITLE
refactor: Decompose the remaining compound keyword constants and gate the rule (#208)

### DIFF
--- a/.claude/rules/sql-building-style.md
+++ b/.claude/rules/sql-building-style.md
@@ -14,7 +14,8 @@ Rules for `Format` implementations and `Keywords.cs` (#207 / #208):
    atoms** — `$"{Keywords.Group} {Keywords.By}"` — which the compiler folds
    into a single string constant (zero runtime cost). Edge spaces inside such
    const interpolations are fine: `$"{Keywords.Where} "`, `$" {Keywords.End}"`.
-   (Four legacy compound constants are being decomposed in #208.)
+   The one-token rule is CI-enforced by `KeywordsTests` (a constant value
+   containing a space fails the unit suite).
 
 2. **Helpers cover what a const interpolation cannot.** Use them for spacing
    that involves a `SqlPart`, a runtime value, or a condition — do not

--- a/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/SqlBuildingBuffer.cs
@@ -113,7 +113,7 @@ internal sealed class SqlBuildingBuffer : IDisposable
     // Emitted faithfully on every dialect; where GROUPING SETS is unavailable
     // (MySQL, SQLite) that is the analyzer's concern (ADR 0003), not Build's.
     internal SqlBuildingBuffer AppendGroupingSets(SqlPart[] sets) =>
-        Append(Keywords.GroupingSets)
+        Append($"{Keywords.Grouping} {Keywords.Sets}")
             .OpenParenthesis()
             .AppendCsv(sets)
             .CloseParenthesis();

--- a/src/SqlArtisan/Internal/SqlPart/Clause/WithinGroup/WithinGroupClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/WithinGroup/WithinGroupClause.cs
@@ -13,7 +13,7 @@ public sealed class WithinGroupClause : SqlPart
     }
 
     internal override void Format(SqlBuildingBuffer buffer) => buffer
-        .Append(Keywords.WithinGroup)
+        .Append($"{Keywords.Within} {Keywords.Group}")
         .AppendSpace()
         .OpenParenthesis()
         .Append(_orderByClause)

--- a/src/SqlArtisan/Internal/SqlPart/Keywords.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Keywords.cs
@@ -66,7 +66,7 @@ internal static class Keywords
     internal const string Greatest = "GREATEST";
     internal const string Group = "GROUP";
     internal const string GroupConcat = "GROUP_CONCAT";
-    internal const string GroupingSets = "GROUPING SETS";
+    internal const string Grouping = "GROUPING";
     internal const string Having = "HAVING";
     internal const string In = "IN";
     internal const string Inner = "INNER";
@@ -82,6 +82,7 @@ internal static class Keywords
     internal const string Key = "KEY";
     internal const string Lag = "LAG";
     internal const string Language = "LANGUAGE";
+    internal const string Last = "LAST";
     internal const string LastDay = "LAST_DAY";
     internal const string LastValue = "LAST_VALUE";
     internal const string Lateral = "LATERAL";
@@ -116,8 +117,7 @@ internal static class Keywords
     internal const string Ntile = "NTILE";
     internal const string Null = "NULL";
     internal const string Nullif = "NULLIF";
-    internal const string NullsFirst = "NULLS FIRST";
-    internal const string NullsLast = "NULLS LAST";
+    internal const string Nulls = "NULLS";
     internal const string Nvl = "NVL";
     internal const string Of = "OF";
     internal const string Offset = "OFFSET";
@@ -156,6 +156,7 @@ internal static class Keywords
     internal const string Select = "SELECT";
     internal const string Separator = "SEPARATOR";
     internal const string Set = "SET";
+    internal const string Sets = "SETS";
     internal const string Sign = "SIGN";
     internal const string Skip = "SKIP";
     internal const string Some = "SOME";
@@ -189,5 +190,5 @@ internal static class Keywords
     internal const string When = "WHEN";
     internal const string Where = "WHERE";
     internal const string With = "WITH";
-    internal const string WithinGroup = "WITHIN GROUP";
+    internal const string Within = "WITHIN";
 }

--- a/src/SqlArtisan/Internal/SqlPart/SortOrder/SortOrder.cs
+++ b/src/SqlArtisan/Internal/SqlPart/SortOrder/SortOrder.cs
@@ -56,10 +56,10 @@ public sealed class SortOrder : SqlPart
         switch (_nullOrdering)
         {
             case NullOrdering.NullsFirst:
-                buffer.Append($" {Keywords.NullsFirst}");
+                buffer.Append($" {Keywords.Nulls} {Keywords.First}");
                 break;
             case NullOrdering.NullsLast:
-                buffer.Append($" {Keywords.NullsLast}");
+                buffer.Append($" {Keywords.Nulls} {Keywords.Last}");
                 break;
         }
     }

--- a/tests/SqlArtisan.Tests/KeywordsTests.cs
+++ b/tests/SqlArtisan.Tests/KeywordsTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+
+namespace SqlArtisan.Tests;
+
+// Keywords.cs holds exactly one SQL lexical token per constant; a multi-word
+// phrase is composed at its use site by const interpolation of atoms
+// (.claude/rules/sql-building-style.md, #208). This gate keeps the rule
+// mechanical instead of remembered, like the BOM gate (#134).
+public class KeywordsTests
+{
+    [Fact]
+    public void Keywords_EveryConstant_IsSingleToken()
+    {
+        Type keywords = typeof(Dbms).Assembly.GetType("SqlArtisan.Internal.Keywords")!;
+        FieldInfo[] constants = keywords.GetFields(BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotEmpty(constants);
+
+        foreach (FieldInfo constant in constants)
+        {
+            string value = (string)constant.GetRawConstantValue()!;
+
+            Assert.False(
+                value.Contains(' '),
+                $"Keywords.{constant.Name} = \"{value}\" contains a space. One SQL token per constant — compose the phrase at the use site with const interpolation.");
+        }
+    }
+}


### PR DESCRIPTION
Closes #208.

Finishes the one-token-per-constant rule for `Keywords.cs`: the four remaining multi-word constants are decomposed into single-token atoms, and a test gate makes the rule mechanical instead of remembered.

## Decomposition

| Removed compound | Use site now composes |
|---|---|
| `NullsFirst` / `NullsLast` | `$" {Keywords.Nulls} {Keywords.First}"` / `{Keywords.Last}` (`SortOrder`) |
| `WithinGroup` | `$"{Keywords.Within} {Keywords.Group}"` (`WithinGroupClause`) |
| `GroupingSets` | `$"{Keywords.Grouping} {Keywords.Sets}"` (`SqlBuildingBuffer.AppendGroupingSets`) |

New atoms `Grouping`, `Last`, `Nulls`, `Sets`, `Within` slot in alphabetically. The compositions are const interpolations, folded at compile time — zero runtime cost, and the emitted SQL is unchanged (the exact-SQL suite passes with zero expected-string edits).

## Guard test

`KeywordsTests.Keywords_EveryConstant_IsSingleToken` reflects over every `Keywords` constant and fails if any value contains a space — so the rule is CI-enforced permanently, in the same spirit as the BOM gate (#134). **Negative-verified**: temporarily introducing a spaced constant fails the suite with an actionable message:

> `Keywords.BadPhrase = "A B" contains a space. One SQL token per constant — compose the phrase at the use site with const interpolation.`

## Rule text

`.claude/rules/sql-building-style.md` replaces its "four legacy compounds pending (#208)" note with a citation of the gate; the `sa-add-sql-function` skill's Keyword step already states the rule (landed with #211).

## Verification

- 538 unit tests pass (537 exact-SQL, unchanged, + the new gate); `dotnet format` clean.
- No CHANGELOG entry — internal constants only, no user-visible change (as scoped in #208).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SYtaXqxjqntaqCdbFNiF5

---
_Generated by [Claude Code](https://claude.ai/code/session_018SYtaXqxjqntaqCdbFNiF5)_