### PR TITLE
chore: Bump version to 0.6.0-beta.1 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [0.6.0-beta.1] - 2026-07-14
 ### Added
 - Opt-in Roslyn analyzer, shipped inside the `SqlArtisan` package with no extra reference. Set a target dialect — `sqlartisan_target_dbms` in `.editorconfig`, or `<SqlArtisanTargetDbms>` as an MSBuild property — and `SQLA0001` warns when a construct isn't supported there, per a curated dialect matrix verified against live engines. `SQLA0002` flags an unrecognized `.editorconfig` value. Every warning names the per-construct override key that would silence or force it. Severity is controlled the standard way (`dotnet_diagnostic.SQLA0001.severity`), so a mismatch can be promoted to a build error. See `docs/analyzer.md`. (#93)
 - Added `Asterisk` for the bare `*` select item (`Select(Asterisk)` → `SELECT *`) and `.Asterisk` on every table class, CTE, and derived table for the qualified star (`Select(u.Asterisk)` → `SELECT “u”.*`). Both also work in `RETURNING` and are select-item-only — expression positions reject them, except `Count(Asterisk)` which emits `COUNT(*)`. On Oracle a bare `*` must be the sole select item — beside other items, use the qualified star. See `docs/query-statements.md`. (#233, #242)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,8 +6,8 @@
     inherit it, so a release never drifts between packages. (#118)
   -->
   <PropertyGroup>
-    <VersionPrefix>0.5.0</VersionPrefix>
-    <VersionSuffix>beta.2</VersionSuffix>
+    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionSuffix>beta.1</VersionSuffix>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
## Summary
- Bump `Directory.Build.props`: `VersionPrefix 0.5.0→0.6.0`, `VersionSuffix beta.2→beta.1` — the shipped version for all three packages (`SqlArtisan` / `SqlArtisan.Dapper` / `SqlArtisan.TableClassGen`).
- Close out `CHANGELOG.md`'s `[Unreleased]` section as `[0.6.0-beta.1] - 2026-07-14` and open a fresh empty `[Unreleased]` above it.
- Minor bump (not patch) because `Unreleased` carries four `Breaking:`-marked changes: `DbColumn` constructor signature, `Concat` overload split, the row-limiting-clause subquery interface change, and the `SqlArtisan.Internal` → root namespace moves — matching the project's existing convention (e.g. 0.4.0 → 0.5.0 for the analytic-function breaking change).

## Test plan
- [x] `dotnet format SqlArtisan.sln --verify-no-changes`
- [x] `dotnet build SqlArtisan.sln -c Release`
- [x] `dotnet test tests/SqlArtisan.Tests -c Release` — 713 passed
- [x] `dotnet test tests/SqlArtisan.Analyzers.Tests -c Release` — 288 passed
- [ ] Merge, then tag `v0.6.0-beta.1` on `main` and push the tag to trigger `release.yml` (verify → integration matrix → publish to nuget.org)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QfrC2XJrC9ipKyHyuHSQ13)_