### PR TITLE
chore: Encode the #225 triage's decision principles into rules, skills, and a reviewer agent

### DIFF
--- a/.claude/agents/sa-reviewer.md
+++ b/.claude/agents/sa-reviewer.md
@@ -1,0 +1,49 @@
+---
+name: sa-reviewer
+description: Independent fresh-context reviewer for SqlArtisan changes and docs. Use after implementing a feature/fix (or before pushing) to get an unanchored review of the branch's diff, and for docs audits. Follows the sa-review-changes / sa-review-docs skill checklists, verifies empirically via a throwaway harness and the test gates, and reports findings — it never edits the repo (no Edit/Write by design).
+tools: Read, Grep, Glob, Bash
+---
+
+You are an independent reviewer for the SqlArtisan repository. You run in a
+fresh context precisely so you are not anchored by the implementing session's
+assumptions — re-derive conclusions from the code and from empirical probes,
+not from how the change describes itself.
+
+## Procedure
+
+1. Read the checklist you are executing **first**:
+   - Code / PR / diff review → `.claude/skills/sa-review-changes/SKILL.md`
+   - Docs review → `.claude/skills/sa-review-docs/SKILL.md` (run its bundled
+     scripts)
+   Follow the skill end to end; it is the contract for this review.
+2. Scope the diff per the skill (branch-point diff, not stale-`main` diff),
+   run the gates (`dotnet build` / `dotnet test` / `dotnet format
+   --verify-no-changes`), then the ADR-conformance and convention checks.
+   The path-scoped rules under `.claude/rules/` (guards-and-empty-states,
+   public-api-design, dbms-differences, unit-tests, docs-style,
+   sql-building-style) are part of the bar — read the ones the diff touches.
+3. **Verify empirically.** You have no Edit/Write tools by design — build the
+   throwaway harness under `/tmp` with Bash heredocs, per
+   `.claude/skills/sa-run-sql-harness/SKILL.md`, including the four
+   hazard-shape probes where the diff could plausibly affect them. Never
+   assert emitted SQL or DBMS grammar from memory: paste probe output
+   verbatim into your report, and tag any unprobed grammar claim
+   `grammar-unverified`.
+
+## Constraints
+
+- You review; you do not fix. Do not modify the repository, commit, push, or
+  comment on GitHub. Repo-mutating Bash is off-limits — Bash is for read-only
+  git commands, the gates, and the `/tmp` harness only.
+- Distinguish "must fix" (bugs, ADR violations, invalid/wrong SQL, policy
+  violations) from "discuss" (trade-offs the ADRs deliberately leave open).
+  A convention the rules permit is not a finding.
+
+## Report (your final message — it is the only thing the caller receives)
+
+Lead with the verdict (mergeable / mergeable-after-must-fix / not mergeable)
+and a one-paragraph summary. Then findings ordered by severity
+(**High/Medium/Low/Nit**), each with `file:line`, a one-sentence defect
+statement, and the concrete failure scenario — with the verbatim probe output
+that demonstrates it where one exists. End with what you verified empirically
+(dialects probed, gates run) so the caller knows the coverage of this review.

--- a/.claude/rules/dbms-differences.md
+++ b/.claude/rules/dbms-differences.md
@@ -37,3 +37,25 @@ make `Build` silently rewrite the author's SQL, violating ADR 0001.
 A construct that simply does not exist on a DBMS needs no flag at all: emit
 faithfully and leave availability to the database and the analyzer (ADR 0003) —
 do not gate it at `Build` time.
+
+Two further classes look like dialect differences but belong in **neither**
+the dialect layer nor a plain matrix entry (both identified in the #225
+triage):
+
+- **Version-bounded availability → docs note + a #232 interval seed.** The
+  matrix asserts against one pinned engine version (`VerifiedAgainstVersion`),
+  so a fact that flips at a version boundary — `WITH RECURSIVE` on
+  Oracle 23ai, `CONCAT`/`||` on SQLite 3.44, MySQL 8.0.16 / 8.0.19 / 8.0.20,
+  `DATETRUNC` on SQL Server 2022 — is recorded as a docs version note and
+  registered as an interval-annotation seed on #232, never as an
+  `IDbmsDialect` member.
+- **Context-bounded validity → docs note + a #232 context-rule candidate.** A
+  construct valid in one syntactic context and rejected in another on the
+  *same* engine — MySQL's `LIMIT` inside `IN`/`ANY`/`ALL`/`SOME` subqueries,
+  MySQL's `GROUPING()` outside a `WITH ROLLUP` query, Oracle's `PRIOR` outside
+  `CONNECT BY` — cannot be expressed by the construct-level matrix at all.
+  Document the workaround and register the case on #232.
+
+Before adding anything to `IDbmsDialect` or `DialectMatrix`, walk the classes
+above in order: token-level → construct-level → plain unavailability →
+version-bounded → context-bounded.

--- a/.claude/rules/docs-style.md
+++ b/.claude/rules/docs-style.md
@@ -10,9 +10,10 @@ paths:
 # Documentation style
 
 Covers wording and formatting for the README (landing + capability-map index),
-`docs/` (reference), `llms.txt`, and `CHANGELOG.md`. The README/`docs/` split
-also lives in CLAUDE.md; the absolute-URL rule and the DBMS enum order live
-only here.
+`docs/` (reference), `llms.txt` (the AI-tool index; `llms-full.txt` and an
+MCP/Context7 feed are future work), and `CHANGELOG.md`. The README/`docs/`
+split also lives in CLAUDE.md; the absolute-URL rule and the DBMS enum order
+live only here.
 
 **No ADR citations on user-facing surfaces** — README, `docs/` reference
 pages, `llms.txt`, and `CHANGELOG.md` must not cite ADR numbers ("per
@@ -55,7 +56,7 @@ with availability left to the database"). ADR cross-references belong in
   DBMS in enum order.
 - **Dialect caveat note** (a construct that is invalid or a trap on some
   DBMS): one sentence naming the affected DBMS (enum order) and the working
-  alternative in the same breath — "On SQL Server and Oracle (< 23ai), recurse
+  alternative in the same breath — "On Oracle (< 23ai) and SQL Server, recurse
   with plain `With(...)` — `WithRecursive()` is rejected there." Never a bare
   "not supported on X" with no way out.
 - **Version boundary note**: parenthesized after the DBMS name — "(SQL Server

--- a/.claude/rules/docs-style.md
+++ b/.claude/rules/docs-style.md
@@ -52,6 +52,14 @@ with availability left to the database"). ADR cross-references belong in
 - Reference entries follow one shape: a one-line description → the C# snippet →
   the emitted SQL → (only when it differs by dialect) a dialect note that lists
   DBMS in enum order.
+- **Dialect caveat note** (a construct that is invalid or a trap on some
+  DBMS): one sentence naming the affected DBMS (enum order) and the working
+  alternative in the same breath — "On SQL Server and Oracle (< 23ai), recurse
+  with plain `With(...)` — `WithRecursive()` is rejected there." Never a bare
+  "not supported on X" with no way out.
+- **Version boundary note**: parenthesized after the DBMS name — "(SQL Server
+  2022+)", "(MySQL 8.0.20+)", "(SQLite 3.44+)" — inside the dialect note, not
+  in the entry's one-line description.
 - README→docs and docs↔docs links are absolute GitHub `blob/main` URLs;
   `llms.txt` uses `raw.githubusercontent.com` URLs; in-page anchors stay relative.
 - Adding/renaming/moving a `## ` section in `docs/expressions.md` or

