### PR TITLE
test: Live-verify correlated-DML aliased targets on Oracle and MySQL (#255)

### DIFF
--- a/tests/SqlArtisan.IntegrationTests/Tests/MySqlTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/MySqlTests.cs
@@ -117,4 +117,28 @@ public sealed class MySqlTests : IntegrationTestBase, IClassFixture<MySqlFixture
 
         Assert.Contains("10001", address);
     }
+
+    [Fact] // #255 / #239 (ERG-09): MySQL accepts a single-table DELETE with an
+           // aliased target (`DELETE FROM users AS `cu``) as of 8.0.16; the pinned
+           // mysql:8.0 image is well past that boundary. This is the safe spelling
+           // for a correlated DELETE on MySQL, so proving it runs clears the
+           // grammar-unverified register entry.
+    public void DeleteAliasedTarget_Executes()
+    {
+        UsersTable cu = new("cu");
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        connection.Execute(
+            InsertInto(u, u.Id, u.Name, u.Age, u.DepartmentId).Values(300, "Temp", 20, 99),
+            transaction);
+        connection.Execute(DeleteFrom(cu).Where(cu.Id == 300), transaction);
+
+        long remaining = Convert.ToInt64(connection.ExecuteScalar(
+            Select(Count(u.Id)).From(u).Where(u.Id == 300), transaction));
+
+        Assert.Equal(0, remaining);
+        transaction.Rollback();
+    }
 }

--- a/tests/SqlArtisan.IntegrationTests/Tests/OracleTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/OracleTests.cs
@@ -226,4 +226,62 @@ public sealed class OracleTests : IntegrationTestBase, IClassFixture<OracleFixtu
 
         Assert.Contains("10001", address);
     }
+
+    [Fact] // #255 / #239 (GAP-10, C5/C6): Oracle accepts the bare-separator DML
+           // target alias `UPDATE users "cu"`, so a correlated subquery can
+           // reference the outer row through the alias — the safe spelling that
+           // avoids the unaliased tautology where the outer column silently
+           // resolves to the inner table. Clears the grammar-unverified register
+           // entry for the Oracle aliased correlated UPDATE.
+    public void CorrelatedUpdate_AliasedTarget_Executes()
+    {
+        UsersTable cu = new("cu");
+        OrdersTable o = new("o");
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        // department_id = 999 for exactly the users referenced by an order
+        // ({1, 2, 3, 5}); the subquery correlates orders back to the outer
+        // "cu".id, so without the alias the bare column would resolve to orders.
+        connection.Execute(
+            Update(cu)
+                .Set(cu.DepartmentId == 999)
+                .Where(cu.Id.In(Select(o.UserId).From(o).Where(o.UserId == cu.Id))),
+            transaction);
+
+        long updated = Convert.ToInt64(connection.ExecuteScalar(
+            Select(Count(u.Id)).From(u).Where(u.DepartmentId == 999), transaction));
+
+        Assert.Equal(4, updated);
+        transaction.Rollback();
+    }
+
+    [Fact] // #255 / #239 (GAP-10, C5/C6): the DELETE counterpart — Oracle accepts
+           // the bare-separator DELETE target alias `DELETE FROM users "cu"`, so
+           // the correlated subquery references the outer row safely. Clears the
+           // grammar-unverified register entry for the Oracle aliased correlated
+           // DELETE.
+    public void CorrelatedDelete_AliasedTarget_Executes()
+    {
+        UsersTable cu = new("cu");
+        OrdersTable o = new("o");
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        // Delete the users referenced by an order ({1, 2, 3, 5}); Dave (4) has no
+        // order and remains. The subquery correlates orders back to the outer
+        // "cu".id.
+        connection.Execute(
+            DeleteFrom(cu)
+                .Where(cu.Id.In(Select(o.UserId).From(o).Where(o.UserId == cu.Id))),
+            transaction);
+
+        long remaining = Convert.ToInt64(connection.ExecuteScalar(
+            Select(Count(u.Id)).From(u), transaction));
+
+        Assert.Equal(1, remaining);
+        transaction.Rollback();
+    }
 }


### PR DESCRIPTION
Closes #255.

Adds integration tests that execute the aliased-target correlated DML forms against real engines, clearing three `grammar-unverified` register entries from the #225 audit (part of the #239 correlated-DML family).

## What changed

- **`OracleTests`** — `CorrelatedUpdate_AliasedTarget_Executes` and `CorrelatedDelete_AliasedTarget_Executes`. Both exercise Oracle's bare-separator DML target alias (`UPDATE users "cu"` / `DELETE FROM users "cu"`), with a correlated subquery that references the outer row **through the alias** — the safe spelling that avoids the unaliased tautology where the outer column silently resolves to the inner table (GAP-10, C5/C6).
- **`MySqlTests`** — `DeleteAliasedTarget_Executes`. A single-table `DELETE FROM users AS ` + backtick `cu`, valid since MySQL 8.0.16; the pinned `mysql:8.0` image is well past that boundary (ERG-09).

Tests only; no `src/` changes.

## Why per-engine tests, not `MatrixSweepCatalog`

The issue lists these as sweep additions, but the sweep is keyed by matrix **construct** and asserts both ways on every engine. DML-target aliasing is not a matrix construct — `Update` / `DeleteFrom` already have sweep cases, and the catalog is keyed, so a second entry can't attach there. These live with the other engine-specific DML proofs (`Merge_UpsertViaMerge_Executes`, `ReturningInto_…`), exactly as the #239 note anticipated ("the positive side is covered by OracleTests").

## Verification

Ran the **Integration Tests** workflow on this branch ([run 28875677216](https://github.com/h-tacayama/SqlArtisan/actions/runs/28875677216)) — all five engines green, including the Oracle and MySQL lanes carrying the new tests. The run predates the rebase onto `main`, but the added test files are byte-identical and the integration suite doesn't touch the docs commit that was squashed, so the result stands.

## Register / docs follow-through

- The three items move out of the `grammar-unverified` register — noted on #255.
- The MySQL 8.0.16 version boundary is already registered as a #232 interval seed (in `.claude/rules/dbms-differences.md` and #263's seed register). The user-facing per-dialect version-boundary note belongs on #253's correlated-DML docs page (its natural home), so it's deferred there rather than orphaned here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cnyqpg4mL23TeoPX9Zw9k5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cnyqpg4mL23TeoPX9Zw9k5)_