### PR TITLE
docs: Sharpen the code-comments rule to why / why-not only

### DIFF
--- a/.claude/rules/code-comments.md
+++ b/.claude/rules/code-comments.md
@@ -1,5 +1,5 @@
 ---
-description: Inline comment conventions — comment the why, never the what; keep it short
+description: Inline comment conventions — comment the why / why-not, never the what; keep it short
 paths:
   - "src/**/*.cs"
   - "tests/**/*.cs"
@@ -7,11 +7,14 @@ paths:
 
 # Code comments
 
-Comment the **why**, never the **what**. The code already states what it does; a
-comment that paraphrases the adjacent statement, a method or field name, or an
-exception message it throws is noise. **Default to no comment** — add one only
-for a non-obvious rationale (a design choice, a hazard avoided, an ordering or
-timing that matters, an allocation note per ADR 0006, a dialect quirk).
+Comment the **why** and the **why-not**, never the **what**. The *why* is the
+non-obvious rationale behind the code; the *why-not* is a rejected alternative or
+an avoided hazard the code itself can't show. Anything derivable from the code —
+what a statement does, a method or field name, an exception message it throws —
+is not a comment; it is noise. **Default to no comment** — add one only for a
+non-obvious why / why-not (a design choice, a rejected alternative, a hazard
+avoided, an ordering or timing that matters, an allocation note per ADR 0006, a
+dialect quirk).
 
 ## Length defaults
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ sa-run-integration-tests, sa-run-sql-harness, sa-write-xml-docs.
   the `sa-run-sql-harness` skill.
 - Update `CHANGELOG.md` for user-visible changes. Usage examples live in
   `docs/`, not in the README.
-- Comment the **why**, never the **what**; keep comments short. See
+- Comment the **why** / **why-not**, never the **what**; keep comments short. See
   `.claude/rules/code-comments.md`.
 
 ## Git


### PR DESCRIPTION
State explicitly that inline comments carry only the why (non-obvious rationale) and the why-not (a rejected alternative or avoided hazard), and that anything derivable from the code is noise. Update the CLAUDE.md pointer to match.


Claude-Session: https://claude.ai/code/session_016xbXhZrdViS71YhmJbXMi4