### PR TITLE
refactor: Consolidate empty-collection guards into CollectionGuard

### DIFF
--- a/src/SqlArtisan/Internal/SqlBuilder/ReturningBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/ReturningBuilder.cs
@@ -13,10 +13,9 @@ internal sealed class ReturningBuilder : IReturningBuilder
 
     internal static ReturningBuilder Create(SqlBuilderBase inner, object[] expressions)
     {
-        if (expressions.Length == 0)
-        {
-            throw new ArgumentException("At least one expression is required for Returning().");
-        }
+        CollectionGuard.ThrowIfEmpty(
+            expressions,
+            "At least one expression is required for Returning().");
 
         SqlPart[] resolved = SelectItemResolver.Resolve(expressions);
 
@@ -35,10 +34,9 @@ internal sealed class ReturningBuilder : IReturningBuilder
 
     public ISqlBuilder Into(params OutputParameter[] outputs)
     {
-        if (outputs.Length == 0)
-        {
-            throw new ArgumentException("At least one output parameter is required for Into().");
-        }
+        CollectionGuard.ThrowIfEmpty(
+            outputs,
+            "At least one output parameter is required for Into().");
 
         if (outputs.Length != _expressions.Length)
         {

--- a/src/SqlArtisan/Internal/SqlBuilder/Validation/CollectionGuard.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Validation/CollectionGuard.cs
@@ -1,11 +1,8 @@
 namespace SqlArtisan.Internal;
 
-// The eager guard for the many clause factories that require at least one item
-// (SELECT/GROUP BY/ORDER BY/PARTITION BY/DISTINCT ON lists, RETURNING and its
-// INTO outputs). Each formerly repeated the same `Length == 0` check inline; this
-// centralizes the throw so the shape is written once. The construct-specific
-// message stays at the call site — the wording names that construct and is
-// asserted verbatim by its tests.
+// The eager empty-collection guard for the clause factories that require at least
+// one item; centralizes the repeated `Length == 0` check, with the
+// construct-specific message supplied at the call site.
 internal static class CollectionGuard
 {
     internal static void ThrowIfEmpty<T>(T[] items, string message)

--- a/src/SqlArtisan/Internal/SqlBuilder/Validation/CollectionGuard.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Validation/CollectionGuard.cs
@@ -1,0 +1,18 @@
+namespace SqlArtisan.Internal;
+
+// The eager guard for the many clause factories that require at least one item
+// (SELECT/GROUP BY/ORDER BY/PARTITION BY/DISTINCT ON lists, RETURNING and its
+// INTO outputs). Each formerly repeated the same `Length == 0` check inline; this
+// centralizes the throw so the shape is written once. The construct-specific
+// message stays at the call site — the wording names that construct and is
+// asserted verbatim by its tests.
+internal static class CollectionGuard
+{
+    internal static void ThrowIfEmpty<T>(T[] items, string message)
+    {
+        if (items.Length == 0)
+        {
+            throw new ArgumentException(message);
+        }
+    }
+}

--- a/src/SqlArtisan/Internal/SqlPart/Clause/GroupBy/GroupByClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/GroupBy/GroupByClause.cs
@@ -6,11 +6,9 @@ internal sealed class GroupByClause : SqlPart
 
     private GroupByClause(SqlPart[] groupByItems)
     {
-        if (groupByItems.Length == 0)
-        {
-            throw new ArgumentException(
-                "GROUP BY requires at least one item.");
-        }
+        CollectionGuard.ThrowIfEmpty(
+            groupByItems,
+            "GROUP BY requires at least one item.");
 
         _groupByItems = groupByItems;
     }

--- a/src/SqlArtisan/Internal/SqlPart/Clause/OrderBy/OrderByClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/OrderBy/OrderByClause.cs
@@ -6,11 +6,9 @@ public sealed class OrderByClause : SqlPart
 
     private OrderByClause(SqlPart[] orderByItems)
     {
-        if (orderByItems.Length == 0)
-        {
-            throw new ArgumentException(
-                "ORDER BY requires at least one item.");
-        }
+        CollectionGuard.ThrowIfEmpty(
+            orderByItems,
+            "ORDER BY requires at least one item.");
 
         _orderByItems = orderByItems;
     }

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Over/PartitionByClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Over/PartitionByClause.cs
@@ -6,11 +6,9 @@ public sealed class PartitionByClause : SqlPart
 
     internal PartitionByClause(SqlExpression[] expressions)
     {
-        if (expressions.Length == 0)
-        {
-            throw new ArgumentException(
-                "PARTITION BY requires at least one expression.");
-        }
+        CollectionGuard.ThrowIfEmpty(
+            expressions,
+            "PARTITION BY requires at least one expression.");
 
         _expressions = expressions;
     }

--- a/src/SqlArtisan/Internal/SqlPart/DistinctOnKeyword.cs
+++ b/src/SqlArtisan/Internal/SqlPart/DistinctOnKeyword.cs
@@ -16,11 +16,9 @@ public sealed class DistinctOnKeyword : SqlPart
 
     internal DistinctOnKeyword(SqlExpression[] expressions)
     {
-        if (expressions.Length == 0)
-        {
-            throw new ArgumentException(
-                "DISTINCT ON requires at least one expression.");
-        }
+        CollectionGuard.ThrowIfEmpty(
+            expressions,
+            "DISTINCT ON requires at least one expression.");
 
         _expressions = expressions;
     }


### PR DESCRIPTION
## Summary

Several clause factories each repeated the identical shape

```csharp
if (items.Length == 0)
{
    throw new ArgumentException("<construct> requires at least one <item>.");
}
```

differing only by the message. This extracts that throw into a single internal helper, `CollectionGuard.ThrowIfEmpty<T>(T[] items, string message)`, and routes the sites through it. The reuse (~7 occurrences) is the same DRY case the existing `DmlTargetGuard` already serves for the aliased-target check — this just applies the same treatment to the most-repeated guard in the codebase.

## Sites migrated (on `main`)

| Site | Message (unchanged) |
|---|---|
| `PartitionByClause` | PARTITION BY requires at least one expression. |
| `GroupByClause` | GROUP BY requires at least one item. |
| `OrderByClause` | ORDER BY requires at least one item. |
| `DistinctOnKeyword` | DISTINCT ON requires at least one expression. |
| `ReturningBuilder.Create` | At least one expression is required for Returning(). |
| `ReturningBuilder.Into` | At least one output parameter is required for Into(). |

The `SELECT` list guard (`SelectItemResolver.ResolveSelectList`) is introduced on the #236 branch, not `main`, so it isn't in this diff; it should route through `CollectionGuard` when #236 lands.

## What this is *not*

One-off, non-reused precondition checks stay inline by design — a helper there would be pure indirection: the multi-row `INSERT` row-length mismatch, `PERCENTILE_CONT`'s finite-fraction check, `Returning()`'s reject-`ExpressionAlias`, and the `OutputParameter` / `DbSequence` name checks. The principle is *consolidate the reused check, keep genuinely one-off checks local*.

## Behavior & verification

- **Behavior-preserving.** Only the throw's location changes; every message is byte-identical, so the existing exact-message tests are untouched and still pass.
- Core lib builds with **0 code warnings**; **573 unit tests pass**; `dotnet format --verify-no-changes` is clean.

## Relationship to #272 (#236)

This is the collection sibling of the empty-**condition** guard (`ConditionGuard.ThrowIfEmpty`) added in #272, kept as a separate PR so #272 stays scoped to the empty-condition policy. The two are file-disjoint and merge cleanly in either order. The `ThrowIf` naming idiom matches the direction taken for the guards in #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012UtMyUvccKfkPJJmDHmsVh)_