### PR TITLE
chore: Agent-config audit fixes (hook SDK pin, local-settings ignore, $schema, docs drift)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # SessionStart hook for Claude Code on the web.
-# Ensures the .NET 8 SDK is available and NuGet packages are restored so that
+# Ensures the .NET 10 SDK pinned by global.json is available and NuGet packages are restored so that
 # `dotnet build` / `dotnet test` work immediately in remote sessions.
 set -euo pipefail
 
@@ -17,15 +17,15 @@ if [ "$(id -u)" -ne 0 ]; then
     SUDO="sudo"
 fi
 
-# Install the .NET 8 SDK from the Ubuntu archive if it isn't already present.
+# Install the .NET 10 SDK from the Ubuntu archive if it isn't already present.
 # (The official dot.net / Azure CDN installers are blocked by the network
 # policy in this environment, but archive.ubuntu.com is reachable.)
 if ! command -v dotnet >/dev/null 2>&1; then
-    echo "Installing .NET 8 SDK..."
+    echo "Installing .NET 10 SDK..."
     export DEBIAN_FRONTEND=noninteractive
     # Refresh package lists; tolerate failures from unrelated third-party PPAs.
     $SUDO apt-get update -qq || true
-    $SUDO apt-get install -y --no-install-recommends dotnet-sdk-8.0
+    $SUDO apt-get install -y --no-install-recommends dotnet-sdk-10.0
 fi
 
 # Quiet the first-run banner and telemetry for this and the session's commands.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
       "Bash(dotnet build:*)",

--- a/.gitignore
+++ b/.gitignore
@@ -482,3 +482,6 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
+
+# Claude Code local settings (per-machine, not shared)
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ for the full procedure.
   **MySQL, Oracle, PostgreSQL, SQLite, SQL Server**.
 - Documentation prose/style conventions (terminology, DBMS naming, spaced em
   dash, reference-entry shape) live in `.claude/rules/docs-style.md` —
-  auto-loaded when editing `README.md`, `docs/**`, or `llms.txt`.
+  auto-loaded when editing `README.md`, `docs/**`, `llms.txt`, or `CHANGELOG.md`.
 
 ## Git
 


### PR DESCRIPTION
## Summary

Results of an audit of the repo's AI-agent configuration files (CLAUDE.md / .claude/settings / rules / hooks) against the current Claude Code official docs:

- **fix: SessionStart hook installed `dotnet-sdk-8.0`**, but `global.json` pins SDK `10.0.109` (rollForward: latestPatch) — a fresh remote (Claude Code on the web) session could not resolve the SDK, so the hook's `dotnet restore` failed and `set -euo pipefail` aborted the whole hook. Now installs `dotnet-sdk-10.0` (comments updated to match).
- **chore: `.gitignore` now excludes `.claude/settings.local.json`** — it was previously excluded only by a machine-local global gitignore, so other clones could commit it accidentally.
- **chore: add `$schema` to `.claude/settings.json`** — enables editor validation/autocomplete; no behavior change.
- **docs: CLAUDE.md said the docs-style rule auto-loads for `README.md`, `docs/**`, `llms.txt`** — the rule's `paths:` frontmatter also includes `CHANGELOG.md`; the description had drifted.

## Verification

- `bash -n` passes on the edited hook; both settings JSON files re-parse as valid JSON.
- An independent verification pass confirmed each commit touches only its claimed file with no extra hunks.
- Note: the hook fix assumes `dotnet-sdk-10.0` is available from the Ubuntu archive in the remote environment — worth watching the hook output on the next web session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)