### PR TITLE
chore: Pin Oracle integration image and correct the integration-test skill

### DIFF
--- a/.claude/skills/sa-run-integration-tests/SKILL.md
+++ b/.claude/skills/sa-run-integration-tests/SKILL.md
@@ -22,8 +22,9 @@ lane with `--filter`.
 
 - **A running Docker daemon** for the four container engines (Testcontainers
   pulls and starts a container per lane). SQLite needs nothing.
-- First run pulls images; **Oracle (`gvenzl/oracle-free`) is large and slow to
-  start** (a minute or two), so it dominates wall-clock.
+- First run pulls images; **Oracle (`gvenzl/oracle-xe:21.3.0-slim-faststart`,
+  XE 21c — pinned in `OracleFixture`, same version the docs cite) is large and
+  slow to start** (a minute or two), so it dominates wall-clock.
 
 ## Run it
 
@@ -52,6 +53,15 @@ Oracle) must run on a real Docker host — a local dev machine or CI. Don't
 interpret a container-lane failure *here* as a product bug; it's the missing
 daemon. Verify those four in CI (below).
 
+Worse in a cloud session with only the .NET 8 SDK: `global.json` pins .NET 10,
+so `dotnet build`/`test` fails outright and you can't even **compile** the
+integration project locally. And the per-PR `ci.yml` builds only
+`SqlArtisan.Tests` and `SqlArtisan.Analyzers.Tests` — **not**
+`SqlArtisan.IntegrationTests` — so a compile error in an integration test never
+surfaces on the PR either. When you touch this project from such a session, the
+dispatched integration run (below) is your *only* gate: it both compiles and
+executes the tests.
+
 ## Run it in CI
 
 The matrix lives in `.github/workflows/integration.yml` as a per-engine matrix
@@ -65,10 +75,22 @@ per-PR fast loop** (`ci.yml`) by design — unit tests are the inner loop. It ru
 - as a **release gate** — `release.yml` calls it via `workflow_call`, so the
   NuGet `publish` job only runs after a green matrix.
 
