### PR TITLE
docs: Add the missing Expressions index links and gate the index (#210)

### DIFF
--- a/.claude/rules/docs-style.md
+++ b/.claude/rules/docs-style.md
@@ -47,3 +47,7 @@ the absolute-URL rule, and the DBMS enum order also live in CLAUDE.md.
   DBMS in enum order.
 - README→docs and docs↔docs links are absolute GitHub `blob/main` URLs;
   `llms.txt` uses `raw.githubusercontent.com` URLs; in-page anchors stay relative.
+- Adding/renaming/moving a `## ` section in `docs/expressions.md` or
+  `docs/functions.md` must update `docs/README.md`'s index **in page order**
+  (and usually the README capability map and `llms.txt`). `DocsIndexTests`
+  fails the unit suite when an index link is missing (#210).

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,9 +43,12 @@ Values, predicates, and computed expressions.
 [Conditions](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/expressions.md#conditions) ·
 [JSON Operators](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/expressions.md#json-operators) ·
 [Full-Text Search](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/expressions.md#full-text-search) ·
+[Scalar Subquery](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/expressions.md#scalar-subquery) ·
+[ALL / ANY / SOME](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/expressions.md#all--any--some) ·
 [CASE](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/expressions.md#case-expressions) ·
 [CAST](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/expressions.md#cast) ·
 [Window Functions](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/expressions.md#window-functions) ·
+[Conditional Aggregation](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/expressions.md#conditional-aggregation-filter) ·
 [String Aggregation](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/expressions.md#string-aggregation) ·
 [Sequence](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/expressions.md#sequence)
 

--- a/tests/SqlArtisan.Tests/DocsIndexTests.cs
+++ b/tests/SqlArtisan.Tests/DocsIndexTests.cs
@@ -1,0 +1,88 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace SqlArtisan.Tests;
+
+// docs/README.md (the reference home) indexes each reference page's sections.
+// That index has drifted repeatedly when a feature added a section without
+// updating it (#210), so this gate compares the pages' `## ` headings against
+// the index mechanically — the same philosophy as KeywordsTests and the BOM
+// gate (#134).
+public class DocsIndexTests
+{
+    // Pages whose every `## ` section must be linked from docs/README.md.
+    // query-statements.md is excluded: its index links `### ` subsections
+    // through grouped entries, which this heading-level check cannot mirror.
+    private static readonly string[] s_indexedPages =
+    [
+        "docs/expressions.md",
+        "docs/functions.md",
+    ];
+
+    [Fact]
+    public void DocsReadme_EveryReferenceSection_IsLinked()
+    {
+        string root = FindRepoRoot();
+        string index = File.ReadAllText(Path.Combine(root, "docs", "README.md"));
+
+        foreach (string page in s_indexedPages)
+        {
+            string[] lines = File.ReadAllLines(Path.Combine(root, page));
+
+            foreach (string line in lines)
+            {
+                if (!line.StartsWith("## ", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                string heading = line[3..].Trim();
+
+                if (heading == "Contents")
+                {
+                    continue;
+                }
+
+                string anchor = $"{Path.GetFileName(page)}#{ToGitHubAnchor(heading)}";
+
+                Assert.True(
+                    index.Contains(anchor, StringComparison.Ordinal),
+                    $"docs/README.md has no link to \"{heading}\" ({anchor}) — add it to the index in page order.");
+            }
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        DirectoryInfo? dir = new(AppContext.BaseDirectory);
+
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "SqlArtisan.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+        return dir.FullName;
+    }
+
+    // GitHub's heading-to-anchor slug: lowercase, drop everything that is not a
+    // letter, digit, space, or hyphen, then turn spaces into hyphens.
+    private static string ToGitHubAnchor(string heading)
+    {
+        StringBuilder slug = new(heading.Length);
+
+        foreach (char c in heading.ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(c) || c == '-')
+            {
+                slug.Append(c);
+            }
+            else if (c == ' ')
+            {
+                slug.Append('-');
+            }
+        }
+
+        return slug.ToString();
+    }
+}


### PR DESCRIPTION
Closes #210.

## Missing links added

`docs/README.md`'s Expressions index was missing three sections that exist in `docs/expressions.md` — the index had silently drifted on at least five feature landings (two JSON gaps were already patched in passing during #206):

- **Scalar Subquery** (`#scalar-subquery`, missed by #156)
- **ALL / ANY / SOME** (`#all--any--some`, missed by #196)
- **Conditional Aggregation** (`#conditional-aggregation-filter`, missed by #154)

Added in page order with absolute GitHub `blob/main` URLs per the docs link rule.

## Drift gate: `DocsIndexTests`

The index has now drifted five times, so the fix comes with a check rather than more vigilance: `DocsIndexTests.DocsReadme_EveryReferenceSection_IsLinked` extracts every `## ` heading of `docs/expressions.md` and `docs/functions.md`, converts it with GitHub's anchor-slug rules (`ALL / ANY / SOME` → `all--any--some`), and asserts `docs/README.md` links to it — the third mechanical gate alongside `KeywordsTests` and the BOM gate (#134).

**Negative-verified**: removing a link fails the suite with an actionable message:

> `docs/README.md has no link to "Scalar Subquery" (expressions.md#scalar-subquery) — add it to the index in page order.`

`query-statements.md` is excluded by design — its index links `### ` subsections through grouped entries, which a heading-level check cannot mirror (noted in the test).

## Rule recorded

`.claude/rules/docs-style.md` gains the touchpoint: adding/renaming/moving a `## ` section in the two reference pages must update the reference-home index in page order (and usually the README capability map and `llms.txt`), with `DocsIndexTests` cited as the enforcement.

## Verification

- 539 unit tests pass (538 + the new gate); `dotnet format` clean.
- Docs-only change plus a test — no CHANGELOG entry, no integration-matrix run needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SYtaXqxjqntaqCdbFNiF5

---
_Generated by [Claude Code](https://claude.ai/code/session_018SYtaXqxjqntaqCdbFNiF5)_