### PR TITLE
style: Adopt file-scoped namespace enforcement and standard naming rules

### DIFF
--- a/.claude/skills/sa-add-sql-function/SKILL.md
+++ b/.claude/skills/sa-add-sql-function/SKILL.md
@@ -120,6 +120,9 @@ Rules:
   (`using static SqlArtisan.Internal.ExpressionResolver;` is at the top of each
   `Sql.*.cs`).
 - Return the concrete `<Name>Function` type, not `SqlExpression`.
+- Keep the signature (and expression body) on as few lines as fit within
+  **100 columns** — `Cast` / `Currval` / the JSON factories are the shape to
+  copy; wrap one parameter per line only when a line would exceed 100 (#209).
 
 ## 4. Test
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -20,6 +20,11 @@ generated_code = true
 [*.cs]
 # Encoding: UTF-8 without BOM is the standard for .cs files (#134)
 charset = utf-8
+# Line length guideline (#209): keep a member signature and its expression body
+# on as few lines as fit within 100 columns; wrap one parameter per line only
+# when a line would exceed it. Editors honor max_line_length; dotnet format
+# does not enforce it.
+max_line_length = 100
 # New line preferences
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -85,10 +85,55 @@ dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = priva
 dotnet_naming_style.camel_case_underscore_style.required_prefix = _
 dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
 
+# namespaces, types, and non-field members should be PascalCase
+dotnet_naming_rule.general_symbols_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.general_symbols_should_be_pascal_case.symbols  = general_symbols
+dotnet_naming_rule.general_symbols_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.general_symbols.applicable_kinds = namespace, class, struct, enum, property, method, event
+
+# interfaces should have an I prefix
+dotnet_naming_rule.interfaces_should_have_i_prefix.severity = suggestion
+dotnet_naming_rule.interfaces_should_have_i_prefix.symbols  = interfaces
+dotnet_naming_rule.interfaces_should_have_i_prefix.style    = interface_style
+dotnet_naming_symbols.interfaces.applicable_kinds = interface
+dotnet_naming_style.interface_style.required_prefix = I
+dotnet_naming_style.interface_style.capitalization = pascal_case
+
+# type parameters should have a T prefix
+dotnet_naming_rule.type_parameters_should_have_t_prefix.severity = suggestion
+dotnet_naming_rule.type_parameters_should_have_t_prefix.symbols  = type_parameters
+dotnet_naming_rule.type_parameters_should_have_t_prefix.style    = type_parameter_style
+dotnet_naming_symbols.type_parameters.applicable_kinds = type_parameter
+dotnet_naming_style.type_parameter_style.required_prefix = T
+dotnet_naming_style.type_parameter_style.capitalization = pascal_case
+
+# non-private static fields should be PascalCase
+# (private/internal static fields keep the s_ prefix rule above)
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols  = non_private_static_fields
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.non_private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_static_fields.required_modifiers = static
+dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities = public, protected, protected_internal
+
+# method parameters should be camelCase
+dotnet_naming_rule.method_parameters_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.method_parameters_should_be_camel_case.symbols  = method_parameters
+dotnet_naming_rule.method_parameters_should_be_camel_case.style    = camel_case_style
+dotnet_naming_symbols.method_parameters.applicable_kinds = parameter
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+# local variables should be camelCase
+dotnet_naming_rule.local_variables_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.local_variables_should_be_camel_case.symbols  = local_variables
+dotnet_naming_rule.local_variables_should_be_camel_case.style    = camel_case_style
+dotnet_naming_symbols.local_variables.applicable_kinds = local
+
 # Code style defaults
+csharp_style_namespace_declarations = file_scoped:warning
 csharp_using_directive_placement = outside_namespace:suggestion
 dotnet_sort_system_directives_first = true
-csharp_prefer_braces = true:silent
+csharp_prefer_braces = true:warning
 csharp_preserve_single_line_blocks = true:none
 csharp_preserve_single_line_statements = false:none
 csharp_prefer_static_local_function = true:suggestion

--- a/src/SqlArtisan/Internal/SqlBuilder/Select/SelectBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Select/SelectBuilder.cs
@@ -140,9 +140,7 @@ internal class SelectBuilder(params SqlPart[] rootParts) :
         return this;
     }
 
-    public ISqlBuilder ForUpdate(
-        OfClause ofClause,
-        LockBehaviorBase? lockBehavior = null)
+    public ISqlBuilder ForUpdate(OfClause ofClause, LockBehaviorBase? lockBehavior = null)
     {
         AddPart(new ForUpdateClause(ofClause, lockBehavior));
         return this;
@@ -220,8 +218,7 @@ internal class SelectBuilder(params SqlPart[] rootParts) :
         return this;
     }
 
-    public ISelectBuilderOrderBy OrderBy(
-        params object[] orderByItems)
+    public ISelectBuilderOrderBy OrderBy(params object[] orderByItems)
     {
         AddPart(OrderByClause.Parse(orderByItems));
         return this;
@@ -239,16 +236,13 @@ internal class SelectBuilder(params SqlPart[] rootParts) :
         return this;
     }
 
-    public ISelectBuilderSelect Select(
-        params object[] selectItems)
+    public ISelectBuilderSelect Select(params object[] selectItems)
     {
         AddPart(SelectClause.Parse(selectItems));
         return this;
     }
 
