### PR TITLE
docs: Triage-review follow-ups — NOT-over-empty rule, DbColumn path erratum, docs-style scope

### DIFF
--- a/.claude/rules/docs-style.md
+++ b/.claude/rules/docs-style.md
@@ -5,15 +5,17 @@ paths:
   - "docs/**/*.md"
   - "llms.txt"
   - "CHANGELOG.md"
+  - "src/*/README.md"
 ---
 
 # Documentation style
 
 Covers wording and formatting for the README (landing + capability-map index),
 `docs/` (reference), `llms.txt` (the AI-tool index; `llms-full.txt` and an
-MCP/Context7 feed are future work), and `CHANGELOG.md`. The README/`docs/`
-split also lives in CLAUDE.md; the absolute-URL rule and the DBMS enum order
-live only here.
+MCP/Context7 feed are future work, tracked in #228), `CHANGELOG.md`, and the
+package READMEs under `src/*/README.md` (NuGet landing pages). The
+README/`docs/` split also lives in CLAUDE.md; the absolute-URL rule and the
+DBMS enum order live only here.
 
 **No ADR citations on user-facing surfaces** — README, `docs/` reference
 pages, `llms.txt`, and `CHANGELOG.md` must not cite ADR numbers ("per

--- a/.claude/rules/guards-and-empty-states.md
+++ b/.claude/rules/guards-and-empty-states.md
@@ -28,12 +28,14 @@ policy; never cite a row as already-enforced without checking the code.
 | SELECT `.Where(...)`, `.Having(...)`, aggregate `.Filter(...)` | **elide the clause** |
 | UPDATE / DELETE `.Where(...)` | **throw at Build()** (eliding turns filtered DML into a full-table write) |
 | JOIN `.On(...)`, CASE `When(...)`, MERGE `.On(...)`/`.WhenMatched(cond)`/`.DeleteWhere(...)` | throw at Build() |
-| Empty SELECT list, empty `IN` collection, empty `VALUES` rows | throw **eagerly** |
+| Empty SELECT list (#236); empty `IN` collection, empty `VALUES` rows (#243) | throw **eagerly** |
 
 Condition emptiness is **recursive**: a tree whose operands are all empty
 renders nothing. Never test an operand with `is EmptyCondition` — that is the
 bug that emitted `()` for nested all-empty groups even in mixed states; use the
-recursive emptiness check.
+recursive emptiness check, **including `NOT`** — a `NOT` over an empty operand
+is itself empty (`NOT ()` is the probe-confirmed hazard a plain AND/OR walk
+misses).
 
 ## When to throw: eagerly vs at Build()
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,9 +89,10 @@ there, not here — a pointer line in this list is enough.
   implicit usings). Match it.
 - Keep DBMS-specific syntax inside `DbmsDialect`; never branch on `Dbms` inside
   function nodes.
-- Public API lives in `Sql.*.cs`, `src/SqlArtisan/SqlBuilder/`, and the
+- Public API lives in `Sql.*.cs`, `src/SqlArtisan/SqlBuilder/`, the
   table-reference types under `src/SqlArtisan/SqlPart/TableReference/`
-  (`DbTableBase`/`DbTable`, `CteBase`/`Cte`, `DerivedTableBase`/`DerivedTable`, `DbColumn`);
+  (`DbTableBase`/`DbTable`, `CteBase`/`Cte`, `DerivedTableBase`/`DerivedTable`),
+  and `DbColumn` under `src/SqlArtisan/SqlPart/Expression/`;
   everything under `Internal/` is implementation detail.
 - Name public members after their SQL token — **underscores are the only word
   boundaries** (`ADD_MONTHS`→`AddMonths`, `DATEADD`→`Dateadd`, never invented

--- a/docs/adr/0005-public-api-in-sql-partial-class.md
+++ b/docs/adr/0005-public-api-in-sql-partial-class.md
@@ -16,8 +16,10 @@ separated from internals that are free to change.
 - A narrow set of **public table-reference types** lives under
   `src/SqlArtisan/SqlPart/TableReference/` — the types consumers subclass or
   instantiate to name relations and reference columns: `DbTableBase` / `DbTable`,
-  `CteBase` / `Cte`, `DerivedTableBase` / `DerivedTable`, and the `DbColumn` they
-  expose. These are public by necessity and part of the contract.
+  `CteBase` / `Cte`, `DerivedTableBase` / `DerivedTable` — and the `DbColumn` they
+  expose lives beside them under `src/SqlArtisan/SqlPart/Expression/`. These are
+  public by necessity and part of the contract. *(Erratum 2026-07: `DbColumn`'s
+  path corrected; the decision itself is unchanged.)*
 - **Everything under `Internal/` is implementation detail**, even where a type is
   `public` for technical reasons.
 

--- a/src/SqlArtisan.TableClassGen/README.md
+++ b/src/SqlArtisan.TableClassGen/README.md
@@ -1,6 +1,6 @@
 ﻿# SqlArtisan.TableClassGen
 
-A .NET tool that generates C# table schema classes from your database for `SqlArtisan`, enabling robust type-safety and IntelliSense in your query building.
+A .NET tool that generates C# table classes from your database for `SqlArtisan`, enabling robust type-safety and IntelliSense in your query building.
 
 ## Installation
 


### PR DESCRIPTION
Repo-document fixes flowing back from the #226–#245 triage-validity review (the reverse-direction findings — cases where the issues were right and the repo documents were wrong or incomplete). The forward-direction findings were posted as comments on #225–#245.

## Changes

- **`.claude/rules/guards-and-empty-states.md`**
  - The recursive emptiness check must include **`NOT`** — probe at `ea8783c` showed `Not(allOffGroup)` beside an active condition emits `WHERE (NOT ()) AND (…)`, a live hazard the plain AND/OR walk (as specified in #236's mechanism bullet) misses. Cross-posted to #236.
  - The eager-guard table row now attributes its sources: empty SELECT list (#236); empty `IN` collection / empty `VALUES` rows (#243) — the section heading previously credited only #236.
- **`CLAUDE.md` + `docs/adr/0005-public-api-in-sql-partial-class.md`** — erratum: `DbColumn` lives under `src/SqlArtisan/SqlPart/Expression/`, not `SqlPart/TableReference/`. Path correction only; the ADR's decision is unchanged (noted inline).
- **`.claude/rules/docs-style.md`** — the rule now covers package READMEs (`src/*/README.md` added to `paths`; they ship as NuGet landing pages and were invisible to the auto-loaded rule), and the `llms-full.txt` / MCP / Context7 future-work note points at its tracking issue (#228).
- **`src/SqlArtisan.TableClassGen/README.md`** — "table schema classes" → "table classes" per the terminology rule (the project deliberately avoids the "Schema" term).

## Verification

- Docs/agent-config-only diff — zero `.cs` files touched, so unit-test and format outcomes are unchanged by construction; CI is the authoritative gate (the pinned net10 SDK band is not installable in the review environment).
- The `NOT ()` hazard and the `DbColumn` location were verified empirically (throwaway net8.0 harness / file-system check) before editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KLEb1ZZvxMLobvpCuz7vH

---
_Generated by [Claude Code](https://claude.ai/code/session_019KLEb1ZZvxMLobvpCuz7vH)_