### PR TITLE
chore: Add a code-comments convention and a review-time comment audit

### DIFF
--- a/.claude/rules/code-comments.md
+++ b/.claude/rules/code-comments.md
@@ -9,19 +9,36 @@ paths:
 
 Comment the **why**, never the **what**. The code already states what it does; a
 comment that paraphrases the adjacent statement, a method or field name, or an
-exception message it throws is noise — delete it.
+exception message it throws is noise. **Default to no comment** — add one only
+for a non-obvious rationale (a design choice, a hazard avoided, an ordering or
+timing that matters, an allocation note per ADR 0006, a dialect quirk).
 
-- **Default to no comment.** Add one only for a non-obvious rationale: a design
-  choice, a hazard avoided, an ordering or timing that matters, an allocation
-  note (ADR 0006), a dialect quirk.
-- **Shortest form that carries the why.** One line is the target; two is a lot;
-  more needs a real reason. Trim to a clause before adding a second sentence.
-- **Don't echo the guard or its message.** A throw's message is self-documenting;
-  a comment near it earns its place only by adding why (e.g. why guard *here*, not
-  elsewhere), never by restating it.
-- **No enumerations the code or call sites already show** — a list of every
-  position, caller, or dialect a helper serves. State the rule once; the code is
-  the index.
+## Length defaults
 
-Audited at review time: the `sa-review-changes` skill flags diff comments that
-break this and trims them.
+- Inline `//`: **one line preferred, two max**.
+- Doc/block prose (`///` remarks, header comments): **three lines max**.
+- **At most one** example per comment; none if a nearby test shows it.
+- **Never** enumerate three or more items (positions, callers, dialects, cases)
+  the code or call sites already name.
+
+A comment past these earns its length only by carrying a real *why* (hazard /
+ordering / allocation); otherwise trim.
+
+## Comment smells — audit every comment against these
+
+| # | Smell | How to spot it | Fix |
+|---|---|---|---|
+| 1 | Restates the code | words mirror the next statement, a method/field name, or a throw message | delete |
+| 2 | Echoes the message | paraphrases an adjacent throw/log string | delete (keep only to add *why here*) |
+| 3 | Over-enumeration | lists ≥3 items the code / call sites already name | state the rule once; drop the list |
+| 4 | Excess examples | ≥2 `e.g.` / inline examples, or one a test already shows | keep ≤1 |
+| 5 | Filler phrasing | has "Note that", "In order to", "It's important to", "Basically", "simply", "just", "obviously", "This is done so that" | rewrite without it (usually a clause shorter) |
+| 6 | Over-length | exceeds the length defaults with no real why | trim to the why; split unclear code instead of narrating it |
+| 7 | Duplicated rationale | the same why on ≥2 sibling members / clauses | state once (shared type or first site); reference, don't repeat |
+| 8 | Re-documents policy | restates something already in a rule / ADR / CHANGELOG | short pointer, or nothing |
+
+Smells 5 and 6 are near-mechanical (a greppable phrase list, a line count);
+1 / 2 / 7 / 8 need the *is-the-why-non-obvious* judgment.
+
+Audited at review time — the `sa-review-changes` skill runs this checklist over
+the diff.

--- a/.claude/rules/code-comments.md
+++ b/.claude/rules/code-comments.md
@@ -1,0 +1,27 @@
+---
+description: Inline comment conventions — comment the why, never the what; keep it short
+paths:
+  - "src/**/*.cs"
+  - "tests/**/*.cs"
+---
+
+# Code comments
+
+Comment the **why**, never the **what**. The code already states what it does; a
+comment that paraphrases the adjacent statement, a method or field name, or an
+exception message it throws is noise — delete it.
+
+- **Default to no comment.** Add one only for a non-obvious rationale: a design
+  choice, a hazard avoided, an ordering or timing that matters, an allocation
+  note (ADR 0006), a dialect quirk.
+- **Shortest form that carries the why.** One line is the target; two is a lot;
+  more needs a real reason. Trim to a clause before adding a second sentence.
+- **Don't echo the guard or its message.** A throw's message is self-documenting;
+  a comment near it earns its place only by adding why (e.g. why guard *here*, not
+  elsewhere), never by restating it.
+- **No enumerations the code or call sites already show** — a list of every
+  position, caller, or dialect a helper serves. State the rule once; the code is
+  the index.
+
+Audited at review time: the `sa-review-changes` skill flags diff comments that
+break this and trims them.

