### PR TITLE
docs: Reserve the sqlartisan_target_version analyzer config key (#262)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -80,4 +80,5 @@ dialect it doesn't support.
 [Mixed-Dialect Projects](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#mixed-dialect-projects) ·
 [CI Gates](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#ci-gates-and-stricter-enforcement) ·
 [Verified-Against Versions](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#verified-against-versions) ·
+[Reserved: Version-Aware Warnings](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#reserved-version-aware-warnings) ·
 [Known Limitations](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#known-limitations)

--- a/docs/analyzer.md
+++ b/docs/analyzer.md
@@ -15,6 +15,7 @@ completely silent until you configure a target.
 - [Mixed-dialect projects](#mixed-dialect-projects)
 - [CI gates and stricter enforcement](#ci-gates-and-stricter-enforcement)
 - [Verified-against versions](#verified-against-versions)
+- [Reserved: version-aware warnings](#reserved-version-aware-warnings)
 - [Known limitations](#known-limitations)
 
 ---
@@ -201,6 +202,41 @@ against):
 An older or newer engine version may disagree with a `false` entry in
 either direction — that's what the `supported`/`unsupported` overrides are
 for, not a bug in the matrix.
+
+---
+
+## Reserved: version-aware warnings
+
+`sqlartisan_target_version` (and its MSBuild counterpart,
+`<SqlArtisanTargetVersion>`) is a **reserved key**. Setting it today does
+nothing; a future release will use it to make the warnings version-aware —
+matrix entries will optionally carry a minimum engine version per dialect,
+so a construct newer than your declared engine (say, `MERGE` before
+PostgreSQL 15, or `DATETRUNC` before SQL Server 2022) warns just like a
+plain dialect mismatch does today.
+
+The reservation pins down now what the future release will not change:
+
+- **Value format.** The engine's own version spelling, the same one this
+  documentation's dialect notes use — `8.0.16` for MySQL, `23` for Oracle,
+  `16` for PostgreSQL, `3.44` for SQLite, `2022` for SQL Server. Versions
+  compare by numeric segment (`8.0.20` is newer than `8.0.16`); trailing
+  letters in a segment are ignored (`23ai` reads as `23`).
+- **Unset means today's behavior.** With no declared version, version
+  bounds never fire and the analyzer behaves exactly as the rest of this
+  page describes. The key also has no effect without
+  `sqlartisan_target_dbms` — a version alone identifies no engine.
+- **Your overrides keep the last word.** A version bound refines the
+  shipped matrix's verdict, not yours: resolution stays *your arity-level
+  override → your member-level override → the matrix (version-refined) →
+  silence*, so `supported` / `unsupported` keys silence or force the
+  warning exactly as they do today.
+- **No new false positives.** A version bound only ever refines a construct
+  the matrix already has an entry for; a construct without an entry stays
+  silent whether or not a version is declared.
+- **Same plumbing as the target key.** Resolved per source file,
+  `.editorconfig` wins over the MSBuild property, and an unrecognized value
+  is flagged as `SQLA0002` and otherwise treated as unset.
 
 ---
 


### PR DESCRIPTION
Closes #262.

Reserves the `sqlartisan_target_version` analyzer config key before the 1.0 freeze so the option space stays open for the post-1.0 version-aware-warnings work (#263), without shipping any behavior now.

## What changed

- **`docs/analyzer.md`** — new "Reserved: version-aware warnings" section documenting the reservation.
- **`docs/README.md`** — indexes the new section (required by the `DocsIndexTests` gate).

Docs-only; no code or analyzer behavior changes.

## Decisions recorded

- **Key name:** `sqlartisan_target_version`, plus the MSBuild counterpart `<SqlArtisanTargetVersion>` — parallel to the existing `sqlartisan_target_dbms` / `SqlArtisanTargetDbms` pair.
- **Value format:** the engine's own version spelling (`8.0.16`, `23`, `16`, `3.44`, `2022`), compared by numeric segment; trailing letters in a segment are ignored (`23ai` → `23`). Unrecognized values flag `SQLA0002` and are otherwise treated as unset — same handling as the target-dialect key.
- **Unset behavior:** exactly today's — version bounds never fire without a declared version, and the key has no effect without `sqlartisan_target_dbms`.
- **Resolution order:** a version bound refines the **matrix step** (user arity override → user member override → matrix, version-refined → silence), so `sqlartisan_construct_*` overrides keep the last word and an entry-less construct still can't false-positive.

Recorded as a docs note rather than an ADR 0008 amendment because accepted ADRs are immutable (`docs/adr/README.md`) and the reservation slots into ADR 0008's precedence order without changing it.

## Verification

The `DocsIndexTests` gate (page `## ` headings ↔ index links) was verified with an exact logic replica — this environment's network policy blocks the pinned .NET 10 SDK download, so CI is the authoritative run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cnyqpg4mL23TeoPX9Zw9k5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cnyqpg4mL23TeoPX9Zw9k5)_