-To validate the container engines on a feature branch *before* merge (since
-`workflow_dispatch` only shows for workflows already on the default branch),
-temporarily add a `pull_request:` trigger to `integration.yml`, push, confirm
-green, then remove it before merging. (This is exactly how #151 was landed.)
+**Validate a feature branch before merge — just dispatch it against the branch
+ref.** The GitHub UI only lists `workflow_dispatch` for workflows already on the
+default branch, but the *API* dispatches against any ref: because
+`integration.yml` is already on `main`, `actions_run_trigger` with
+`ref: <your-branch>` runs the workflow **against your branch's code**, new tests
+included. No `pull_request:`-trigger hack, no push-to-default:
+
+```
+actions_run_trigger(run_workflow, workflow_id="integration.yml", ref="<your-branch>")
+```
+
+Then read per-lane results — the matrix is `fail-fast: false`, so lanes stand
+alone — with `actions_list(list_workflow_jobs, <run-id>)`: each job is named
+`integration (<Engine>)` with its own `conclusion`. (Rebasing the branch after a
+green run doesn't invalidate it as long as the touched test files are unchanged
+and the run covered the lanes you care about.)
 
 ## Adding coverage
 
@@ -88,12 +110,22 @@ green, then remove it before merging. (This is exactly how #151 was landed.)
   repeated-parameter GROUP BY? — the GAP-19/#241 pattern), write a dedicated
   test that records accept/reject per engine instead; promote the fact into
   the matrix + a sweep case only after the results are in.
+- **The sweep can't hold a spelling variation of an existing construct.** The
+  catalog is keyed by `MatrixKey` (member name + optional arity), so there is
+  one entry per construct. A *grammar/spelling variation* of a construct that
+  already has a matrix key — e.g. aliasing a DML target (`UPDATE users "cu"` on
+  Oracle, or MySQL's backtick-quoted `AS` form), where `Update` / `DeleteFrom`
+  are already swept — has no key of its own and can't be a second sweep entry.
+  Verify it in the per-engine class alongside the other engine-specific DML
+  proofs (this is where the #255 correlated-DML alias checks live).
 
 ## Notes
 
-- A known Oracle bug (#165, CTE column alias → `ORA-00904`) is parked as a
-  **skipped** test, `OracleTests.Cte_AliasedColumn_KnownOracleBug` — un-skip it
-  when #165 is fixed.
+- The Oracle CTE-column-alias bug (#165, re-aliased CTE column → `ORA-00904`)
+  is **fixed**; `OracleTests.Cte_AliasedColumn_Executes` stands as its active
+  regression guard (a re-aliased CTE column now emits a bare alias that resolves
+  on Oracle). The still-skipped Oracle tests are the ones XE 21c genuinely can't
+  run — no native boolean (`is_active` is `NUMBER(1)`), no multi-row `VALUES`.
 - This complements `sa-run-sql-harness` (which only *observes* the emitted string)
   and `sa-run-benchmark`: use this when "does it actually run on the engine?" is the
   question.

--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/OracleFixture.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/OracleFixture.cs
@@ -5,13 +5,18 @@ using Testcontainers.Oracle;
 namespace SqlArtisan.IntegrationTests.Infrastructure;
 
 /// <summary>
-/// Oracle fixture, backed by the Testcontainers <c>oracle</c> module's default
-/// image (gvenzl/oracle-free). The image is large and slow to start, so the
-/// Oracle lane is the heaviest entry in the matrix.
+/// Oracle fixture, backed by Oracle Database XE 21c
+/// (<c>gvenzl/oracle-xe:21.3.0-slim-faststart</c>). The tag is pinned
+/// explicitly — matching the other fixtures — so the verified-against version
+/// is deterministic rather than tracking the Testcontainers module's default,
+/// which has drifted across releases. The image is large and slow to start, so
+/// the Oracle lane is the heaviest entry in the matrix.
 /// </summary>
 public sealed class OracleFixture : IAsyncLifetime, IDatabaseFixture
 {
-    private readonly OracleContainer _container = new OracleBuilder().Build();
+    private readonly OracleContainer _container = new OracleBuilder()
+        .WithImage("gvenzl/oracle-xe:21.3.0-slim-faststart")
+        .Build();
 
     public Dbms Dbms => Dbms.Oracle;
 


### PR DESCRIPTION
Follow-up from verifying #255 — pins the Oracle integration image and corrects several stale/incorrect facts in the `sa-run-integration-tests` skill that surfaced during that work.

## Code — `OracleFixture`

Pins the container image to `gvenzl/oracle-xe:21.3.0-slim-faststart` (Oracle XE 21c) with an explicit `.WithImage(...)`, matching the other three fixtures. This is the **exact image the `Testcontainers.Oracle` 3.10.0 default already resolves to** (extracted from the package DLL) and the version `docs/analyzer.md` already cites — so it's a **zero-behavior-change** pin that just stops the verified-against version from drifting with the module default. The Oracle lane ran green with the explicit pin ([run 28877255516](https://github.com/h-tacayama/SqlArtisan/actions/runs/28877255516) — all five engines).

## Skill — `sa-run-integration-tests/SKILL.md`

Corrections, each surfaced while doing #255:

1. **Feature-branch validation needs no `pull_request:`-trigger hack.** The old text said to temporarily add a trigger and push; in fact `actions_run_trigger` with `ref: <branch>` dispatches the workflow **against the branch's code** (because `integration.yml` already lives on `main`). Documented that, plus reading per-lane results via `list_workflow_jobs` (the matrix is `fail-fast: false`).
2. **Neither the .NET 8 cloud session nor `ci.yml` compiles the integration project** — `ci.yml` builds only `SqlArtisan.Tests` / `Analyzers.Tests`, so a compile error in an integration test never shows on the PR; the dispatched run is the only gate.
3. **The sweep is keyed by `MatrixKey`**, so a spelling variation of an existing construct (DML-target aliasing, the #255 case) can't be a second sweep entry — it belongs in the per-engine class.
4. **Oracle image fact fixed**: it's `oracle-xe` 21c, not `oracle-free` (both the skill and the fixture comment were wrong).
5. **Stale `#165` note fixed**: that bug is fixed and `OracleTests.Cte_AliasedColumn_Executes` is its active regression guard — the note claimed a skipped `Cte_AliasedColumn_KnownOracleBug` test that doesn't exist.

## Verification

Docs/skill are not covered by any unit gate; the fixture change is exercised by the integration run linked above (Oracle lane green with the explicit pin). The per-PR `ci.yml` will run the unit suites, which this branch doesn't touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cnyqpg4mL23TeoPX9Zw9k5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cnyqpg4mL23TeoPX9Zw9k5)_