--- a/.claude/rules/docs-style.md
+++ b/.claude/rules/docs-style.md
@@ -10,8 +10,9 @@ paths:
 # Documentation style
 
 Covers wording and formatting for the README (landing + capability-map index),
-`docs/` (reference), `llms.txt`, and `CHANGELOG.md`. The README/`docs/` split,
-the absolute-URL rule, and the DBMS enum order also live in CLAUDE.md.
+`docs/` (reference), `llms.txt`, and `CHANGELOG.md`. The README/`docs/` split
+also lives in CLAUDE.md; the absolute-URL rule and the DBMS enum order live
+only here.
 
 **No ADR citations on user-facing surfaces** — README, `docs/` reference
 pages, `llms.txt`, and `CHANGELOG.md` must not cite ADR numbers ("per

--- a/.claude/rules/guards-and-empty-states.md
+++ b/.claude/rules/guards-and-empty-states.md
@@ -1,0 +1,51 @@
+---
+description: Guard conventions — the empty-state policy, eager vs Build()-time timing, exception message grammar
+paths:
+  - "src/SqlArtisan/Internal/SqlBuilder/**/*.cs"
+  - "src/SqlArtisan/Internal/SqlPart/Condition/**/*.cs"
+  - "src/SqlArtisan/Sql/*.cs"
+---
+
+# Guards and empty states
+
+The #225 audit's worst findings were statements that *silently* emitted invalid
+or wrong SQL (bare `WHERE`, `()` from nested empty groups, correlated-DML
+tautologies). Guards exist to convert that failure class into loud errors —
+follow these conventions so every new guard lands on the same policy.
+
+## The empty-state policy (#236)
+
+Elide a clause only where an all-empty condition plausibly means "no
+restriction"; fail loudly everywhere else.
+
+| Position | All-empty behavior |
+|---|---|
+| SELECT `.Where(...)`, `.Having(...)`, aggregate `.Filter(...)` | **elide the clause** |
+| UPDATE / DELETE `.Where(...)` | **throw at Build()** (eliding turns filtered DML into a full-table write) |
+| JOIN `.On(...)`, CASE `When(...)`, MERGE `.On(...)`/`.WhenMatched(cond)`/`.DeleteWhere(...)` | throw at Build() |
+| Empty SELECT list, empty `IN` collection, empty `VALUES` rows | throw **eagerly** |
+
+Condition emptiness is **recursive**: a tree whose operands are all empty
+renders nothing. Never test an operand with `is EmptyCondition` — that is the
+bug that emitted `()` for nested all-empty groups even in mixed states; use the
+recursive emptiness check.
+
+## When to throw: eagerly vs at Build()
+
+- **Eagerly (in the factory / clause method)** only when the fact is fixed at
+  the call site: a `params` array length, a collection count. Precedent:
+  `PartitionBy` (#69), empty `Select()` (#236).
+- **At Build()/format time** when later mutation can change the fact:
+  conditions (`operator &` mutates a held `AndCondition`, so an empty tree at
+  `.Where(...)` time can legitimately become non-empty before `Build()`) and
+  builder stages. An eager check here would misfire on legal code.
+
+## Message grammar
+
+One sentence; name the construct by its **SQL spelling**; state the
+requirement. Unit tests assert the message verbatim (see the unit-tests rule),
+so the wording is part of the contract.
+
+- ✓ `PARTITION BY requires at least one expression.`
+- ✓ `The target of a correlated UPDATE or DELETE must be aliased.`
+- ✗ `Invalid input.` — names nothing, states nothing.

--- a/.claude/rules/guards-and-empty-states.md
+++ b/.claude/rules/guards-and-empty-states.md
@@ -18,6 +18,11 @@ follow these conventions so every new guard lands on the same policy.
 Elide a clause only where an all-empty condition plausibly means "no
 restriction"; fail loudly everywhere else.
 
+**Status:** this table is the policy *decided* in #236, not shipped behavior —
+today the library still emits bare `WHERE ` / `SELECT  FROM` / `IN ()` for
+these states (probed in the #225 follow-up). New guards must land on this
+policy; never cite a row as already-enforced without checking the code.
+
 | Position | All-empty behavior |
 |---|---|
 | SELECT `.Where(...)`, `.Having(...)`, aggregate `.Filter(...)` | **elide the clause** |
@@ -34,7 +39,8 @@ recursive emptiness check.
 
 - **Eagerly (in the factory / clause method)** only when the fact is fixed at
   the call site: a `params` array length, a collection count. Precedent:
-  `PartitionBy` (#69), empty `Select()` (#236).
+  `PartitionBy` (#69); the empty-`Select()` eager guard is decided in #236
+  but not yet landed.
 - **At Build()/format time** when later mutation can change the fact:
   conditions (`operator &` mutates a held `AndCondition`, so an empty tree at
   `.Where(...)` time can legitimately become non-empty before `Build()`) and

--- a/.claude/rules/public-api-design.md
+++ b/.claude/rules/public-api-design.md
@@ -1,0 +1,66 @@
+---
+description: Public API design decisions — naming categories, overload split for analyzer arity, collection parameters, no opinion-holes
+paths:
+  - "src/SqlArtisan/Sql/*.cs"
+  - "src/SqlArtisan/SqlPart/**/*.cs"
+  - "src/SqlArtisan.Analyzers/DialectMatrix.cs"
+  - "tests/SqlArtisan.IntegrationTests/Infrastructure/MatrixSweepCatalog.cs"
+---
+
+# Public API design
+
+Decision principles distilled from the #225 expressibility triage
+(#231–#245). The mechanical six-touch-point procedure stays in the
+`sa-add-sql-function` skill; this rule covers the *decisions* made before it.
+
+## Naming: three categories, in priority order
+
+1. **SQL-token names** — the CLAUDE.md rule (underscores are the only word
+   boundaries): `ADD_MONTHS`→`AddMonths`, `DATETRUNC`→`Datetrunc`.
+2. **Symbol-only operators → glyph names**, precedent `JsonArrow` (`->`) /
+   `JsonArrowText` (`->>`); the `||` factory (#234) follows this category.
+3. **Non-token helpers** (`ConditionIf`, `Hints`, `Group`, `Value`,
+   `NoCondition`) — invented names are allowed *only* here, for API
+   affordances that correspond to no SQL token.
+
+Never invent a token-like name for a real construct: `CountAll()` was rejected
+(#233) because no `COUNT_ALL` token exists — `COUNT(*)` is the parameterless
+`Count()` overload, and real tokens like SQL Server's `COUNT_BIG` keep their
+conventional names available.
+
+## Overload split for analyzer arity
+
+The analyzer keys the dialect matrix by the **declared** parameter count
+(`method.Parameters.Length`), so a single `params` overload can never carry an
+arity-restricted matrix entry — every call site reports the same declared
+arity. When dialect support differs by argument count, **split the overloads
+so the declared arities differ**:
+
+> Worked example (#234): `Concat(object, object)` (arity 2, all dialects) +
+> `Concat(object, object, object, params object[])` (arity 4, `oracle: false`)
+> lets `("Concat", 2)` / `("Concat", 4)` matrix entries warn on Oracle's
+> 2-argument limit with zero analyzer-engine changes. First from-scratch use:
+> `Grouping` (#235).
+
+Before adding a matrix entry, check the `MatrixKey` collision caveat in
+`DialectMatrix.cs`: keys are (name, arity) with **no parameter types**, so
+same-name same-arity overloads collide into a support union.
+
+## Collection parameters: `IReadOnlyCollection<T>`, not `IEnumerable<T>`
+
+> Worked example — do not repeat (#243 ERG-07): an `In<T>(IEnumerable<T>)`
+> overload would silently re-bind `x.In("abc")` — today one bind via
+> `params object[]` — into three `char` binds, because `string` implements
+> `IEnumerable<char>` and a generic method in normal form beats `params`
+> expansion. `string` does **not** implement `IReadOnlyCollection<char>`,
+> while `List<T>`, arrays, and sets all do — so `IReadOnlyCollection<T>`
+> keeps strings on the `params` path and still covers every runtime
+> collection.
+
+## Opinions live in docs and the analyzer, not in API holes
+
+Never omit a legitimate SQL spelling to steer users toward a "better" one —
+the `COUNT(*)` lesson (#233, #232): knowledge encoded as API absence is
+invisible, unexplained, and unsuppressible, and the adoption test is binary.
+Emit faithfully; put the guidance in `docs/`; let the matrix warn where a
+dialect genuinely rejects the construct.

--- a/.claude/rules/public-api-design.md
+++ b/.claude/rules/public-api-design.md
@@ -15,18 +15,22 @@ Decision principles distilled from the #225 expressibility triage
 
 ## Naming: three categories, in priority order
 
-1. **SQL-token names** — the CLAUDE.md rule (underscores are the only word
-   boundaries): `ADD_MONTHS`→`AddMonths`, `DATETRUNC`→`Datetrunc`.
+1. **SQL-token names** — underscores are the only word boundaries: each
+   underscore-delimited segment gets one leading capital and the rest
+   lowercase; a token with no underscore stays a single word
+   (`ADD_MONTHS`→`AddMonths`, `DATETRUNC`→`Datetrunc`, never invented
+   internal capitals). CLAUDE.md carries the one-line summary; this is the
+   full rule.
 2. **Symbol-only operators → glyph names**, precedent `JsonArrow` (`->`) /
    `JsonArrowText` (`->>`); the `||` factory (#234) follows this category.
-3. **Non-token helpers** (`ConditionIf`, `Hints`, `Group`, `Value`,
-   `NoCondition`) — invented names are allowed *only* here, for API
-   affordances that correspond to no SQL token.
+3. **Non-token helpers** (`ConditionIf`, `Hints`, `Group`) — invented names
+   are allowed *only* here, for API affordances that correspond to no SQL
+   token.
 
 Never invent a token-like name for a real construct: `CountAll()` was rejected
-(#233) because no `COUNT_ALL` token exists — `COUNT(*)` is the parameterless
-`Count()` overload, and real tokens like SQL Server's `COUNT_BIG` keep their
-conventional names available.
+(#233) because no `COUNT_ALL` token exists — `COUNT(*)` lands as a
+parameterless `Count()` overload (#233, not yet implemented), and real tokens
+like SQL Server's `COUNT_BIG` keep their conventional names available.
 
 ## Overload split for analyzer arity
 
@@ -36,11 +40,13 @@ arity-restricted matrix entry — every call site reports the same declared
 arity. When dialect support differs by argument count, **split the overloads
 so the declared arities differ**:
 
-> Worked example (#234): `Concat(object, object)` (arity 2, all dialects) +
-> `Concat(object, object, object, params object[])` (arity 4, `oracle: false`)
-> lets `("Concat", 2)` / `("Concat", 4)` matrix entries warn on Oracle's
-> 2-argument limit with zero analyzer-engine changes. First from-scratch use:
-> `Grouping` (#235).
+> Decided shape (#234 — **not yet landed**; today `Concat` is still one
+> `params` method and its matrix entry is a support union, see the caveat
+> comment on it in `DialectMatrix.cs`): `Concat(object, object)` (arity 2,
+> all dialects) + `Concat(object, object, object, params object[])` (arity 4,
+> `oracle: false`) lets `("Concat", 2)` / `("Concat", 4)` matrix entries warn
+> on Oracle's 2-argument limit with zero analyzer-engine changes. `Grouping`
+> (#235) is decided as the first from-scratch use.
 
 Before adding a matrix entry, check the `MatrixKey` collision caveat in
 `DialectMatrix.cs`: keys are (name, arity) with **no parameter types**, so

--- a/.claude/rules/sql-building-style.md
+++ b/.claude/rules/sql-building-style.md
@@ -39,3 +39,11 @@ Rules for `Format` implementations and `Keywords.cs` (#207 / #208):
    block body stays on one line while it is short
    (`buffer.Append(_offset).AppendSpace();`); once it wraps, one method per
    line applies there too.
+
+5. **Builder ordering.** Order a statement builder's **implemented-interface
+   list** and its **member methods** alphabetically by name (e.g.
+   `DeleteBuilder`, `UpdateBuilder`). Properties precede methods and the
+   `protected` build hook trails; overloads stay adjacent and explicit
+   interface implementations sort by their simple name. Within an interface
+   definition, declare members alphabetically too. This is mechanical and
+   keeps builders consistent as they grow.

--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -20,7 +20,10 @@ paths:
     (`UsesRowAlias`, `EscapesLiteral`).
   - e.g. `Abs_NumericValue_CorrectSql`, `Extract_Oracle_CorrectSql`,
     `Returning_NoArguments_ThrowsArgumentException`.
-- **Guard and elision assertions.** A `Throws...` test asserts the exception's
+- **Guard and elision assertions** (forward convention — applies to the
+  #236/#245 guards as they land; tests written before it assert only the
+  exception type or use `Contains`, don't copy them). A `Throws...` test
+  asserts the exception's
   **exact message** (`Assert.Equal` on `ex.Message`) — the message grammar in
   the guards rule is part of the contract, not incidental wording. An
   `Omits<Clause>` test asserts the **exact full SQL string** without the

--- a/.claude/rules/unit-tests.md
+++ b/.claude/rules/unit-tests.md
@@ -15,9 +15,19 @@ paths:
     `DistinctSeparator`); omit when there is nothing to qualify.
   - `<Expectation>` — required tail: `CorrectSql` (exact SQL-string assertion),
     `ThrowsArgumentException` / `ThrowsArgumentNullException`, `Returns<X>`
-    (Dapper), or a specific behavior (`UsesRowAlias`, `EscapesLiteral`).
+    (Dapper), a clause-elision assertion (`Omits<Clause>`, e.g.
+    `Where_AllConditionsExcluded_OmitsWhereClause`), or a specific behavior
+    (`UsesRowAlias`, `EscapesLiteral`).
   - e.g. `Abs_NumericValue_CorrectSql`, `Extract_Oracle_CorrectSql`,
     `Returning_NoArguments_ThrowsArgumentException`.
+- **Guard and elision assertions.** A `Throws...` test asserts the exception's
+  **exact message** (`Assert.Equal` on `ex.Message`) — the message grammar in
+  the guards rule is part of the contract, not incidental wording. An
+  `Omits<Clause>` test asserts the **exact full SQL string** without the
+  clause; never a `Contains`/negation check, which passes on garbage. Where a
+  Build()-time builder guard is added, also cover the legal twin: building a
+  *finished* chain twice (multi-dialect) asserts equal text, while a stage
+  call after `Build()` asserts the guard throw (#245).
 - **Build with the dialect the SQL targets.** A test that asserts
   dialect-specific tokens (Oracle `SYSDATE`, SQL Server `DATEADD`, MySQL
   `GROUP_CONCAT`, …) must `.Build(Dbms.X)`, never the default `.Build()` —

--- a/.claude/skills/sa-add-sql-function/SKILL.md
+++ b/.claude/skills/sa-add-sql-function/SKILL.md
@@ -17,7 +17,12 @@ Reference implementations to copy from:
 - **Optional trailing args** → `RtrimFunction` (`CharacterFunction/RtrimFunction.cs`)
 - **Conditional / keyword-in-args** → `TrimFunction` (`CharacterFunction/TrimFunction.cs`)
 
-Before starting, decide the **category** and **name**:
+Before starting, decide the **category** and **name**. Naming has three
+categories — SQL-token names (the rule below), glyph names for symbol-only
+operators (`JsonArrow` for `->`), and invented names for non-token helpers
+(`ConditionIf`, `Hints`) — see `.claude/rules/public-api-design.md` for when
+each applies and why token-like inventions (`CountAll`) are rejected. For a
+token name:
 - Pick the function `<Category>` folder under
   `src/SqlArtisan/Internal/SqlPart/Expression/Function/`. Existing categories:
   `AggregateFunction`, `AnalyticFunction`, `CharacterFunction`,
@@ -125,8 +130,17 @@ Rules:
 - Keep the signature (and expression body) on as few lines as fit within
   **100 columns** — `Cast` / `Currval` / the JSON factories are the shape to
   copy; wrap one parameter per line only when a line would exceed 100 (#209).
+- Adding a guard (empty `params`, empty collection, mandatory argument)?
+  Follow `.claude/rules/guards-and-empty-states.md` — the eager vs
+  Build()-time timing decision and the message grammar live there.
 
 ## 4. Test
+
+**Probe first, then pin.** Before writing the tests, run the construct through
+the `sa-run-sql-harness` skill: print `Build(Dbms.X)` for every target dialect
+and read the real output — the #225 follow-up corrected seven from-memory
+claims this way. Paste the probe output into the issue/PR, then pin those
+exact strings as the tests.
 
 Add `[Fact]`(s) to `FunctionTests.<Letter>.cs` (a `public partial class
 FunctionTests`) covering the basic case and each overload (multi-arg, `DISTINCT`,
@@ -147,6 +161,15 @@ by the C# member name (add an `_arity<N>`-suffixed key alongside the
 member-wide one only if support genuinely differs by overload, e.g.
 `StringAgg`'s 3-arg inline-`ORDER BY` form vs. its 2-arg form — see the
 file's own doc comment for the full key scheme and its collision caveat).
+
+**When support differs by argument count on a `params` method, split the
+overloads first.** The analyzer computes arity from the *declared* parameter
+count, so a single `params` overload reports one arity for every call site
+and can never carry an arity-restricted entry. Declare e.g. `(object, object)`
+and `(object, object, object, params object[])` so the declared arities
+differ, then key the entries per arity — the `Concat` split (#234) is the
+worked example, `Grouping` (#235) the first from-scratch use. Full recipe in
+`.claude/rules/public-api-design.md`.
 Cite the primary source (the XML remark,
 `docs/functions.md`/`docs/expressions.md`, a `CHANGELOG.md` entry, or a test)
 in a comment next to the entry — do not guess a `false` without one, since a
@@ -227,4 +250,8 @@ dotnet test tests/SqlArtisan.IntegrationTests --filter "Engine=Sqlite|FullyQuali
 
 All must pass. Then, for user-visible additions:
 - Add an entry to `CHANGELOG.md`.
-- Document the function in `README.md` if it belongs in a usage section.
+- Add the reference entry to `docs/functions.md` (or `docs/expressions.md` /
+  `docs/query-statements.md` for non-function surface) and keep
+  `docs/README.md`'s index in page order — `DocsIndexTests` fails the suite
+  on a missing index link. Touch `README.md` only if the capability map
+  itself changes; usage examples live in `docs/`, not the README.

--- a/.claude/skills/sa-add-sql-function/SKILL.md
+++ b/.claude/skills/sa-add-sql-function/SKILL.md
@@ -167,9 +167,10 @@ overloads first.** The analyzer computes arity from the *declared* parameter
 count, so a single `params` overload reports one arity for every call site
 and can never carry an arity-restricted entry. Declare e.g. `(object, object)`
 and `(object, object, object, params object[])` so the declared arities
-differ, then key the entries per arity — the `Concat` split (#234) is the
-worked example, `Grouping` (#235) the first from-scratch use. Full recipe in
-`.claude/rules/public-api-design.md`.
+differ, then key the entries per arity — the `Concat` split is the decided
+shape of #234 (not yet landed; today's single-`params` `Concat` entry carries
+the union caveat in `DialectMatrix.cs`), `Grouping` the first from-scratch
+use decided in #235. Full recipe in `.claude/rules/public-api-design.md`.
 Cite the primary source (the XML remark,
 `docs/functions.md`/`docs/expressions.md`, a `CHANGELOG.md` entry, or a test)
 in a comment next to the entry — do not guess a `false` without one, since a

--- a/.claude/skills/sa-review-changes/SKILL.md
+++ b/.claude/skills/sa-review-changes/SKILL.md
@@ -67,6 +67,13 @@ check the diff against each:
   Complexity in the hot path (`Format`) is justified **only by a measured**
   allocation win; otherwise prefer simplicity. Back any perf claim with a number
   (§5), and note that the official benchmark is `tests/SqlArtisan.Benchmark`.
+- **0007 — validity enforcement boundary.** Misuse fails loudly at the right
+  layer: compile time via return-type narrowing where possible, else a thrown
+  guard — never a silently emitted invalid/wrong statement. For anything that
+  can be *empty* (conditions, select lists, collections), check the change
+  against the empty-state policy in `.claude/rules/guards-and-empty-states.md`
+  (elide vs eager-throw vs Build()-time throw), and that guard messages follow
+  its grammar with exact-message tests.
 
 ## 4. Check consistency with existing conventions
 
@@ -82,8 +89,13 @@ check the diff against each:
   clause (Oracle `LISTAGG` needs `WITHIN GROUP`); keep it optional when the
   clause is genuinely optional (SQL Server `STRING_AGG`, MySQL `GROUP_CONCAT`
   ordering).
-- **Mutable builder fields returning `this`** are acceptable — there is
-  precedent (`SortOrder.SetNullOrdering`). Not a finding on its own.
+- **Mutable builder fields returning `this`** are acceptable as an
+  implementation — there is precedent (`SortOrder.SetNullOrdering`). Not a
+  finding on its own, **but** the reuse contract is (#245): a stage call after
+  `Build()` must throw once the freeze-after-Build guard lands, and docs must
+  never *promise* mutation (the contract wording is "a partial chain is
+  one-way"), keeping copy-on-write open as a later bug-fix. Flag docs or code
+  that locks mutation in.
 
 ## 5. Verify empirically with a throwaway harness
 
@@ -96,6 +108,11 @@ to run for a review:
   confirm `sql.Text` is valid for *that* DBMS's grammar (§6).
 - **Negative / enforcement** — a misuse (e.g. a mandatory clause omitted) must
   throw, not emit invalid SQL.
+- **Hazard shapes** — the four shapes that produced the #225 audit's silent
+  failures (the harness skill has the code): all-`ConditionIf`-off, a nested
+  all-empty OR/AND group beside an active condition, a held builder prefix
+  built along two branches, and a correlated UPDATE/DELETE with an unaliased
+  target. Run whichever the diff could plausibly affect.
 - **Allocation** — probe with `GC.GetAllocatedBytesForCurrentThread` to back any
   ADR 0006 claim; the formal suite is `tests/SqlArtisan.Benchmark`.
 
@@ -109,6 +126,13 @@ the form. Known sharp edges:
 - Oracle `LISTAGG` **requires** `WITHIN GROUP (ORDER BY ...)`.
 - `STRING_AGG` ordering differs: PostgreSQL inline `ORDER BY`, SQL Server
   `WITHIN GROUP`.
+- MySQL's default `sql_mode` parses `||` as **logical OR**, not concatenation —
+  valid SQL with silently different semantics (#234).
+- MySQL rejects `LIMIT` inside `IN`/`ANY`/`ALL`/`SOME` subqueries while
+  allowing it in scalar position — context-bounded, not matrix-expressible
+  (#240).
+- T-SQL cannot alias the direct UPDATE/DELETE target (`UPDATE t AS x` is
+  invalid); the alias comes via the `FROM` form (#239/#237).
 
 ## 7. Check docs match the source
 

--- a/.claude/skills/sa-run-integration-tests/SKILL.md
+++ b/.claude/skills/sa-run-integration-tests/SKILL.md
@@ -81,6 +81,13 @@ green, then remove it before merging. (This is exactly how #151 was landed.)
   follow that pattern, don't leave committed writes behind.
 - DDL is per-engine in `Infrastructure/TestSchema.cs`; the seed rows are inserted
   through SqlArtisan, so seeding doubles as INSERT-execution coverage.
+- **Sweep entry vs verification test.** A `MatrixSweepCatalog` entry asserts
+  that each engine's accept/reject outcome **matches the dialect matrix** in
+  both directions — it presumes the answer is already known and entered. When
+  the point is to *discover* per-engine behavior (does Oracle reject the
+  repeated-parameter GROUP BY? — the GAP-19/#241 pattern), write a dedicated
+  test that records accept/reject per engine instead; promote the fact into
+  the matrix + a sweep case only after the results are in.
 
 ## Notes
 

--- a/.claude/skills/sa-run-sql-harness/SKILL.md
+++ b/.claude/skills/sa-run-sql-harness/SKILL.md
@@ -115,6 +115,8 @@ binding grows the parameter list.
 findings — probe whichever the change could plausibly affect:
 
 ```csharp
+using SqlArtisan.Internal;                              // SqlCondition lives here
+
 SqlCondition e() => ConditionIf(false, u.Id == 1);      // an excluded condition
 
 // (a) all conditions off — must elide WHERE (SELECT) / throw (DML), never emit "WHERE "

--- a/.claude/skills/sa-run-sql-harness/SKILL.md
+++ b/.claude/skills/sa-run-sql-harness/SKILL.md
@@ -111,10 +111,32 @@ same reference (0 B) when there is no match; `char.ToString()` costs ~24 B; the
 inline-literal separator path is lighter than the bound-parameter path because
 binding grows the parameter list.
 
+**4. Hazard shapes.** The four shapes behind the #225 audit's silent-failure
+findings — probe whichever the change could plausibly affect:
+
+```csharp
+SqlCondition e() => ConditionIf(false, u.Id == 1);      // an excluded condition
+
+// (a) all conditions off — must elide WHERE (SELECT) / throw (DML), never emit "WHERE "
+Show("all-off", Select(u.Id).From(u).Where(e() & e()).Build());
+// (b) nested all-empty group beside an active condition — historically emitted "() AND (...)"
+Show("nested", Select(u.Id).From(u).Where((e() | e()) & (u.Id > 1)).Build());
+// (c) held prefix built along two branches — the second build must not inherit the first's state
+var q = Select(u.Id).From(u);
+Show("branch-1", q.Where(u.Id == 1).Build());
+Show("branch-2", q.Build());                            // watch for a leaked WHERE
+// (d) correlated DML with an unaliased target — watch for a bare outer column (tautology)
+Show("corr", Update(new T()).Set(/* col == correlated subquery */).Build());
+```
+
 ## Notes
 
 - This is for **observation**, not a substitute for `tests/SqlArtisan.Tests` —
   durable expectations belong in xUnit exact-SQL tests.
+- **Paste probe output verbatim** into the issue/PR/review that relies on it —
+  that is what makes the claim grounded. An emitted-SQL assertion made without
+  a probe carries the `grammar-unverified` tag until one is run (the #225
+  follow-up corrected seven from-memory claims this way).
 - Keep it in `/tmp`; never commit the harness.
 - Complements the built-in `run`/`verify` skills with the SqlArtisan-specific
   project reference and the SQL/parameter/allocation probes above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,12 @@ SQL-like C# and it produces the SQL string plus its bind parameters.
 
 Faithful emission is the foundation, not the whole mission: SqlArtisan aims
 to be the **deterministic guard rail for SQL written alongside generative
-AI** — misuse fails to compile, the analyzer deterministically flags what
-the target DBMS rejects (dialect availability today; version/schema checks
-are the #232 direction; cost-based advice is permanently out of scope), and
-exact-SQL tests plus the live-engine matrix close the loop. The full
-decision is **ADR 0010** (`docs/adr/`), building on ADRs 0001–0003/0007.
+AI** — misuse fails to compile or throws loudly, the analyzer
+deterministically flags what the target DBMS rejects (dialect availability
+today; version/schema checks are the #232 direction; cost-based advice is
+permanently out of scope), and exact-SQL tests plus the live-engine matrix
+close the loop. The full decision is **ADR 0010** (`docs/adr/`), building on
+ADRs 0001–0003/0007.
 
 Do **not** introduce abstractions whose purpose is to make one query run
 unchanged across multiple DBMS. DBMS differences are handled only where the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,20 @@ SQL-like C# and it produces the SQL string plus its bind parameters.
 > "The SQL you write is the SQL that runs. Cross-database portability is a
 > deliberate non-goal."
 
+Faithful emission is the foundation, not the whole mission: SqlArtisan aims
+to be the **deterministic guard rail for SQL written alongside generative
+AI** — misuse fails to compile, the analyzer deterministically flags what
+the target DBMS rejects (dialect availability today; version/schema checks
+are the #232 direction; cost-based advice is permanently out of scope), and
+exact-SQL tests plus the live-engine matrix close the loop. The full
+decision is **ADR 0010** (`docs/adr/`), building on ADRs 0001–0003/0007.
+
 Do **not** introduce abstractions whose purpose is to make one query run
 unchanged across multiple DBMS. DBMS differences are handled only where the
 *syntax* genuinely differs (quoting, parameter markers, pagination), via the
-dialect layer — never by rewriting the user's SQL semantics.
+dialect layer — never by rewriting the user's SQL semantics. And never omit
+a legitimate SQL spelling to steer users — opinions live in docs and the
+analyzer, not in API holes (ADR 0010).
 
 ## Layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,15 @@ for the full procedure.
 - Unit test conventions (naming grammar, dialect-specific `Build`, exact-SQL
   assertions) live in `.claude/rules/unit-tests.md` — auto-loaded when editing
   `tests/**`.
+- Guard conventions (the empty-state policy, eager vs Build()-time throws,
+  message grammar) live in `.claude/rules/guards-and-empty-states.md`; public
+  API design decisions (naming categories, the overload split for analyzer
+  arity, collection parameters) in `.claude/rules/public-api-design.md` —
+  both auto-loaded when editing the relevant sources.
+- Before asserting emitted-SQL behavior anywhere durable (an issue, docs, a
+  review comment), reproduce it with the `sa-run-sql-harness` skill — the
+  #225 follow-up corrected seven audit-record claims this way. An assertion
+  not yet probed carries the `grammar-unverified` tag.
 - Update `CHANGELOG.md` for user-visible changes. The **README is the
   landing/overview plus a capability-map index**; the **API reference lives in
   `docs/`** — `docs/README.md` (reference home), `docs/query-statements.md`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,13 +48,11 @@ string, so any output change will surface here. Also run
 `dotnet format SqlArtisan.sln` before pushing — CI fails on any `.editorconfig`
 violation.
 
-The SDK is pinned by `global.json` (CI installs exactly that via
-`setup-dotnet`'s `global-json-file`), because analyzer/`dotnet format`
-behavior differs across SDK feature bands — an unpinned local SDK can pass
-`--verify-no-changes` while CI fails it. If your environment cannot install
-the pinned band, run the commands from **outside** the repo directory with
-explicit project paths (SDK resolution reads `global.json` upward from the
-current directory), and treat CI as the authoritative format gate.
+The SDK is pinned by `global.json` — `dotnet format` behavior differs across
+feature bands, so an unpinned local SDK can pass `--verify-no-changes` while
+CI fails it. If the pinned band isn't installable, run the commands from
+**outside** the repo directory with explicit project paths, and treat CI as
+the authoritative format gate.
 
 ## How to add a new SQL function (the most common task)
 
@@ -70,6 +68,11 @@ for the full procedure.
 
 ## Conventions
 
+This file carries only always-true invariants and the map. File-scoped
+conventions live in `.claude/rules/` (auto-loaded by path when the matching
+files are edited); procedures live in `.claude/skills/`. Add new conventions
+there, not here — a pointer line in this list is enough.
+
 - Style is enforced by `.editorconfig` (4-space indent, Allman braces,
   explicit types over `var` unless the type is apparent, `Nullable` enabled,
   implicit usings). Match it.
@@ -79,25 +82,15 @@ for the full procedure.
   table-reference types under `src/SqlArtisan/SqlPart/TableReference/`
   (`DbTableBase`/`DbTable`, `CteBase`/`Cte`, `DerivedTableBase`/`DerivedTable`, `DbColumn`);
   everything under `Internal/` is implementation detail.
-- Name a function (factory method, `*Function` node, keyword constant) after its
-  SQL token, treating **underscores as the only word boundaries**: each
-  underscore-delimited segment gets one leading capital, the rest lowercase; a
-  token with no underscore stays a single word — never invent internal capitals.
-  So `ADD_MONTHS`→`AddMonths`, `DATE_TRUNC`→`DateTrunc`, but `DATEPART`→`Datepart`,
-  `CURRVAL`→`Currval`, and `DATEADD`/`DATEDIFF`→`Dateadd`/`Datediff`.
-- Order a statement builder's **implemented-interface list** and its **member
-  methods** alphabetically by name (e.g. `DeleteBuilder`, `UpdateBuilder`).
-  Properties precede methods and the `protected` build hook trails; overloads
-  stay adjacent and explicit interface implementations sort by their simple
-  name. Within an interface definition, declare members alphabetically too. This
-  is mechanical and keeps builders consistent as they grow.
-- Make invalid fluent chains uncompilable through the **return type**, rather than
-  returning the same builder and trusting the caller. A one-shot step returns a
-  *narrowed* interface that omits it (e.g. `WithRollup()` returns
-  `ISelectBuilderWithRollup`, so `.WithRollup().WithRollup()` is a compile error);
-  a mandatory trailing clause uses the two-type "pending" pattern (the pending
-  type is not a `SqlExpression`, so omitting it fails at `Select(...)`). The
-  `sa-add-sql-function` skill has the full recipe.
+- Name public members after their SQL token — **underscores are the only word
+  boundaries** (`ADD_MONTHS`→`AddMonths`, `DATEADD`→`Dateadd`, never invented
+  internal capitals). The full rule, the glyph/helper naming categories, and
+  the other API-shape decisions live in `.claude/rules/public-api-design.md`.
+- Make invalid fluent chains uncompilable through the **return type** (narrowed
+  step interfaces for one-shot steps; the two-type "pending" pattern for
+  mandatory trailing clauses) — the `sa-add-sql-function` skill has the full
+  recipe. Builder member/interface ordering lives in
+  `.claude/rules/sql-building-style.md`.
 - Unit test conventions (naming grammar, dialect-specific `Build`, exact-SQL
   assertions) live in `.claude/rules/unit-tests.md` — auto-loaded when editing
   `tests/**`.
@@ -112,19 +105,12 @@ for the full procedure.
   not yet probed carries the `grammar-unverified` tag.
 - Update `CHANGELOG.md` for user-visible changes. The **README is the
   landing/overview plus a capability-map index**; the **API reference lives in
-  `docs/`** — `docs/README.md` (reference home), `docs/query-statements.md`,
-  `docs/expressions.md`, `docs/functions.md`. Keep usage examples, expressions,
-  and functions in `docs/`, not the README. `/llms.txt` is the AI-tool entry
-  point (an index of the docs); keep its links in sync when docs move
-  (`llms-full.txt` and an MCP/Context7 feed are future work).
-- README→docs links must be **absolute GitHub URLs** (nuget.org, which renders
-  the bundled README, does not resolve relative links); `llms.txt` uses
-  `raw.githubusercontent.com` URLs. In-page anchors stay relative.
-- List DBMS in documentation in `Dbms` enum order:
-  **MySQL, Oracle, PostgreSQL, SQLite, SQL Server**.
-- Documentation prose/style conventions (terminology, DBMS naming, spaced em
-  dash, reference-entry shape) live in `.claude/rules/docs-style.md` —
-  auto-loaded when editing `README.md`, `docs/**`, `llms.txt`, or `CHANGELOG.md`.
+  `docs/`** (`docs/README.md` home + `query-statements.md` / `expressions.md` /
+  `functions.md`) — keep usage examples there, not in the README; `/llms.txt`
+  is the AI-tool index. Link formats (absolute GitHub URLs), DBMS
+  naming/order, terminology, and the reference-entry/caveat-note shapes live
+  in `.claude/rules/docs-style.md` — auto-loaded when editing `README.md`,
+  `docs/**`, `llms.txt`, or `CHANGELOG.md`.
 
 ## Git
 

--- a/docs/adr/0010-deterministic-guard-mission.md
+++ b/docs/adr/0010-deterministic-guard-mission.md
@@ -58,6 +58,10 @@ an explicit, sourced, suppressible diagnostic or a docs note.
   layer or unblock a constituency's adoption (planned waves #237/#159), and
   can still say wontfix where a same-dialect, vendor-recommended workaround
   exists (CONNECT BY, PIVOT, legacy index hints — #225).
+- Tier 2 *extends* the analyzer's planned remit beyond the
+  dialect-availability scope noted in ADR 0007's consequences (and ADR 0003's
+  original out-of-scope list); the decisions themselves — the permissive API
+  and the rejection boundary — stand unchanged.
 - Analyzer facts require a primary source or live verification; unverified
   grammar claims carry the `grammar-unverified` tag. Version-bounded and
   context-bounded facts the construct-level matrix cannot express are

--- a/docs/adr/0010-deterministic-guard-mission.md
+++ b/docs/adr/0010-deterministic-guard-mission.md
@@ -1,0 +1,67 @@
+# ADR 0010 — The mission: deterministic guard rails for AI-assisted SQL
+
+**Status:** Accepted
+
+## Context
+
+ADR 0001 fixed the emission philosophy — the SQL you write is the SQL that
+runs — and ADRs 0002/0003/0007 built the machinery around it. The #225
+expressibility audit and its triage (#231–#245, consolidated in #232) forced
+the question of what that machinery is ultimately *for*, and produced two
+observations:
+
+1. **Generative AI changes who writes the SQL.** Assistants produce
+   plausible-but-wrong SQL probabilistically; a reviewer can no longer assume
+   the author knew the target DBMS. What a library can uniquely add is
+   *determinism*: constraints that hold every time, not advice that holds
+   usually.
+2. **Encoding an opinion as an API hole fails.** `COUNT(*)` was deliberately
+   omitted to steer users toward counting indexed columns. The audit showed
+   the omission was invisible, unexplained, unsuppressible — and the premise
+   does not hold on modern engines. The adoption test is binary ("one of our
+   queries can't be written → we're out"), so the omission cost adoption
+   without delivering the guidance (#233).
+
+## Decision
+
+**SqlArtisan's mission is to be a deterministic guard rail for SQL written
+alongside generative AI. Faithful emission (ADR 0001) is the foundation of
+that mission, not the whole of it.**
+
+The guard is a ladder of layers, each deterministic because it rests on the
+one below (the analyzer reasons over a typed AST, not strings):
+
+1. **Types** — misuse fails to compile (narrowed step interfaces, pending
+   types; ADR 0007) or throws loudly.
+2. **Analyzer** — deterministically flags what the configured target rejects
+   (ADR 0003). Its knowledge scope is tiered:
+   - *Dialect availability* — shipped (the dialect matrix, #93).
+   - *Version boundaries and literal-decidable limits* (feature introduction
+     points, identifier-length ceilings) and *schema-aware **categorical**
+     diagnostics* (a nullable column under `COUNT`/`NOT IN`, SARGability
+     loss) — the planned direction, tracked in #232.
+   - ***Cost-based judgments are permanently out of scope.*** "This query is
+     slow" depends on statistics and hardware — the optimizer's domain.
+     Guessed-cost warnings would break the no-false-positive property that
+     makes the analyzer trustworthy (ADR 0003's degradable design).
+3. **Exact-SQL unit tests** — pin the emission.
+4. **Live-engine integration matrix** — prove it runs (#151).
+
+**Corollary: opinions live in docs and the analyzer, never in API holes.** No
+legitimate SQL spelling is omitted to steer users; guidance is delivered as
+an explicit, sourced, suppressible diagnostic or a docs note.
+
+## Consequences
+
+- The `COUNT(*)` omission is reversed (#233); its guidance moves to docs.
+- Feature triage judges additions by whether they strengthen a deterministic
+  layer or unblock a constituency's adoption (planned waves #237/#159), and
+  can still say wontfix where a same-dialect, vendor-recommended workaround
+  exists (CONNECT BY, PIVOT, legacy index hints — #225).
+- Analyzer facts require a primary source or live verification; unverified
+  grammar claims carry the `grammar-unverified` tag. Version-bounded and
+  context-bounded facts the construct-level matrix cannot express are
+  recorded as docs notes plus #232 seeds — never as wrong matrix entries.
+- Positioning surfaces (#226, #228) may state the mission in plain words;
+  user-facing pages still do not cite ADR numbers (docs-style rule).
+- CLAUDE.md carries a summary of this decision; this ADR is the source.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,7 +14,8 @@ code.
 ## Index
 
 ADRs are ordered as a narrative: the philosophy first, then handling DBMS
-divergence, then the output, API, performance, and enforcement-boundary decisions.
+divergence, then the output, API, performance, and enforcement-boundary
+decisions — closed by the mission that ties them together.
 
 | ADR | Title | Status |
 |-----|-------|--------|
@@ -27,3 +28,4 @@ divergence, then the output, API, performance, and enforcement-boundary decision
 | [0007](0007-validity-enforcement-boundary.md) | What the library rejects: grammatical completeness vs dialect availability | Accepted |
 | [0008](0008-analyzer-override-configuration.md) | Analyzer override configuration: keys, precedence, and what's out of scope | Accepted |
 | [0009](0009-analyzer-distribution-bundled.md) | Analyzer distribution: bundled in the core package, coupled only by contract | Accepted |
+| [0010](0010-deterministic-guard-mission.md) | The mission: deterministic guard rails for AI-assisted SQL | Accepted |


### PR DESCRIPTION
Prepares the agent configuration for executing the #225 triage backlog (#231–#245) with higher precision: the recurring design decisions made during the triage lived only in issue text, so this encodes them where an implementing session actually reads them — path-loaded rules, on-demand skills, and an independent reviewer agent. No product code changes.

## Rules (`5585c58`)

- **New `guards-and-empty-states.md`** — the #236 empty-state policy table (elide vs throw per position), the eager-vs-Build()-time throw timing principle, and the #69 exception-message grammar with positive/negative examples.
- **New `public-api-design.md`** — the three naming categories (SQL token / glyph / non-token helper, with the `CountAll` rejection criterion), the overload-split recipe for declared-arity matrix entries (#234/#235), the `IReadOnlyCollection<T>` collection-parameter rule with the `string : IEnumerable<char>` trap as a do-not-repeat example (#243 ERG-07), and the "opinions live in docs and the analyzer, not in API holes" principle (#232/#233).
- **`dbms-differences.md`** — adds the version-bounded and context-bounded difference classes (docs note + #232 seed; never a dialect flag or plain matrix entry) and the five-class triage order.
- **`unit-tests.md`** — `Omits<Clause>` elision assertions (exact full string, never a Contains-negation), exact-message `Throws` assertions, and the legal-twin double-Build pattern for builder guards (#245).
- **`docs-style.md`** — dialect caveat note template (name the affected DBMS and the working alternative in the same breath) and the parenthesized version-boundary note format.
- **CLAUDE.md** — pointers to the two new rules plus the probe-before-asserting discipline (`sa-run-sql-harness`; unprobed claims carry `grammar-unverified`) — the discipline that produced this session's seven audit-record corrections.

## Skills (`46ba938`)

- **`sa-add-sql-function`** — probe-first ordering (print real output on every target dialect, paste it into the issue/PR, then pin as exact-SQL tests); the overload-split recipe at the matrix step; naming-category and guards-rule cross-references; and a drift fix: the final step now points at `docs/functions.md` + the `DocsIndexTests`-enforced index instead of the README.
- **`sa-review-changes`** — ADR 0007 (validity enforcement boundary) with the empty-state policy as a review dimension; the #245 builder reuse contract (mutation stays an implementation detail, never a documented promise); four named hazard-shape probes; three newly verified dialect sharp edges (MySQL `||` = logical OR by default, MySQL `LIMIT` rejected inside `IN`/`ANY`/`ALL`/`SOME`, T-SQL cannot alias the direct DML target).
- **`sa-run-sql-harness`** — a "Hazard shapes" section with runnable probes for the four silent-failure shapes from the audit, and the paste-verbatim grounding note.
- **`sa-run-integration-tests`** — the sweep-entry vs discovery-style verification-test distinction (the GAP-19/#241 pattern).

## Agent (`16453e0`)

- **New `.claude/agents/sa-reviewer.md`** — a fresh-context reviewer wrapping the two review skills (no duplication; the skills stay authoritative). Read-only tool set (`Read`/`Grep`/`Glob`/`Bash` — no `Edit`/`Write`) makes "review, don't fix" structural; the prompt mandates empirical verification via the `/tmp` harness including the hazard-shape probes, and a severity-ordered report as the returned message.

## Verification

Markdown-only changes: no build/test/format surface. Rule frontmatter `paths` follow the existing rule files' scheme; the skill edits were made against the current SKILL.md contents; the drift fix in `sa-add-sql-function` was checked against CLAUDE.md's README/docs split.

Refs: #225 (triage record and corrections), #231–#245 (the backlog these serve), #232 (principles cited), #149 (freeze context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KLEb1ZZvxMLobvpCuz7vH

---
_Generated by [Claude Code](https://claude.ai/code/session_019KLEb1ZZvxMLobvpCuz7vH)_