-    public ISelectBuilderSelect Select(
-        DistinctKeyword distinct,
-        params object[] selectItems)
+    public ISelectBuilderSelect Select(DistinctKeyword distinct, params object[] selectItems)
     {
         AddPart(
             SelectClauseWithDistinct.Parse(
@@ -258,9 +252,7 @@ internal class SelectBuilder(params SqlPart[] rootParts) :
         return this;
     }
 
-    public ISelectBuilderSelect Select(
-        DistinctOnKeyword distinctOn,
-        params object[] selectItems)
+    public ISelectBuilderSelect Select(DistinctOnKeyword distinctOn, params object[] selectItems)
     {
         AddPart(
             SelectClauseWithDistinct.Parse(
@@ -270,9 +262,7 @@ internal class SelectBuilder(params SqlPart[] rootParts) :
         return this;
     }
 
-    public ISelectBuilderSelect Select(
-        SqlHints hints,
-        params object[] selectItems)
+    public ISelectBuilderSelect Select(SqlHints hints, params object[] selectItems)
     {
         AddPart(
             SelectClauseWithHints.Parse(

--- a/src/SqlArtisan/Internal/SqlBuilder/With/WithBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/With/WithBuilder.cs
@@ -24,27 +24,14 @@ internal sealed class WithBuilder : IWithBuilderWith
             _withPart,
             new InsertIntoClause(table));
 
-    public IInsertBuilderColumns InsertInto(
-        DbTableBase table,
-        params DbColumn[] columns) =>
-        new InsertBuilder(
-            _withPart,
-            new InsertIntoClause(table, columns));
+    public IInsertBuilderColumns InsertInto(DbTableBase table, params DbColumn[] columns) =>
+        new InsertBuilder(_withPart, new InsertIntoClause(table, columns));
 
-    public ISelectBuilderSelect Select(
-        params object[] selectItems) =>
-        new SelectBuilder(
-            _withPart,
-            SelectClause.Parse(selectItems));
+    public ISelectBuilderSelect Select(params object[] selectItems) =>
+        new SelectBuilder(_withPart, SelectClause.Parse(selectItems));
 
-    public ISelectBuilderSelect Select(
-        DistinctKeyword distinct,
-        params object[] selectItems) =>
-        new SelectBuilder(
-            _withPart,
-            SelectClauseWithDistinct.Parse(
-                distinct,
-                selectItems));
+    public ISelectBuilderSelect Select(DistinctKeyword distinct, params object[] selectItems) =>
+        new SelectBuilder(_withPart, SelectClauseWithDistinct.Parse(distinct, selectItems));
 
     public ISelectBuilderSelect Select(
         DistinctOnKeyword distinctOn,
@@ -55,14 +42,8 @@ internal sealed class WithBuilder : IWithBuilderWith
                 distinctOn,
                 selectItems));
 
-    public ISelectBuilderSelect Select(
-        SqlHints hints,
-        params object[] selectItems) =>
-        new SelectBuilder(
-            _withPart,
-            SelectClauseWithHints.Parse(
-                hints,
-                selectItems));
+    public ISelectBuilderSelect Select(SqlHints hints, params object[] selectItems) =>
+        new SelectBuilder(_withPart, SelectClauseWithHints.Parse(hints, selectItems));
 
     public ISelectBuilderSelect Select(
         SqlHints hints,

--- a/src/SqlArtisan/Internal/SqlPart/Clause/ForUpdate/ForUpdateClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/ForUpdate/ForUpdateClause.cs
@@ -11,9 +11,7 @@ internal sealed class ForUpdateClause : SqlPart
         _lockBehavior = lockBehavior;
     }
 
-    internal ForUpdateClause(
-        OfClause ofClause,
-        LockBehaviorBase? lockBehavior = null)
+    internal ForUpdateClause(OfClause ofClause, LockBehaviorBase? lockBehavior = null)
     {
         _ofClause = ofClause;
         _lockBehavior = lockBehavior;

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Over/PartitionByClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Over/PartitionByClause.cs
@@ -19,7 +19,6 @@ public sealed class PartitionByClause : SqlPart
         .Append($"{Keywords.Partition} {Keywords.By} ")
         .AppendCsv(_expressions);
 
-    public PartitionByAndOrderBy OrderBy(
-        params object[] orderByItems) =>
+    public PartitionByAndOrderBy OrderBy(params object[] orderByItems) =>
         new(this, OrderByClause.Parse(orderByItems));
 }

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Select/SelectClauseWithDistinct.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Select/SelectClauseWithDistinct.cs
@@ -7,19 +7,14 @@ internal sealed class SelectClauseWithDistinct : SqlPart
     private readonly SqlPart _distinct;
     private readonly SqlPart[] _selectItems;
 
-    private SelectClauseWithDistinct(
-        SqlPart distinct,
-        SqlPart[] selectItems)
+    private SelectClauseWithDistinct(SqlPart distinct, SqlPart[] selectItems)
     {
         _distinct = distinct;
         _selectItems = selectItems;
     }
 
-    internal static SelectClauseWithDistinct Parse(
-        SqlPart distinct,
-        object[] selectItems) => new(
-            distinct,
-            SelectItemResolver.Resolve(selectItems));
+    internal static SelectClauseWithDistinct Parse(SqlPart distinct, object[] selectItems) =>
+        new(distinct, SelectItemResolver.Resolve(selectItems));
 
     internal override void Format(SqlBuildingBuffer buffer) => buffer
         .Append($"{Keywords.Select} ")

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Select/SelectClauseWithHints.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Select/SelectClauseWithHints.cs
@@ -5,19 +5,14 @@ internal sealed class SelectClauseWithHints : SqlPart
     private readonly SqlHints _hints;
     private readonly SqlPart[] _selectItems;
 
-    private SelectClauseWithHints(
-        SqlHints hints,
-        SqlPart[] selectItems)
+    private SelectClauseWithHints(SqlHints hints, SqlPart[] selectItems)
     {
         _hints = hints;
         _selectItems = selectItems;
     }
 
-    internal static SelectClauseWithHints Parse(
-        SqlHints hints,
-        object[] selectItems) => new(
-            hints,
-            SelectItemResolver.Resolve(selectItems));
+    internal static SelectClauseWithHints Parse(SqlHints hints, object[] selectItems) =>
+        new(hints, SelectItemResolver.Resolve(selectItems));
 
     internal override void Format(SqlBuildingBuffer buffer) => buffer
         .Append($"{Keywords.Select} ")

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Select/SelectClauseWithOptions.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Select/SelectClauseWithOptions.cs
@@ -7,10 +7,7 @@ internal sealed class SelectClauseWithOptions : SqlPart
     private readonly SqlPart _distinct;
     private readonly SqlPart[] _selectItems;
 
-    private SelectClauseWithOptions(
-        SqlHints hints,
-        SqlPart distinct,
-        SqlPart[] selectItems)
+    private SelectClauseWithOptions(SqlHints hints, SqlPart distinct, SqlPart[] selectItems)
     {
         _hints = hints;
         _distinct = distinct;

--- a/src/SqlArtisan/Internal/SqlPart/Condition/PatternMatchingCondition/LikeEscapeCondition.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Condition/PatternMatchingCondition/LikeEscapeCondition.cs
@@ -6,10 +6,7 @@ public sealed class LikeEscapeCondition : SqlCondition
     private readonly SqlExpression _rightSide;
     private readonly char _escapeChar;
 
-    internal LikeEscapeCondition(
-        SqlExpression leftSide,
-        SqlExpression rightSide,
-        char escapeChar)
+    internal LikeEscapeCondition(SqlExpression leftSide, SqlExpression rightSide, char escapeChar)
     {
         _leftSide = leftSide;
         _rightSide = rightSide;

--- a/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/AdditionOperator.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/AdditionOperator.cs
@@ -1,6 +1,4 @@
 namespace SqlArtisan.Internal;
 
-public sealed class AdditionOperator(
-    SqlExpression leftSide,
-    SqlExpression rightSide) :
+public sealed class AdditionOperator(SqlExpression leftSide, SqlExpression rightSide) :
     ArithmeticOperator(leftSide, Operators.Plus, rightSide);

--- a/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/DivisionOperator.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/DivisionOperator.cs
@@ -1,6 +1,4 @@
 namespace SqlArtisan.Internal;
 
-public sealed class DivisionOperator(
-    SqlExpression leftSide,
-    SqlExpression rightSide) :
+public sealed class DivisionOperator(SqlExpression leftSide, SqlExpression rightSide) :
     ArithmeticOperator(leftSide, Operators.Slash, rightSide);

--- a/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/ModulusOperator.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/ModulusOperator.cs
@@ -1,6 +1,4 @@
 namespace SqlArtisan.Internal;
 
-public sealed class ModulusOperator(
-    SqlExpression leftSide,
-    SqlExpression rightSide) :
+public sealed class ModulusOperator(SqlExpression leftSide, SqlExpression rightSide) :
     ArithmeticOperator(leftSide, Operators.Percent, rightSide);

--- a/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/MultiplicationOperator.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/MultiplicationOperator.cs
@@ -1,6 +1,4 @@
 namespace SqlArtisan.Internal;
 
-public sealed class MultiplicationOperator(
-    SqlExpression leftSide,
-    SqlExpression rightSide) :
+public sealed class MultiplicationOperator(SqlExpression leftSide, SqlExpression rightSide) :
     ArithmeticOperator(leftSide, Operators.Asterisk, rightSide);

--- a/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/SubtractionOperator.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/ArithmeticOperator/SubtractionOperator.cs
@@ -1,6 +1,4 @@
 namespace SqlArtisan.Internal;
 
-public sealed class SubtractionOperator(
-    SqlExpression leftSide,
-    SqlExpression rightSide) :
+public sealed class SubtractionOperator(SqlExpression leftSide, SqlExpression rightSide) :
     ArithmeticOperator(leftSide, Operators.Minus, rightSide);

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Case/SimpleCaseExpression/SimpleCaseExpression.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Case/SimpleCaseExpression/SimpleCaseExpression.cs
@@ -6,9 +6,7 @@ public sealed class SimpleCaseExpression : SqlExpression
     private readonly SimpleCaseWhenClause[] _whenClauses;
     private readonly CaseElseExpression? _elseClause;
 
-    internal SimpleCaseExpression(
-        SqlExpression expr,
-        SimpleCaseWhenClause[] whenClauses)
+    internal SimpleCaseExpression(SqlExpression expr, SimpleCaseWhenClause[] whenClauses)
     {
         _expr = expr;
         _whenClauses = whenClauses;

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Case/SimpleCaseExpression/SimpleCaseWhenClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Case/SimpleCaseExpression/SimpleCaseWhenClause.cs
@@ -5,9 +5,7 @@ public sealed class SimpleCaseWhenClause : SqlPart
     private readonly SimpleCaseWhenExpression _whenExpr;
     private readonly CaseThenExpression _thenExpr;
 
-    internal SimpleCaseWhenClause(
-        SimpleCaseWhenExpression whenExpr,
-        CaseThenExpression thenExpr)
+    internal SimpleCaseWhenClause(SimpleCaseWhenExpression whenExpr, CaseThenExpression thenExpr)
     {
         _whenExpr = whenExpr;
         _thenExpr = thenExpr;

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticLagFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticLagFunction.cs
@@ -20,10 +20,7 @@ public sealed class AnalyticLagFunction : AnalyticFunction
         _default = null;
     }
 
-    internal AnalyticLagFunction(
-        SqlExpression expr,
-        int offset,
-        SqlExpression @default)
+    internal AnalyticLagFunction(SqlExpression expr, int offset, SqlExpression @default)
     {
         _expr = expr;
         _offset = offset;

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticLeadFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/AnalyticLeadFunction.cs
@@ -20,10 +20,7 @@ public sealed class AnalyticLeadFunction : AnalyticFunction
         _default = null;
     }
 
-    internal AnalyticLeadFunction(
-        SqlExpression expr,
-        int offset,
-        SqlExpression @default)
+    internal AnalyticLeadFunction(SqlExpression expr, int offset, SqlExpression @default)
     {
         _expr = expr;
         _offset = offset;

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/WindowFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/AnalyticFunction/WindowFunction.cs
@@ -5,9 +5,7 @@ public sealed class WindowFunction : SqlExpression
     private readonly SqlPart _function;
     private readonly OverClause _overClause;
 
-    internal WindowFunction(
-        SqlPart function,
-        OverClause overClause)
+    internal WindowFunction(SqlPart function, OverClause overClause)
     {
         _function = function;
         _overClause = overClause;

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/CharacterFunction/ConcatFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/CharacterFunction/ConcatFunction.cs
@@ -4,10 +4,7 @@ public sealed class ConcatFunction : SqlExpression
 {
     private readonly VariadicFunctionCore _core;
 
-    internal ConcatFunction(
-        SqlExpression primary,
-        SqlExpression secondary,
-        SqlExpression[] others)
+    internal ConcatFunction(SqlExpression primary, SqlExpression secondary, SqlExpression[] others)
     {
         _core = new(Keywords.Concat, [primary, secondary, .. others]);
     }

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/CharacterFunction/LtrimFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/CharacterFunction/LtrimFunction.cs
@@ -5,9 +5,7 @@ public sealed class LtrimFunction : SqlExpression
     private readonly SqlExpression _source;
     private readonly SqlExpression? _trimChars;
 
-    internal LtrimFunction(
-        SqlExpression source,
-        SqlExpression? trimChars = null)
+    internal LtrimFunction(SqlExpression source, SqlExpression? trimChars = null)
     {
         _source = source;
         _trimChars = trimChars;

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/CharacterFunction/ReplaceFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/CharacterFunction/ReplaceFunction.cs
@@ -6,10 +6,7 @@ public sealed class ReplaceFunction : SqlExpression
     private readonly SqlExpression _search;
     private readonly SqlExpression _replacement;
 
-    internal ReplaceFunction(
-        SqlExpression source,
-        SqlExpression search,
-        SqlExpression replacement)
+    internal ReplaceFunction(SqlExpression source, SqlExpression search, SqlExpression replacement)
     {
 
         _source = source;

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/CharacterFunction/RtrimFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/CharacterFunction/RtrimFunction.cs
@@ -5,9 +5,7 @@ public sealed class RtrimFunction : SqlExpression
     private readonly SqlExpression _source;
     private readonly SqlExpression? _trimChars;
 
-    internal RtrimFunction(
-        SqlExpression source,
-        SqlExpression? trimChars = null)
+    internal RtrimFunction(SqlExpression source, SqlExpression? trimChars = null)
     {
         _source = source;
         _trimChars = trimChars;

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/CharacterFunction/TrimFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/CharacterFunction/TrimFunction.cs
@@ -5,9 +5,7 @@ public sealed class TrimFunction : SqlExpression
     private readonly SqlExpression _source;
     private readonly SqlExpression? _trimChar;
 
-    internal TrimFunction(
-        SqlExpression source,
-        SqlExpression? trimChar = null)
+    internal TrimFunction(SqlExpression source, SqlExpression? trimChar = null)
     {
         _source = source;
         _trimChar = trimChar;

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/ConversionFunction/ToCharFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/ConversionFunction/ToCharFunction.cs
@@ -5,9 +5,7 @@ public sealed class ToCharFunction : SqlExpression
     private readonly SqlExpression _expr;
     private readonly SqlExpression? _format;
 
-    internal ToCharFunction(
-        SqlExpression expr,
-        SqlExpression? format = null)
+    internal ToCharFunction(SqlExpression expr, SqlExpression? format = null)
     {
         _expr = expr;
         _format = format;

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/ConversionFunction/ToNumberFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/ConversionFunction/ToNumberFunction.cs
@@ -5,9 +5,7 @@ public sealed class ToNumberFunction : SqlExpression
     private readonly SqlExpression _expr;
     private readonly SqlExpression? _format;
 
-    internal ToNumberFunction(
-        SqlExpression expr,
-        SqlExpression? format = null)
+    internal ToNumberFunction(SqlExpression expr, SqlExpression? format = null)
     {
         _expr = expr;
         _format = format;

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/DateTimeFunction/DateaddFunction.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/DateTimeFunction/DateaddFunction.cs
@@ -6,10 +6,7 @@ public sealed class DateaddFunction : SqlExpression
     private readonly SqlExpression _number;
     private readonly SqlExpression _dateTime;
 
-    internal DateaddFunction(
-        DateTimePart datepart,
-        SqlExpression number,
-        SqlExpression dateTime)
+    internal DateaddFunction(DateTimePart datepart, SqlExpression number, SqlExpression dateTime)
     {
         _datepart = datepart;
         _number = number;

--- a/src/SqlArtisan/Internal/SqlPart/Expression/Function/VariadicFunctionCore.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/Function/VariadicFunctionCore.cs
@@ -1,8 +1,6 @@
 namespace SqlArtisan.Internal;
 
-internal sealed class VariadicFunctionCore(
-    string functionName,
-    params SqlPart?[] args)
+internal sealed class VariadicFunctionCore(string functionName, params SqlPart?[] args)
 {
     private readonly string _functionName = functionName;
     private readonly SqlPart?[] _args = args;

--- a/src/SqlArtisan/Internal/SqlPart/Expression/JsonOperator/JsonArrowOperator.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/JsonOperator/JsonArrowOperator.cs
@@ -1,6 +1,4 @@
 namespace SqlArtisan.Internal;
 
-public sealed class JsonArrowOperator(
-    SqlExpression leftSide,
-    SqlExpression rightSide) :
+public sealed class JsonArrowOperator(SqlExpression leftSide, SqlExpression rightSide) :
     JsonOperator(leftSide, Operators.JsonArrow, rightSide);

--- a/src/SqlArtisan/Internal/SqlPart/Expression/JsonOperator/JsonArrowTextOperator.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/JsonOperator/JsonArrowTextOperator.cs
@@ -1,6 +1,4 @@
 namespace SqlArtisan.Internal;
 
-public sealed class JsonArrowTextOperator(
-    SqlExpression leftSide,
-    SqlExpression rightSide) :
+public sealed class JsonArrowTextOperator(SqlExpression leftSide, SqlExpression rightSide) :
     JsonOperator(leftSide, Operators.JsonArrowText, rightSide);

--- a/src/SqlArtisan/Internal/SqlPart/Expression/JsonOperator/JsonHashArrowOperator.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/JsonOperator/JsonHashArrowOperator.cs
@@ -1,6 +1,4 @@
 namespace SqlArtisan.Internal;
 
-public sealed class JsonHashArrowOperator(
-    SqlExpression leftSide,
-    SqlExpression rightSide) :
+public sealed class JsonHashArrowOperator(SqlExpression leftSide, SqlExpression rightSide) :
     JsonOperator(leftSide, Operators.JsonHashArrow, rightSide);

--- a/src/SqlArtisan/Internal/SqlPart/Expression/JsonOperator/JsonHashArrowTextOperator.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/JsonOperator/JsonHashArrowTextOperator.cs
@@ -1,6 +1,4 @@
 namespace SqlArtisan.Internal;
 
-public sealed class JsonHashArrowTextOperator(
-    SqlExpression leftSide,
-    SqlExpression rightSide) :
+public sealed class JsonHashArrowTextOperator(SqlExpression leftSide, SqlExpression rightSide) :
     JsonOperator(leftSide, Operators.JsonHashArrowText, rightSide);

--- a/src/SqlArtisan/Internal/SqlPart/Expression/SqlExpression.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/SqlExpression.cs
@@ -42,9 +42,7 @@ public abstract class SqlExpression : SqlPart
         object rightSide) =>
         new LessThanCondition(@this, Resolve(rightSide));
 
-    public static SqlCondition operator >(
-        SqlExpression @this,
-        object rightSide) =>
+    public static SqlCondition operator >(SqlExpression @this, object rightSide) =>
         new GreaterThanCondition(@this, Resolve(rightSide));
 
     public static SqlCondition operator <=(
@@ -80,13 +78,11 @@ public abstract class SqlExpression : SqlPart
     public ExpressionAlias As(string alias) => new(this, alias);
     public ExpressionAlias As(DbColumn column) => new(this, column.Name, quoteAlias: false);
 
-    public BetweenCondition Between(
-        object rightSide1,
-        object rightSide2) => new(this, Resolve(rightSide1), Resolve(rightSide2));
+    public BetweenCondition Between(object rightSide1, object rightSide2) =>
+        new(this, Resolve(rightSide1), Resolve(rightSide2));
 
-    public NotBetweenCondition NotBetween(
-        object rightSide1,
-        object rightSide2) => new(this, Resolve(rightSide1), Resolve(rightSide2));
+    public NotBetweenCondition NotBetween(object rightSide1, object rightSide2) =>
+        new(this, Resolve(rightSide1), Resolve(rightSide2));
 
     public InCondition In(params object[] expressions) =>
         new(this, Resolve(expressions));
@@ -100,9 +96,7 @@ public abstract class SqlExpression : SqlPart
     public NotInSubqueryCondition NotIn(ISubquery subquery) =>
         new(this, subquery);
 
-    public LikeCondition Like(
-        object rightSide) => new(this, Resolve(rightSide));
+    public LikeCondition Like(object rightSide) => new(this, Resolve(rightSide));
 
-    public NotLikeCondition NotLike(
-        object rightSide) => new(this, Resolve(rightSide));
+    public NotLikeCondition NotLike(object rightSide) => new(this, Resolve(rightSide));
 }

--- a/src/SqlArtisan/Internal/SqlPart/SortOrder/SortOrder.cs
+++ b/src/SqlArtisan/Internal/SqlPart/SortOrder/SortOrder.cs
@@ -23,10 +23,7 @@ public sealed class SortOrder : SqlPart
     {
     }
 
-    internal SortOrder(
-        SqlPart exprOrAlias,
-        SortDirection direction,
-        NullOrdering nullOrdering)
+    internal SortOrder(SqlPart exprOrAlias, SortDirection direction, NullOrdering nullOrdering)
     {
         _exprOrAlias = exprOrAlias;
         _direction = direction;

--- a/src/SqlArtisan/Sql/Sql.A.cs
+++ b/src/SqlArtisan/Sql/Sql.A.cs
@@ -31,11 +31,8 @@ public static partial class Sql
     /// <param name="months">The number of months to add.</param>
     /// <returns>An <see cref="AddMonthsFunction"/> emitting
     /// <c>ADD_MONTHS(dateTime, months)</c>.</returns>
-    public static AddMonthsFunction AddMonths(
-        object dateTime,
-        object months) => new(
-            Resolve(dateTime),
-            Resolve(months));
+    public static AddMonthsFunction AddMonths(object dateTime, object months) =>
+        new(Resolve(dateTime), Resolve(months));
 
     /// <summary>
     /// The <c>ALL (subquery)</c> quantified comparison operator: the comparison must

--- a/src/SqlArtisan/Sql/Sql.C.cs
+++ b/src/SqlArtisan/Sql/Sql.C.cs
@@ -509,9 +509,7 @@ public static partial class Sql
     /// <returns><paramref name="condition"/> when <paramref name="when"/> is
     /// <see langword="true"/>; otherwise an empty <see cref="SqlCondition"/> that emits
     /// nothing.</returns>
-    public static SqlCondition ConditionIf(
-        bool when,
-        SqlCondition condition) =>
+    public static SqlCondition ConditionIf(bool when, SqlCondition condition) =>
         when ? condition : new EmptyCondition();
 
     /// <summary>

--- a/src/SqlArtisan/Sql/Sql.D.cs
+++ b/src/SqlArtisan/Sql/Sql.D.cs
@@ -23,13 +23,8 @@ public static partial class Sql
     /// shared with EXTRACT/DATEPART; only the dateparts SQL Server's <c>DATEADD</c>
     /// accepts are valid here.
     /// </remarks>
-    public static DateaddFunction Dateadd(
-        DateTimePart datepart,
-        object number,
-        object dateTime) => new(
-            datepart,
-            Resolve(number),
-            Resolve(dateTime));
+    public static DateaddFunction Dateadd(DateTimePart datepart, object number, object dateTime) =>
+        new(datepart, Resolve(number), Resolve(dateTime));
 
     /// <summary>
     /// The <c>DATEDIFF(<paramref name="datepart"/>, <paramref name="startDate"/>, <paramref name="endDate"/>)</c>
@@ -82,9 +77,8 @@ public static partial class Sql
     /// <see cref="DateTimePart"/> is a superset shared with EXTRACT/DATEPART; only
     /// the fields PostgreSQL's <c>date_trunc</c> accepts are valid here.
     /// </remarks>
-    public static DateTruncFunction DateTrunc(
-        DateTimePart datepart,
-        object source) => new(datepart, Resolve(source));
+    public static DateTruncFunction DateTrunc(DateTimePart datepart, object source) =>
+        new(datepart, Resolve(source));
 
     /// <summary>
     /// The <c>DECODE(<paramref name="expr"/>, search, result, ..., <paramref name="default"/>)</c>

--- a/src/SqlArtisan/Sql/Sql.G.cs
+++ b/src/SqlArtisan/Sql/Sql.G.cs
@@ -156,7 +156,6 @@ public static partial class Sql
     /// <c>GROUPING SETS(...)</c>.</returns>
     /// <remarks>PostgreSQL, Oracle, and SQL Server support it; MySQL and SQLite do
     /// not, where it is emitted as written for the database to reject.</remarks>
-    public static GroupingSetsGrouping GroupingSets(
-        GroupingSet set,
-        params GroupingSet[] sets) => new(set, sets);
+    public static GroupingSetsGrouping GroupingSets( GroupingSet set, params GroupingSet[] sets) =>
+        new(set, sets);
 }

--- a/src/SqlArtisan/Sql/Sql.I.cs
+++ b/src/SqlArtisan/Sql/Sql.I.cs
@@ -24,9 +24,7 @@ public static partial class Sql
     /// <param name="columns">The columns to insert into, emitted as a
     /// parenthesized list after the table.</param>
     /// <returns>An insert builder awaiting the values for the named columns.</returns>
-    public static IInsertBuilderColumns InsertInto(
-        DbTableBase table,
-        params DbColumn[] columns) =>
+    public static IInsertBuilderColumns InsertInto(DbTableBase table, params DbColumn[] columns) =>
         new InsertBuilder(new InsertIntoClause(table, columns));
 
     /// <summary>
@@ -39,23 +37,15 @@ public static partial class Sql
     /// <param name="substring">The substring to search for.</param>
     /// <returns>The INSTR construct.</returns>
     /// <remarks>Oracle syntax.</remarks>
-    public static InstrFunction Instr(
-        object source,
-        object substring) => new(
-            Resolve(source),
-            Resolve(substring));
+    public static InstrFunction Instr(object source, object substring) =>
+        new(Resolve(source), Resolve(substring));
 
     /// <inheritdoc cref="Instr(object, object)"/>
     /// <param name="source">The string to search in.</param>
     /// <param name="substring">The substring to search for.</param>
     /// <param name="position">The 1-based position at which to start searching.</param>
-    public static InstrFunction Instr(
-        object source,
-        object substring,
-        object position) => new(
-            Resolve(source),
-            Resolve(substring),
-            Resolve(position));
+    public static InstrFunction Instr(object source, object substring, object position) =>
+        new(Resolve(source), Resolve(substring), Resolve(position));
 
     /// <inheritdoc cref="Instr(object, object)"/>
     /// <param name="source">The string to search in.</param>

--- a/src/SqlArtisan/Sql/Sql.J.cs
+++ b/src/SqlArtisan/Sql/Sql.J.cs
@@ -13,9 +13,8 @@ public static partial class Sql
     /// <param name="path">The JSON path (e.g. <c>"$.name"</c>). Emitted as an
     /// inline string literal.</param>
     /// <returns>A <c>JSON_EXTRACT</c> function expression.</returns>
-    public static JsonExtractFunction JsonExtract(
-        object jsonDoc,
-        string path) => new(Resolve(jsonDoc), path);
+    public static JsonExtractFunction JsonExtract(object jsonDoc, string path) =>
+        new(Resolve(jsonDoc), path);
 
     /// <summary>
     /// The <c>(jsonExpr -&gt; key)</c> JSON operator: extracts a JSON element by
@@ -24,9 +23,8 @@ public static partial class Sql
     /// <param name="jsonExpr">The JSON expression.</param>
     /// <param name="key">The key or index to access.</param>
     /// <returns>A <c>-&gt;</c> operator expression.</returns>
-    public static JsonArrowOperator JsonArrow(
-        object jsonExpr,
-        object key) => new(Resolve(jsonExpr), Resolve(key));
+    public static JsonArrowOperator JsonArrow(object jsonExpr, object key) =>
+        new(Resolve(jsonExpr), Resolve(key));
 
     /// <summary>
     /// The <c>(jsonExpr -&gt;&gt; key)</c> JSON operator: extracts a JSON element
@@ -35,9 +33,8 @@ public static partial class Sql
     /// <param name="jsonExpr">The JSON expression.</param>
     /// <param name="key">The key or index to access.</param>
     /// <returns>A <c>-&gt;&gt;</c> operator expression.</returns>
-    public static JsonArrowTextOperator JsonArrowText(
-        object jsonExpr,
-        object key) => new(Resolve(jsonExpr), Resolve(key));
+    public static JsonArrowTextOperator JsonArrowText(object jsonExpr, object key) =>
+        new(Resolve(jsonExpr), Resolve(key));
 
     /// <summary>
     /// The <c>(jsonExpr #&gt; path)</c> JSON operator: extracts a JSON element at
@@ -46,9 +43,8 @@ public static partial class Sql
     /// <param name="jsonExpr">The JSON expression.</param>
     /// <param name="path">The path to access (e.g. <c>"{a,b}"</c>).</param>
     /// <returns>A <c>#&gt;</c> operator expression.</returns>
-    public static JsonHashArrowOperator JsonHashArrow(
-        object jsonExpr,
-        object path) => new(Resolve(jsonExpr), Resolve(path));
+    public static JsonHashArrowOperator JsonHashArrow(object jsonExpr, object path) =>
+        new(Resolve(jsonExpr), Resolve(path));
 
     /// <summary>
     /// The <c>(jsonExpr #&gt;&gt; path)</c> JSON operator: extracts a JSON element
@@ -57,9 +53,8 @@ public static partial class Sql
     /// <param name="jsonExpr">The JSON expression.</param>
     /// <param name="path">The path to access (e.g. <c>"{a,b}"</c>).</param>
     /// <returns>A <c>#&gt;&gt;</c> operator expression.</returns>
-    public static JsonHashArrowTextOperator JsonHashArrowText(
-        object jsonExpr,
-        object path) => new(Resolve(jsonExpr), Resolve(path));
+    public static JsonHashArrowTextOperator JsonHashArrowText(object jsonExpr, object path) =>
+        new(Resolve(jsonExpr), Resolve(path));
 
     /// <summary>
     /// The <c>JSON_QUERY(jsonDoc, 'path')</c> function: extracts a JSON object
@@ -70,9 +65,8 @@ public static partial class Sql
     /// <param name="path">The JSON path (e.g. <c>"$.address"</c>). Emitted as an
     /// inline string literal.</param>
     /// <returns>A <c>JSON_QUERY</c> function expression.</returns>
-    public static JsonQueryFunction JsonQuery(
-        object jsonDoc,
-        string path) => new(Resolve(jsonDoc), path);
+    public static JsonQueryFunction JsonQuery(object jsonDoc, string path) =>
+        new(Resolve(jsonDoc), path);
 
     /// <summary>
     /// The <c>JSON_VALUE(jsonDoc, 'path')</c> function: extracts a scalar value
@@ -83,7 +77,6 @@ public static partial class Sql
     /// <param name="path">The JSON path (e.g. <c>"$.name"</c>). Emitted as an
     /// inline string literal.</param>
     /// <returns>A <c>JSON_VALUE</c> function expression.</returns>
-    public static JsonValueFunction JsonValue(
-        object jsonDoc,
-        string path) => new(Resolve(jsonDoc), path);
+    public static JsonValueFunction JsonValue(object jsonDoc, string path) =>
+        new(Resolve(jsonDoc), path);
 }

--- a/src/SqlArtisan/Sql/Sql.L.cs
+++ b/src/SqlArtisan/Sql/Sql.L.cs
@@ -39,13 +39,8 @@ public static partial class Sql
     /// <returns>An <see cref="AnalyticLagFunction"/> emitting <c>LAG(expr, offset, default)</c>.</returns>
     /// <remarks>The offset is emitted as an integer literal; the default value is
     /// parameterized.</remarks>
-    public static AnalyticLagFunction Lag(
-        object expr,
-        int offset,
-        object defaultValue) => new(
-            Resolve(expr),
-            offset,
-            Resolve(defaultValue));
+    public static AnalyticLagFunction Lag(object expr, int offset, object defaultValue) =>
+        new(Resolve(expr), offset, Resolve(defaultValue));
 
     /// <summary>
     /// The <c>LAST_DAY(<paramref name="date"/>)</c> function: the date
@@ -103,13 +98,8 @@ public static partial class Sql
     /// <returns>An <see cref="AnalyticLeadFunction"/> emitting <c>LEAD(expr, offset, default)</c>.</returns>
     /// <remarks>The offset is emitted as an integer literal; the default value is
     /// parameterized.</remarks>
-    public static AnalyticLeadFunction Lead(
-        object expr,
-        int offset,
-        object defaultValue) => new(
-            Resolve(expr),
-            offset,
-            Resolve(defaultValue));
+    public static AnalyticLeadFunction Lead(object expr, int offset, object defaultValue) =>
+        new(Resolve(expr), offset, Resolve(defaultValue));
 
     /// <summary>
     /// The <c>LEAST(a, b, ...)</c> function: the smallest of its
@@ -169,23 +159,15 @@ public static partial class Sql
     /// <param name="source">The string to pad.</param>
     /// <param name="length">The target total length.</param>
     /// <returns>The LPAD construct.</returns>
-    public static LpadFunction Lpad(
-        object source,
-        object length) => new(
-            Resolve(source),
-            Resolve(length));
+    public static LpadFunction Lpad(object source, object length) =>
+        new(Resolve(source), Resolve(length));
 
     /// <inheritdoc cref="Lpad(object, object)"/>
     /// <param name="source">The string to pad.</param>
     /// <param name="length">The target total length.</param>
     /// <param name="padding">The string to pad with instead of spaces.</param>
-    public static LpadFunction Lpad(
-        object source,
-        object length,
-        object padding) => new(
-            Resolve(source),
-            Resolve(length),
-            Resolve(padding));
+    public static LpadFunction Lpad(object source, object length, object padding) =>
+        new(Resolve(source), Resolve(length), Resolve(padding));
 
     /// <summary>
     /// The <c>LTRIM(<paramref name="source"/>)</c> function: removes leading
@@ -199,9 +181,6 @@ public static partial class Sql
     /// <inheritdoc cref="Ltrim(object)"/>
     /// <param name="source">The string to trim.</param>
     /// <param name="trimChars">The set of characters to strip from the left.</param>
-    public static LtrimFunction Ltrim(
-        object source,
-        object trimChars) => new(
-            Resolve(source),
-            Resolve(trimChars));
+    public static LtrimFunction Ltrim(object source, object trimChars) =>
+        new(Resolve(source), Resolve(trimChars));
 }

--- a/src/SqlArtisan/Sql/Sql.M.cs
+++ b/src/SqlArtisan/Sql/Sql.M.cs
@@ -71,11 +71,8 @@ public static partial class Sql
     /// <param name="dividend">The number being divided.</param>
     /// <param name="divisor">The number to divide by.</param>
     /// <returns>The MOD construct.</returns>
-    public static ModFunction Mod(
-        object dividend,
-        object divisor) => new(
-            Resolve(dividend),
-            Resolve(divisor));
+    public static ModFunction Mod(object dividend, object divisor) =>
+        new(Resolve(dividend), Resolve(divisor));
 
     /// <summary>
     /// The <c>MONTHS_BETWEEN(<paramref name="date1"/>, <paramref name="date2"/>)</c>
@@ -86,9 +83,6 @@ public static partial class Sql
     /// <param name="date2">The earlier date.</param>
     /// <returns>The MONTHS_BETWEEN construct.</returns>
     /// <remarks>Oracle syntax.</remarks>
-    public static MonthsBetweenFunction MonthsBetween(
-        object date1,
-        object date2) => new(
-            Resolve(date1),
-            Resolve(date2));
+    public static MonthsBetweenFunction MonthsBetween(object date1, object date2) =>
+        new(Resolve(date1), Resolve(date2));
 }

--- a/src/SqlArtisan/Sql/Sql.N.cs
+++ b/src/SqlArtisan/Sql/Sql.N.cs
@@ -88,9 +88,8 @@ public static partial class Sql
     /// <param name="expr1">The expression returned when the two differ.</param>
     /// <param name="expr2">The expression compared against <paramref name="expr1"/>.</param>
     /// <returns>A <c>NULLIF</c> function expression.</returns>
-    public static NullifFunction Nullif(
-        object expr1,
-        object expr2) => new(Resolve(expr1), Resolve(expr2));
+    public static NullifFunction Nullif(object expr1, object expr2) =>
+        new(Resolve(expr1), Resolve(expr2));
 
     /// <summary>
     /// The <c>NVL(expr1, expr2)</c> function: returns <paramref name="expr1"/> when
@@ -101,7 +100,6 @@ public static partial class Sql
     /// <returns>An <c>NVL</c> function expression.</returns>
     /// <remarks>Oracle syntax. For the standard equivalent use
     /// <see cref="Coalesce(object, object, object[])"/>.</remarks>
-    public static NvlFunction Nvl(
-        object expr1,
-        object expr2) => new(Resolve(expr1), Resolve(expr2));
+    public static NvlFunction Nvl(object expr1, object expr2) =>
+        new(Resolve(expr1), Resolve(expr2));
 }

--- a/src/SqlArtisan/Sql/Sql.O.cs
+++ b/src/SqlArtisan/Sql/Sql.O.cs
@@ -21,7 +21,6 @@ public static partial class Sql
     /// </summary>
     /// <param name="orderByItems">The columns or expressions to order by.</param>
     /// <returns>An <c>ORDER BY</c> clause.</returns>
-    public static OrderByClause OrderBy(
-        params object[] orderByItems) =>
+    public static OrderByClause OrderBy(params object[] orderByItems) =>
         OrderByClause.Parse(orderByItems);
 }

--- a/src/SqlArtisan/Sql/Sql.P.cs
+++ b/src/SqlArtisan/Sql/Sql.P.cs
@@ -11,8 +11,8 @@ public static partial class Sql
     /// </summary>
     /// <param name="expressions">The columns or expressions to partition by.</param>
     /// <returns>A <c>PARTITION BY</c> clause.</returns>
-    public static PartitionByClause PartitionBy(
-        params object[] expressions) => new(Resolve(expressions));
+    public static PartitionByClause PartitionBy(params object[] expressions) =>
+        new(Resolve(expressions));
 
     /// <summary>
     /// The <c>PERCENTILE_CONT(fraction)</c> ordered-set aggregate (continuous
@@ -77,11 +77,8 @@ public static partial class Sql
     /// <param name="base">The base value.</param>
     /// <param name="exponent">The exponent to raise <paramref name="base"/> to.</param>
     /// <returns>A <c>POWER</c> function expression.</returns>
-    public static PowerFunction Power(
-        object @base,
-        object exponent) => new(
-            Resolve(@base),
-            Resolve(exponent));
+    public static PowerFunction Power(object @base, object exponent) =>
+        new(Resolve(@base), Resolve(exponent));
 
     /// <summary>
     /// A <c>n PRECEDING</c> window-frame bound (offset rows/range before the

--- a/src/SqlArtisan/Sql/Sql.R.cs
+++ b/src/SqlArtisan/Sql/Sql.R.cs
@@ -27,11 +27,8 @@ public static partial class Sql
     /// <param name="pattern">The regular-expression pattern.</param>
     /// <returns>A <c>REGEXP_COUNT</c> function expression.</returns>
     /// <remarks>Oracle syntax.</remarks>
-    public static RegexpCountFunction RegexpCount(
-        object source,
-        object pattern) => new(
-            Resolve(source),
-            Resolve(pattern));
+    public static RegexpCountFunction RegexpCount(object source, object pattern) =>
+        new(Resolve(source), Resolve(pattern));
 
     /// <inheritdoc cref="RegexpCount(object, object)"/>
     /// <param name="source">The string searched.</param>
@@ -69,11 +66,8 @@ public static partial class Sql
     /// <param name="pattern">The regular-expression pattern.</param>
     /// <returns>A <c>REGEXP_LIKE</c> condition.</returns>
     /// <remarks>Oracle syntax.</remarks>
-    public static RegexpLikeCondition RegexpLike(
-        object source,
-        object pattern) => new(
-            Resolve(source),
-            Resolve(pattern));
+    public static RegexpLikeCondition RegexpLike(object source, object pattern) =>
+        new(Resolve(source), Resolve(pattern));
 
     /// <inheritdoc cref="RegexpLike(object, object)"/>
     /// <param name="source">The string tested.</param>
@@ -168,13 +162,8 @@ public static partial class Sql
     /// <param name="search">The substring to find.</param>
     /// <param name="replacement">The replacement substring.</param>
     /// <returns>A <c>REPLACE</c> function expression.</returns>
-    public static ReplaceFunction Replace(
-        object source,
-        object search,
-        object replacement) => new(
-            Resolve(source),
-            Resolve(search),
-            Resolve(replacement));
+    public static ReplaceFunction Replace(object source, object search, object replacement) =>
+        new(Resolve(source), Resolve(search), Resolve(replacement));
 
     /// <summary>
     /// The <c>ROLLUP(...)</c> GROUP BY grouping extension. Each element is an
@@ -207,11 +196,8 @@ public static partial class Sql
     /// <param name="expr">The numeric expression to round.</param>
     /// <param name="decimals">The number of decimal places to round to.</param>
     /// <returns>A <c>ROUND(x, n)</c> function expression.</returns>
-    public static RoundFunction Round(
-        object expr,
-        object decimals) => new(
-            Resolve(expr),
-            Resolve(decimals));
+    public static RoundFunction Round(object expr, object decimals) =>
+        new(Resolve(expr), Resolve(decimals));
 
     /// <summary>
     /// The <c>RPAD(source, length)</c> function: right-pads <paramref name="source"/>
@@ -220,23 +206,15 @@ public static partial class Sql
     /// <param name="source">The string to pad.</param>
     /// <param name="length">The target length.</param>
     /// <returns>An <c>RPAD</c> function expression.</returns>
-    public static RpadFunction Rpad(
-        object source,
-        object length) => new(
-            Resolve(source),
-            Resolve(length));
+    public static RpadFunction Rpad(object source, object length) =>
+        new(Resolve(source), Resolve(length));
 
     /// <inheritdoc cref="Rpad(object, object)"/>
     /// <param name="source">The string to pad.</param>
     /// <param name="length">The target length.</param>
     /// <param name="padding">The padding string used instead of spaces.</param>
-    public static RpadFunction Rpad(
-        object source,
-        object length,
-        object padding) => new(
-            Resolve(source),
-            Resolve(length),
-            Resolve(padding));
+    public static RpadFunction Rpad(object source, object length, object padding) =>
+        new(Resolve(source), Resolve(length), Resolve(padding));
 
     /// <summary>
     /// The <c>RTRIM(source)</c> function: removes trailing spaces from
@@ -250,11 +228,8 @@ public static partial class Sql
     /// <inheritdoc cref="Rtrim(object)"/>
     /// <param name="source">The string to trim.</param>
     /// <param name="trimChars">The set of characters to strip instead of spaces.</param>
-    public static RtrimFunction Rtrim(
-        object source,
-        object trimChars) => new(
-            Resolve(source),
-            Resolve(trimChars));
+    public static RtrimFunction Rtrim(object source, object trimChars) =>
+        new(Resolve(source), Resolve(trimChars));
 
     /// <summary>
     /// The <c>REGEXP_SUBSTR(source, pattern)</c> function: the first substring of
@@ -264,11 +239,8 @@ public static partial class Sql
     /// <param name="pattern">The regular-expression pattern.</param>
     /// <returns>A <c>REGEXP_SUBSTR</c> function expression.</returns>
     /// <remarks>Oracle syntax.</remarks>
-    public static RegexpSubstrFunction RegexpSubstr(
-        object source,
-        object pattern) => new(
-            Resolve(source),
-            Resolve(pattern));
+    public static RegexpSubstrFunction RegexpSubstr(object source, object pattern) =>
+        new(Resolve(source), Resolve(pattern));
 
     /// <inheritdoc cref="RegexpSubstr(object, object)"/>
     /// <param name="source">The string searched.</param>

--- a/src/SqlArtisan/Sql/Sql.S.cs
+++ b/src/SqlArtisan/Sql/Sql.S.cs
@@ -24,8 +24,7 @@ public static partial class Sql
     /// </summary>
     /// <param name="selectItems">The columns or expressions to project.</param>
     /// <returns>A select builder positioned for <c>.From(...)</c>.</returns>
-    public static ISelectBuilderSelect Select(
-        params object[] selectItems) =>
+    public static ISelectBuilderSelect Select(params object[] selectItems) =>
         new SelectBuilder(SelectClause.Parse(selectItems));
 
     /// <inheritdoc cref="Select(object[])"/>
@@ -53,13 +52,8 @@ public static partial class Sql
     /// <inheritdoc cref="Select(object[])"/>
     /// <param name="hints">Optimizer hints (<see cref="Hints(string)"/>), emitted after <c>SELECT</c>.</param>
     /// <param name="selectItems">The columns or expressions to project.</param>
-    public static ISelectBuilderSelect Select(
-        SqlHints hints,
-        params object[] selectItems) =>
-        new SelectBuilder(
-            SelectClauseWithHints.Parse(
-                hints,
-                selectItems));
+    public static ISelectBuilderSelect Select(SqlHints hints, params object[] selectItems) =>
+        new SelectBuilder(SelectClauseWithHints.Parse(hints, selectItems));
 
     /// <inheritdoc cref="Select(object[])"/>
     /// <param name="hints">Optimizer hints (<see cref="Hints(string)"/>), emitted after <c>SELECT</c>.</param>
@@ -180,23 +174,15 @@ public static partial class Sql
     /// <param name="source">The string to slice.</param>
     /// <param name="position">The 1-based start position.</param>
     /// <returns>A <c>SUBSTR</c> function expression.</returns>
-    public static SubstrFunction Substr(
-        object source,
-        object position) => new(
-            Resolve(source),
-            Resolve(position));
+    public static SubstrFunction Substr(object source, object position) =>
+        new(Resolve(source), Resolve(position));
 
     /// <inheritdoc cref="Substr(object, object)"/>
     /// <param name="source">The string to slice.</param>
     /// <param name="position">The 1-based start position.</param>
     /// <param name="length">The number of characters to take.</param>
-    public static SubstrFunction Substr(
-        object source,
-        object position,
-        object length) => new(
-            Resolve(source),
-            Resolve(position),
-            Resolve(length));
+    public static SubstrFunction Substr(object source, object position, object length) =>
+        new(Resolve(source), Resolve(position), Resolve(length));
 
     /// <summary>
     /// The <c>SUBSTRB(source, position)</c> function: like <see cref="Substr(object, object)"/>
@@ -206,23 +192,15 @@ public static partial class Sql
     /// <param name="position">The 1-based start position, in bytes.</param>
     /// <returns>A <c>SUBSTRB</c> function expression.</returns>
     /// <remarks>Oracle syntax.</remarks>
-    public static SubstrbFunction Substrb(
-        object source,
-        object position) => new(
-            Resolve(source),
-            Resolve(position));
+    public static SubstrbFunction Substrb(object source, object position) =>
+        new(Resolve(source), Resolve(position));
 
     /// <inheritdoc cref="Substrb(object, object)"/>
     /// <param name="source">The string to slice.</param>
     /// <param name="position">The 1-based start position, in bytes.</param>
     /// <param name="length">The number of bytes to take.</param>
-    public static SubstrbFunction Substrb(
-        object source,
-        object position,
-        object length) => new(
-            Resolve(source),
-            Resolve(position),
-            Resolve(length));
+    public static SubstrbFunction Substrb(object source, object position, object length) =>
+        new(Resolve(source), Resolve(position), Resolve(length));
 
     /// <summary>
     /// The <c>SUM(expr)</c> aggregate: the total of <paramref name="expr"/> over the

--- a/src/SqlArtisan/Sql/Sql.T.cs
+++ b/src/SqlArtisan/Sql/Sql.T.cs
@@ -18,11 +18,8 @@ public static partial class Sql
     /// <inheritdoc cref="ToChar(object)"/>
     /// <param name="expr">The value to convert to text.</param>
     /// <param name="format">The Oracle format model controlling the output.</param>
-    public static ToCharFunction ToChar(
-        object expr,
-        object format) => new(
-            Resolve(expr),
-            Resolve(format));
+    public static ToCharFunction ToChar(object expr, object format) =>
+        new(Resolve(expr), Resolve(format));
 
     /// <summary>
     /// The <c>TO_DATE(text, format)</c> function: parses <paramref name="text"/> into
@@ -32,11 +29,8 @@ public static partial class Sql
     /// <param name="format">The Oracle format model describing <paramref name="text"/>.</param>
     /// <returns>A <c>TO_DATE</c> function expression.</returns>
     /// <remarks>Oracle syntax.</remarks>
-    public static ToDateFunction ToDate(
-        object text,
-        object format) => new(
-            Resolve(text),
-            Resolve(format));
+    public static ToDateFunction ToDate(object text, object format) =>
+        new(Resolve(text), Resolve(format));
 
     /// <summary>
     /// The <c>TO_NUMBER(expr)</c> function: converts <paramref name="expr"/> to a
@@ -51,11 +45,8 @@ public static partial class Sql
     /// <inheritdoc cref="ToNumber(object)"/>
     /// <param name="expr">The value to convert.</param>
     /// <param name="numericFormat">The Oracle numeric format model describing <paramref name="expr"/>.</param>
-    public static ToNumberFunction ToNumber(
-        object expr,
-        object numericFormat) => new(
-            Resolve(expr),
-            Resolve(numericFormat));
+    public static ToNumberFunction ToNumber(object expr, object numericFormat) =>
+        new(Resolve(expr), Resolve(numericFormat));
 
     /// <summary>
     /// The <c>TO_TIMESTAMP(text, format)</c> function: parses <paramref name="text"/>
@@ -65,11 +56,8 @@ public static partial class Sql
     /// <param name="format">The Oracle format model describing <paramref name="text"/>.</param>
     /// <returns>A <c>TO_TIMESTAMP</c> function expression.</returns>
     /// <remarks>Oracle syntax.</remarks>
-    public static ToTimestampFunction ToTimestamp(
-        object text,
-        object format) => new(
-            Resolve(text),
-            Resolve(format));
+    public static ToTimestampFunction ToTimestamp(object text, object format) =>
+        new(Resolve(text), Resolve(format));
 
     /// <summary>
     /// The PostgreSQL <c>TO_TSQUERY(text)</c> function: parses <paramref name="text"/>
@@ -127,11 +115,8 @@ public static partial class Sql
     /// <param name="source">The string to trim.</param>
     /// <param name="trimChar">The character to strip from both ends instead of spaces.</param>
     /// <returns>A <c>TRIM</c> function expression.</returns>
-    public static TrimFunction Trim(
-        object source,
-        object trimChar) => new(
-            Resolve(source),
-            Resolve(trimChar));
+    public static TrimFunction Trim(object source, object trimChar) =>
+        new(Resolve(source), Resolve(trimChar));
 
     /// <summary>
     /// The <c>TRUNC(expr)</c> function: truncates <paramref name="expr"/> toward zero
@@ -147,11 +132,8 @@ public static partial class Sql
     /// <inheritdoc cref="Trunc(object)"/>
     /// <param name="expr">The numeric or date value to truncate.</param>
     /// <param name="format">The number of decimal places, or the Oracle date format unit (e.g. <c>'MM'</c>).</param>
-    public static TruncFunction Trunc(
-        object expr,
-        object format) => new(
-            Resolve(expr),
-            Resolve(format));
+    public static TruncFunction Trunc(object expr, object format) =>
+        new(Resolve(expr), Resolve(format));
 
     /// <summary>
     /// The PostgreSQL text-search match predicate <c>vector @@ query</c>: whether

--- a/src/SqlArtisan/Sql/Sql.W.cs
+++ b/src/SqlArtisan/Sql/Sql.W.cs
@@ -20,8 +20,7 @@ public static partial class Sql
     /// </summary>
     /// <param name="whenCondition">The condition tested by this arm.</param>
     /// <returns>A searched <c>WHEN</c> arm awaiting <c>.Then(...)</c>.</returns>
-    public static SearchedCaseWhenCondition When(
-        SqlCondition whenCondition) => new(whenCondition);
+    public static SearchedCaseWhenCondition When(SqlCondition whenCondition) => new(whenCondition);
 
     /// <summary>
     /// A <c>WHEN value THEN ...</c> arm of a simple <c>CASE expr</c> expression: the
@@ -41,8 +40,7 @@ public static partial class Sql
     /// </summary>
     /// <param name="ctes">One or more CTE definitions, each produced by <c>cte.As(subquery)</c>.</param>
     /// <returns>A <c>WITH</c> builder positioned for the following statement.</returns>
-    public static IWithBuilderWith With(
-        params CommonTableExpression[] ctes) =>
+    public static IWithBuilderWith With(params CommonTableExpression[] ctes) =>
         new WithBuilder(new WithClause(ctes));
 
     /// <summary>
@@ -52,7 +50,6 @@ public static partial class Sql
     /// </summary>
     /// <param name="ctes">One or more CTE definitions, each produced by <c>cte.As(subquery)</c>.</param>
     /// <returns>A <c>WITH RECURSIVE</c> builder positioned for the following statement.</returns>
-    public static IWithBuilderWith WithRecursive(
-        params CommonTableExpression[] ctes) =>
+    public static IWithBuilderWith WithRecursive(params CommonTableExpression[] ctes) =>
         new WithBuilder(new WithRecursiveClause(ctes));
 }


### PR DESCRIPTION
## Summary

Compared the repo `.editorconfig` against an external reference config and folded in the parts worth adopting, keeping everything that is deliberately project-specific (UTF-8 no BOM for `.cs`, `max_line_length = 100`, per-folder diagnostic suppressions, Roslyn-default modifier order).

- **`csharp_style_namespace_declarations = file_scoped:warning`** — the codebase is already 100% file-scoped (0 block-scoped namespaces); `warning` puts the rule behind the `dotnet format --verify-no-changes` CI gate.
- **Standard naming rules added** — namespaces/types/properties/methods/events PascalCase, interface `I` prefix, type parameter `T` prefix, method parameters and locals camelCase. Non-private static fields get PascalCase, scoped to `public, protected, protected_internal` so the existing `s_` prefix rule keeps covering `private, internal`. Existing field rules are untouched.
- **`csharp_prefer_braces` raised `silent` → `warning`** — no brace-less statements exist in the codebase, so this only prevents future regressions.

Deliberately **not** adopted from the reference: custom modifier order (would normalize `protected internal` to the non-standard `internal protected`; the current value is the Roslyn/IDE0036 default), `csharp_style_prefer_primary_constructors = false` (the codebase uses primary constructors extensively), global UTF-8 BOM, and `end_of_line = crlf`.

## Verification

`dotnet format SqlArtisan.sln --verify-no-changes` passes with the stricter settings — zero violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)