### PR TITLE
style: Adopt file-scoped namespace enforcement and standard naming rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -85,10 +85,55 @@ dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = priva
 dotnet_naming_style.camel_case_underscore_style.required_prefix = _
 dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
 
+# namespaces, types, and non-field members should be PascalCase
+dotnet_naming_rule.general_symbols_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.general_symbols_should_be_pascal_case.symbols  = general_symbols
+dotnet_naming_rule.general_symbols_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.general_symbols.applicable_kinds = namespace, class, struct, enum, property, method, event
+
+# interfaces should have an I prefix
+dotnet_naming_rule.interfaces_should_have_i_prefix.severity = suggestion
+dotnet_naming_rule.interfaces_should_have_i_prefix.symbols  = interfaces
+dotnet_naming_rule.interfaces_should_have_i_prefix.style    = interface_style
+dotnet_naming_symbols.interfaces.applicable_kinds = interface
+dotnet_naming_style.interface_style.required_prefix = I
+dotnet_naming_style.interface_style.capitalization = pascal_case
+
+# type parameters should have a T prefix
+dotnet_naming_rule.type_parameters_should_have_t_prefix.severity = suggestion
+dotnet_naming_rule.type_parameters_should_have_t_prefix.symbols  = type_parameters
+dotnet_naming_rule.type_parameters_should_have_t_prefix.style    = type_parameter_style
+dotnet_naming_symbols.type_parameters.applicable_kinds = type_parameter
+dotnet_naming_style.type_parameter_style.required_prefix = T
+dotnet_naming_style.type_parameter_style.capitalization = pascal_case
+
+# non-private static fields should be PascalCase
+# (private/internal static fields keep the s_ prefix rule above)
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.symbols  = non_private_static_fields
+dotnet_naming_rule.non_private_static_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.non_private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.non_private_static_fields.required_modifiers = static
+dotnet_naming_symbols.non_private_static_fields.applicable_accessibilities = public, protected, protected_internal
+
+# method parameters should be camelCase
+dotnet_naming_rule.method_parameters_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.method_parameters_should_be_camel_case.symbols  = method_parameters
+dotnet_naming_rule.method_parameters_should_be_camel_case.style    = camel_case_style
+dotnet_naming_symbols.method_parameters.applicable_kinds = parameter
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+# local variables should be camelCase
+dotnet_naming_rule.local_variables_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.local_variables_should_be_camel_case.symbols  = local_variables
+dotnet_naming_rule.local_variables_should_be_camel_case.style    = camel_case_style
+dotnet_naming_symbols.local_variables.applicable_kinds = local
+
 # Code style defaults
+csharp_style_namespace_declarations = file_scoped:warning
 csharp_using_directive_placement = outside_namespace:suggestion
 dotnet_sort_system_directives_first = true
-csharp_prefer_braces = true:silent
+csharp_prefer_braces = true:warning
 csharp_preserve_single_line_blocks = true:none
 csharp_preserve_single_line_statements = false:none
 csharp_prefer_static_local_function = true:suggestion


### PR DESCRIPTION
## Summary

Compared the repo `.editorconfig` against an external reference config and folded in the parts worth adopting, keeping everything that is deliberately project-specific (UTF-8 no BOM for `.cs`, `max_line_length = 100`, per-folder diagnostic suppressions, Roslyn-default modifier order).

- **`csharp_style_namespace_declarations = file_scoped:warning`** — the codebase is already 100% file-scoped (0 block-scoped namespaces); `warning` puts the rule behind the `dotnet format --verify-no-changes` CI gate.
- **Standard naming rules added** — namespaces/types/properties/methods/events PascalCase, interface `I` prefix, type parameter `T` prefix, method parameters and locals camelCase. Non-private static fields get PascalCase, scoped to `public, protected, protected_internal` so the existing `s_` prefix rule keeps covering `private, internal`. Existing field rules are untouched.
- **`csharp_prefer_braces` raised `silent` → `warning`** — no brace-less statements exist in the codebase, so this only prevents future regressions.

Deliberately **not** adopted from the reference: custom modifier order (would normalize `protected internal` to the non-standard `internal protected`; the current value is the Roslyn/IDE0036 default), `csharp_style_prefer_primary_constructors = false` (the codebase uses primary constructors extensively), global UTF-8 BOM, and `end_of_line = crlf`.

Supersedes #215 (withdrawn, re-submitted on a dedicated branch).

## Verification

`dotnet format SqlArtisan.sln --verify-no-changes` passes with the stricter settings — zero violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)