--- a/.claude/skills/sa-review-changes/SKILL.md
+++ b/.claude/skills/sa-review-changes/SKILL.md
@@ -97,10 +97,10 @@ check the diff against each:
   one-way"), keeping copy-on-write open as a later bug-fix. Flag docs or code
   that locks mutation in.
 - **Comment audit.** Comments are part of the diff — hold them to the same bar.
-  Scan every added or changed `//` and `///`: delete any that restate the code or
-  echo a nearby name / exception message, and trim any past the one-line-preferred
-  target in `.claude/rules/code-comments.md` to why-only. AI-written diffs skew
-  verbose here, so this is a required pass, not an optional one.
+  Run the `.claude/rules/code-comments.md` smell checklist (1–8) and length
+  defaults over every added or changed `//` and `///`; delete restatements and
+  message-echoes, and trim anything over the defaults to why-only. AI-written
+  diffs skew verbose here, so this is a required pass, not an optional one.
 
 ## 5. Verify empirically with a throwaway harness
 

--- a/.claude/skills/sa-review-changes/SKILL.md
+++ b/.claude/skills/sa-review-changes/SKILL.md
@@ -96,6 +96,11 @@ check the diff against each:
   never *promise* mutation (the contract wording is "a partial chain is
   one-way"), keeping copy-on-write open as a later bug-fix. Flag docs or code
   that locks mutation in.
+- **Comment audit.** Comments are part of the diff — hold them to the same bar.
+  Scan every added or changed `//` and `///`: delete any that restate the code or
+  echo a nearby name / exception message, and trim any past the one-line-preferred
+  target in `.claude/rules/code-comments.md` to why-only. AI-written diffs skew
+  verbose here, so this is a required pass, not an optional one.
 
 ## 5. Verify empirically with a throwaway harness
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,8 @@ there, not here — a pointer line in this list is enough.
   the `sa-run-sql-harness` skill.
 - Update `CHANGELOG.md` for user-visible changes. Usage examples live in
   `docs/`, not in the README.
+- Comment the **why**, never the **what**; keep comments short. See
+  `.claude/rules/code-comments.md`.
 
 ## Git
 


### PR DESCRIPTION
## Summary

AI-written diffs skew toward verbose inline comments that restate the code. This adds a small mechanism so that tendency is caught in two places — when writing and at review — rather than one comment at a time by hand.

## What's added

- **`.claude/rules/code-comments.md`** (new) — the convention: comment the *why*, never the *what*; shortest form that carries the why (one line preferred); don't echo a guard's own exception message; no enumerations the code or call sites already show. `paths` scope it to `src/**/*.cs` and `tests/**/*.cs`, so it auto-loads whenever those files are edited.
- **`CLAUDE.md`** — a one-line pointer in the conventions list (per the file's own "a pointer line is enough" rule; the convention body lives in the rule).
- **`sa-review-changes` skill** — a required **Comment audit** step under §4: scan every added/changed `//` and `///` in the diff, delete restatements and message echoes, and trim anything past the one-line target to why-only.

## Why a rule + a skill step (not a hook)

"Unnecessarily long comment" is a judgment call, not something a deterministic linter/hook can flag well — so the mechanism is an auto-loaded convention (shapes writing) plus an explicit review pass (catches what slipped through), which is where this repo already puts its conventions and procedures.

## Notes

- Docs-only; no code, no test impact.
- Independent of the in-flight #272 (empty-condition policy) and merges cleanly alongside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012UtMyUvccKfkPJJmDHmsVh)_