### PR TITLE
feat: Add SQL Server OUTPUT clause (INSERTED./DELETED., OUTPUT … INTO)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Added SQL Server's `OUTPUT` clause — read back affected rows from the `INSERTED` / `DELETED` pseudo-tables (`Inserted(col)` / `Deleted(col)`) with a positioned `.Output(...)` step on `INSERT` / `UPDATE` / `DELETE`. Chain `.Into(archive, cols...)` for `OUTPUT ... INTO`, the single-statement archive-then-delete form. See [OUTPUT (SQL Server)](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/query-statements.md#output-clause-sql-server). (#259)
 - Added joined `UPDATE` / `DELETE` — update or delete rows using columns from other tables, each dialect in its own spelling: PostgreSQL's `UPDATE ... FROM` and `DELETE ... USING` (plus SQLite's `UPDATE ... FROM`, 3.33+), and MySQL / SQL Server's `FROM ... JOIN` forms. Start from `Update(target)` / `DeleteFrom(target)` and chain `.From(...)` / `.Using(...)` / `.InnerJoin(...).On(...)` in the dialect's own order; the joined target must be aliased. See [Joined UPDATE / DELETE](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/query-statements.md#joined-update--delete). (#258)
 
 ## [0.6.0-beta.1] - 2026-07-14

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,9 @@ How to assemble each statement and clause.
 - **RETURNING** —
   [RETURNING](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/query-statements.md#returning-clause) ·
   [RETURNING INTO (Oracle)](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/query-statements.md#returning-into-oracle)
-- **[OUTPUT (SQL Server)](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/query-statements.md#output-clause-sql-server)**
+- **OUTPUT (SQL Server)** —
+  [OUTPUT](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/query-statements.md#output-clause-sql-server) ·
+  [OUTPUT … INTO](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/query-statements.md#output--into)
 
 ## [Expressions](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/expressions.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ How to assemble each statement and clause.
 - **RETURNING** —
   [RETURNING](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/query-statements.md#returning-clause) ·
   [RETURNING INTO (Oracle)](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/query-statements.md#returning-into-oracle)
+- **[OUTPUT (SQL Server)](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/query-statements.md#output-clause-sql-server)**
 
 ## [Expressions](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/expressions.md)
 

--- a/docs/query-statements.md
+++ b/docs/query-statements.md
@@ -1206,4 +1206,47 @@ int deletedId = outputs.Get<int>("outId");
 string deletedName = outputs.Get<string>("outName");
 ```
 
-**Note:** `RETURNING` is supported by Oracle, PostgreSQL, and SQLite (3.35+). It is not supported by SQL Server (which uses `OUTPUT`) or MySQL. The `RETURNING ... INTO` form is Oracle-specific. SqlArtisan does not validate database feature support, so ensure the clause is valid for your target DBMS.
+**Note:** `RETURNING` is supported by Oracle, PostgreSQL, and SQLite (3.35+). It is not supported by SQL Server (which uses [`OUTPUT`](#output-clause-sql-server)) or MySQL. The `RETURNING ... INTO` form is Oracle-specific. SqlArtisan does not validate database feature support, so ensure the clause is valid for your target DBMS.
+
+## OUTPUT Clause (SQL Server)
+
+SQL Server's `OUTPUT` is the counterpart to [`RETURNING`](#returning-clause): it reads back the rows an `INSERT`, `UPDATE`, or `DELETE` affects, from the `INSERTED` and `DELETED` pseudo-tables via `Inserted(col)` / `Deleted(col)`. Unlike `RETURNING`, `OUTPUT` sits mid-statement — after the column list on `INSERT`, after `SET` on `UPDATE`, after the target on `DELETE` — so it is a positioned `.Output(...)` step, chained before `VALUES` / `WHERE` / `FROM`.
+
+`INSERT` sees only `INSERTED`; `DELETE` only `DELETED`; `UPDATE` both — the row's pre-image (`DELETED`) and post-image (`INSERTED`). Column aliases are allowed (`Deleted(u.Age).As("old_age")`).
+
+```csharp
+UsersTable u = new();
+SqlStatement sql =
+    Update(u)
+    .Set(u.Age == 30)
+    .Output(Deleted(u.Age), Inserted(u.Age))
+    .Where(u.Id == 5)
+    .Build(Dbms.SqlServer);
+
+// UPDATE users SET age = @0
+// OUTPUT DELETED.age, INSERTED.age
+// WHERE id = @1
+```
+
+### OUTPUT … INTO
+
+Chain `.Into(archive, cols...)` after `.Output(...)` to copy the output rows into an archive table instead of returning them to the caller. This is the single-statement archive-then-delete form, and the only `OUTPUT` spelling exempt from the AFTER-trigger limitation that blocks a plain `OUTPUT` on a triggered table:
+
+```csharp
+RentalTable rental = new();
+RentalArchiveTable archive = new();
+DateTime cutoff = new(2024, 1, 1);
+SqlStatement sql =
+    DeleteFrom(rental)
+    .Output(Deleted(rental.RentalId), Deleted(rental.CustomerId))
+    .Into(archive, archive.RentalId, archive.CustomerId)
+    .Where(rental.RentalDate < cutoff)
+    .Build(Dbms.SqlServer);
+
+// DELETE FROM rental
+// OUTPUT DELETED.rental_id, DELETED.customer_id
+// INTO rental_archive (rental_id, customer_id)
+// WHERE rental_date < @0
+```
+
+**Dialect note:** `OUTPUT` is SQL Server syntax; on MySQL, Oracle, PostgreSQL, and SQLite it is unavailable — use [`RETURNING`](#returning-clause) on Oracle, PostgreSQL, and SQLite (MySQL has neither).

--- a/docs/query-statements.md
+++ b/docs/query-statements.md
@@ -24,6 +24,8 @@
   - [Standard](#standard-syntax) · [Multiple Rows](#multiple-rows) · [SET-like](#alternative-syntax-set-like) · [INSERT … SELECT](#insert-select-syntax) · [UPSERT](#upsert-insert-update-or-skip) · [MERGE](#merge-statement) · [WITH / CTE](#with-clause-common-table-expressions)
 - [RETURNING](#returning-clause)
   - [RETURNING INTO (Oracle)](#returning-into-oracle)
+- [OUTPUT (SQL Server)](#output-clause-sql-server)
+  - [OUTPUT … INTO](#output--into)
 
 ---
 

--- a/src/SqlArtisan.Analyzers/DialectMatrix.cs
+++ b/src/SqlArtisan.Analyzers/DialectMatrix.cs
@@ -213,6 +213,15 @@ internal static class DialectMatrix
         // "Into" (the RETURNING ... INTO chain) is Oracle-specific — narrower than Returning itself.
         [new MatrixKey("Into")] = new DbmsSupport(mySql: false, oracle: true, postgreSql: false, sqlite: false, sqlServer: false),
 
+        // --- OUTPUT (SQL Server): the RETURNING counterpart, plus the INSERTED./DELETED.
+        // pseudo-table references. All SQL-Server-only. The OUTPUT ... INTO redirect is
+        // Into arity 2 (DbTableBase, params DbColumn[]); the arity-priority lookup keeps it
+        // distinct from the arity-1 Oracle "Into" above (same split as JOIN/MERGE "Using").
+        [new MatrixKey("Output")] = new DbmsSupport(mySql: false, oracle: false, postgreSql: false, sqlite: false, sqlServer: true),
+        [new MatrixKey("Inserted")] = new DbmsSupport(mySql: false, oracle: false, postgreSql: false, sqlite: false, sqlServer: true),
+        [new MatrixKey("Deleted")] = new DbmsSupport(mySql: false, oracle: false, postgreSql: false, sqlite: false, sqlServer: true),
+        [new MatrixKey("Into", 2)] = new DbmsSupport(mySql: false, oracle: false, postgreSql: false, sqlite: false, sqlServer: true),
+
         // --- MERGE sub-states narrower than the surrounding MergeInto/Using/On/WhenMatched/
         // WhenNotMatched scope (Oracle/PostgreSQL 15+/SQL Server) — a coverage gap the initial
         // pass left silent since these method names had no entry of their own at all.

--- a/src/SqlArtisan/Internal/SqlBuilder/Delete/DeleteBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Delete/DeleteBuilder.cs
@@ -3,8 +3,10 @@ namespace SqlArtisan.Internal;
 internal sealed class DeleteBuilder(DbTableBase table, DmlJoinState state, params SqlPart[] rootParts) :
     SqlBuilderBase(rootParts),
     IDeleteBuilderDelete,
+    IDeleteBuilderDeleteOutput,
     IDeleteBuilderFrom,
     IDeleteBuilderFromJoinOn,
+    IDeleteBuilderOutputInto,
     IDeleteBuilderUsing,
     IDeleteBuilderWhere
 {
@@ -49,6 +51,12 @@ internal sealed class DeleteBuilder(DbTableBase table, DmlJoinState state, param
         return this;
     }
 
+    public IDeleteBuilderDelete Into(DbTableBase archive, params DbColumn[] columns)
+    {
+        AddPart(new OutputIntoClause(archive, columns));
+        return this;
+    }
+
     public IDeleteBuilderFromJoinOn LeftJoin(TableReference joined)
     {
         AddJoin(new LeftJoinClause(joined));
@@ -58,6 +66,13 @@ internal sealed class DeleteBuilder(DbTableBase table, DmlJoinState state, param
     public IDeleteBuilderFrom On(SqlCondition condition)
     {
         AddPart(new OnClause(condition));
+        return this;
+    }
+
+    public IDeleteBuilderOutputInto Output(params object[] items)
+    {
+        CollectionGuard.ThrowIfEmpty(items, "OUTPUT requires at least one expression.");
+        AddPart(new OutputClause(SelectItemResolver.Resolve(items)));
         return this;
     }
 

--- a/src/SqlArtisan/Internal/SqlBuilder/Delete/DeleteBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Delete/DeleteBuilder.cs
@@ -51,9 +51,9 @@ internal sealed class DeleteBuilder(DbTableBase table, DmlJoinState state, param
         return this;
     }
 
-    public IDeleteBuilderDelete Into(DbTableBase archive, params DbColumn[] columns)
+    public IDeleteBuilderDelete Into(DbTableBase table, params DbColumn[] columns)
     {
-        AddPart(new OutputIntoClause(archive, columns));
+        AddPart(new OutputIntoClause(table, columns));
         return this;
     }
 

--- a/src/SqlArtisan/Internal/SqlBuilder/Delete/IDeleteBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Delete/IDeleteBuilder.cs
@@ -9,6 +9,6 @@ public interface IDeleteBuilder
     /// Opens <c>DELETE FROM table</c>.
     /// </summary>
     /// <param name="table">The table to delete from.</param>
-    /// <returns>The builder positioned for <c>WHERE</c>, <c>RETURNING</c>, or build.</returns>
-    IDeleteBuilderDelete DeleteFrom(DbTableBase table);
+    /// <returns>The builder positioned for <c>OUTPUT</c>, <c>WHERE</c>, <c>RETURNING</c>, or build.</returns>
+    IDeleteBuilderDeleteOutput DeleteFrom(DbTableBase table);
 }

--- a/src/SqlArtisan/Internal/SqlBuilder/Delete/IDeleteBuilderDeleteOutput.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Delete/IDeleteBuilderDeleteOutput.cs
@@ -1,0 +1,17 @@
+namespace SqlArtisan.Internal;
+
+/// <summary>
+/// The state after <c>DELETE FROM table</c>: as <see cref="IDeleteBuilderDelete"/>,
+/// and additionally return affected-row data with SQL Server's <c>OUTPUT</c>.
+/// </summary>
+public interface IDeleteBuilderDeleteOutput : IDeleteBuilderDelete
+{
+    /// <summary>
+    /// Appends <c>OUTPUT expr, ...</c> (SQL Server) to read values from the deleted
+    /// rows — reference the <c>DELETED</c> pseudo-table via
+    /// <see cref="Sql.Deleted(DbColumn)"/>.
+    /// </summary>
+    /// <param name="items">The columns or expressions to output; literals are auto-parameterized and <c>.As(...)</c> aliases are allowed.</param>
+    /// <returns>The builder positioned to redirect the output <c>Into(...)</c> an archive table, or continue with <c>WHERE</c> / <c>FROM</c> / <c>USING</c> / build.</returns>
+    IDeleteBuilderOutputInto Output(params object[] items);
+}

--- a/src/SqlArtisan/Internal/SqlBuilder/Delete/IDeleteBuilderOutputInto.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Delete/IDeleteBuilderOutputInto.cs
@@ -2,17 +2,17 @@ namespace SqlArtisan.Internal;
 
 /// <summary>
 /// The state after <c>DELETE FROM table OUTPUT ...</c> (SQL Server): optionally
-/// redirect the output <c>INTO</c> an archive table, or continue the statement.
+/// redirect the output <c>INTO</c> a table, or continue the statement.
 /// </summary>
 public interface IDeleteBuilderOutputInto : IDeleteBuilderDelete
 {
     /// <summary>
-    /// Appends <c>INTO archive (col, ...)</c> (SQL Server), redirecting the
-    /// <c>OUTPUT</c> rows into <paramref name="archive"/> instead of returning them
+    /// Appends <c>INTO table (col, ...)</c> (SQL Server), redirecting the
+    /// <c>OUTPUT</c> rows into <paramref name="table"/> instead of returning them
     /// to the caller — the single-statement archive-then-delete form.
     /// </summary>
-    /// <param name="archive">The table the output rows are inserted into.</param>
-    /// <param name="columns">The archive columns to populate, in output order; omit to target the archive's columns positionally.</param>
+    /// <param name="table">The table the output rows are inserted into.</param>
+    /// <param name="columns">The columns to populate, in output order; omit to target the table's columns positionally.</param>
     /// <returns>The builder positioned to continue with <c>WHERE</c> / <c>FROM</c> / <c>USING</c> / build.</returns>
-    IDeleteBuilderDelete Into(DbTableBase archive, params DbColumn[] columns);
+    IDeleteBuilderDelete Into(DbTableBase table, params DbColumn[] columns);
 }

--- a/src/SqlArtisan/Internal/SqlBuilder/Delete/IDeleteBuilderOutputInto.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Delete/IDeleteBuilderOutputInto.cs
@@ -1,0 +1,18 @@
+namespace SqlArtisan.Internal;
+
+/// <summary>
+/// The state after <c>DELETE FROM table OUTPUT ...</c> (SQL Server): optionally
+/// redirect the output <c>INTO</c> an archive table, or continue the statement.
+/// </summary>
+public interface IDeleteBuilderOutputInto : IDeleteBuilderDelete
+{
+    /// <summary>
+    /// Appends <c>INTO archive (col, ...)</c> (SQL Server), redirecting the
+    /// <c>OUTPUT</c> rows into <paramref name="archive"/> instead of returning them
+    /// to the caller — the single-statement archive-then-delete form.
+    /// </summary>
+    /// <param name="archive">The table the output rows are inserted into.</param>
+    /// <param name="columns">The archive columns to populate, in output order; omit to target the archive's columns positionally.</param>
+    /// <returns>The builder positioned to continue with <c>WHERE</c> / <c>FROM</c> / <c>USING</c> / build.</returns>
+    IDeleteBuilderDelete Into(DbTableBase archive, params DbColumn[] columns);
+}

--- a/src/SqlArtisan/Internal/SqlBuilder/Insert/IInsertBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Insert/IInsertBuilder.cs
@@ -32,6 +32,6 @@ public interface IInsertBuilder
     /// </summary>
     /// <param name="table">The table to insert into.</param>
     /// <param name="columns">The target columns, emitted in parentheses after the table name.</param>
-    /// <returns>The builder positioned to add rows via <c>Values(...)</c> or a <c>SELECT</c> source.</returns>
-    IInsertBuilderColumns InsertInto(DbTableBase table, params DbColumn[] columns);
+    /// <returns>The builder positioned to add <c>OUTPUT</c>, then rows via <c>Values(...)</c> or a <c>SELECT</c> source.</returns>
+    IInsertBuilderColumnsOutput InsertInto(DbTableBase table, params DbColumn[] columns);
 }

--- a/src/SqlArtisan/Internal/SqlBuilder/Insert/IInsertBuilderColumnsOutput.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Insert/IInsertBuilderColumnsOutput.cs
@@ -1,0 +1,18 @@
+namespace SqlArtisan.Internal;
+
+/// <summary>
+/// The state after <c>INSERT INTO table (col, ...)</c>: as
+/// <see cref="IInsertBuilderColumns"/>, and additionally return affected-row data
+/// with SQL Server's <c>OUTPUT</c> (emitted before <c>VALUES</c>/<c>SELECT</c>).
+/// </summary>
+public interface IInsertBuilderColumnsOutput : IInsertBuilderColumns
+{
+    /// <summary>
+    /// Appends <c>OUTPUT expr, ...</c> (SQL Server) to read values from the inserted
+    /// rows — reference the <c>INSERTED</c> pseudo-table via
+    /// <see cref="Sql.Inserted(DbColumn)"/>.
+    /// </summary>
+    /// <param name="items">The columns or expressions to output; literals are auto-parameterized and <c>.As(...)</c> aliases are allowed.</param>
+    /// <returns>The builder positioned to redirect the output <c>Into(...)</c> an archive table, or supply the rows with <c>Values(...)</c> / a <c>SELECT</c>.</returns>
+    IInsertBuilderColumnsOutputInto Output(params object[] items);
+}

--- a/src/SqlArtisan/Internal/SqlBuilder/Insert/IInsertBuilderColumnsOutputInto.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Insert/IInsertBuilderColumnsOutputInto.cs
@@ -1,0 +1,18 @@
+namespace SqlArtisan.Internal;
+
+/// <summary>
+/// The state after <c>INSERT INTO table (col, ...) OUTPUT ...</c> (SQL Server):
+/// optionally redirect the output <c>INTO</c> an archive table, then supply the rows.
+/// </summary>
+public interface IInsertBuilderColumnsOutputInto : IInsertBuilderColumns
+{
+    /// <summary>
+    /// Appends <c>INTO archive (col, ...)</c> (SQL Server), redirecting the
+    /// <c>OUTPUT</c> rows into <paramref name="archive"/> instead of returning them
+    /// to the caller.
+    /// </summary>
+    /// <param name="archive">The table the output rows are inserted into.</param>
+    /// <param name="columns">The archive columns to populate, in output order; omit to target the archive's columns positionally.</param>
+    /// <returns>The builder positioned to supply the rows with <c>Values(...)</c> / a <c>SELECT</c>.</returns>
+    IInsertBuilderColumns Into(DbTableBase archive, params DbColumn[] columns);
+}

--- a/src/SqlArtisan/Internal/SqlBuilder/Insert/IInsertBuilderColumnsOutputInto.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Insert/IInsertBuilderColumnsOutputInto.cs
@@ -2,17 +2,17 @@ namespace SqlArtisan.Internal;
 
 /// <summary>
 /// The state after <c>INSERT INTO table (col, ...) OUTPUT ...</c> (SQL Server):
-/// optionally redirect the output <c>INTO</c> an archive table, then supply the rows.
+/// optionally redirect the output <c>INTO</c> a table, then supply the rows.
 /// </summary>
 public interface IInsertBuilderColumnsOutputInto : IInsertBuilderColumns
 {
     /// <summary>
-    /// Appends <c>INTO archive (col, ...)</c> (SQL Server), redirecting the
-    /// <c>OUTPUT</c> rows into <paramref name="archive"/> instead of returning them
+    /// Appends <c>INTO table (col, ...)</c> (SQL Server), redirecting the
+    /// <c>OUTPUT</c> rows into <paramref name="table"/> instead of returning them
     /// to the caller.
     /// </summary>
-    /// <param name="archive">The table the output rows are inserted into.</param>
-    /// <param name="columns">The archive columns to populate, in output order; omit to target the archive's columns positionally.</param>
+    /// <param name="table">The table the output rows are inserted into.</param>
+    /// <param name="columns">The columns to populate, in output order; omit to target the table's columns positionally.</param>
     /// <returns>The builder positioned to supply the rows with <c>Values(...)</c> / a <c>SELECT</c>.</returns>
-    IInsertBuilderColumns Into(DbTableBase archive, params DbColumn[] columns);
+    IInsertBuilderColumns Into(DbTableBase table, params DbColumn[] columns);
 }

--- a/src/SqlArtisan/Internal/SqlBuilder/Insert/InsertBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Insert/InsertBuilder.cs
@@ -34,9 +34,9 @@ internal sealed class InsertBuilder(DbTableBase table, params SqlPart[] rootPart
         return this;
     }
 
-    public IInsertBuilderColumns Into(DbTableBase archive, params DbColumn[] columns)
+    public IInsertBuilderColumns Into(DbTableBase table, params DbColumn[] columns)
     {
-        AddPart(new OutputIntoClause(archive, columns));
+        AddPart(new OutputIntoClause(table, columns));
         return this;
     }
 

--- a/src/SqlArtisan/Internal/SqlBuilder/Insert/InsertBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Insert/InsertBuilder.cs
@@ -3,6 +3,8 @@ namespace SqlArtisan.Internal;
 internal sealed class InsertBuilder(DbTableBase table, params SqlPart[] rootParts) :
     SelectBuilder(rootParts),
     IInsertBuilderColumns,
+    IInsertBuilderColumnsOutput,
+    IInsertBuilderColumnsOutputInto,
     IInsertBuilderDoUpdateSet,
     IInsertBuilderOnConflict,
     IInsertBuilderSet,
@@ -32,6 +34,12 @@ internal sealed class InsertBuilder(DbTableBase table, params SqlPart[] rootPart
         return this;
     }
 
+    public IInsertBuilderColumns Into(DbTableBase archive, params DbColumn[] columns)
+    {
+        AddPart(new OutputIntoClause(archive, columns));
+        return this;
+    }
+
     public IInsertBuilderOnConflict OnConflict(params DbColumn[] conflictTarget)
     {
         AddPart(new OnConflictClause(conflictTarget));
@@ -42,6 +50,13 @@ internal sealed class InsertBuilder(DbTableBase table, params SqlPart[] rootPart
     {
         AddPart(new RowAliasClause());
         AddPart(OnDuplicateKeyUpdateClause.Parse(assignments));
+        return this;
+    }
+
+    public IInsertBuilderColumnsOutputInto Output(params object[] items)
+    {
+        CollectionGuard.ThrowIfEmpty(items, "OUTPUT requires at least one expression.");
+        AddPart(new OutputClause(SelectItemResolver.Resolve(items)));
         return this;
     }
 

--- a/src/SqlArtisan/Internal/SqlBuilder/Update/IUpdateBuilderOutputInto.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Update/IUpdateBuilderOutputInto.cs
@@ -1,0 +1,18 @@
+namespace SqlArtisan.Internal;
+
+/// <summary>
+/// The state after <c>UPDATE ... SET ... OUTPUT ...</c> (SQL Server): optionally
+/// redirect the output <c>INTO</c> an archive table, or continue the statement.
+/// </summary>
+public interface IUpdateBuilderOutputInto : IUpdateBuilderSet
+{
+    /// <summary>
+    /// Appends <c>INTO archive (col, ...)</c> (SQL Server), redirecting the
+    /// <c>OUTPUT</c> rows into <paramref name="archive"/> instead of returning them
+    /// to the caller.
+    /// </summary>
+    /// <param name="archive">The table the output rows are inserted into.</param>
+    /// <param name="columns">The archive columns to populate, in output order; omit to target the archive's columns positionally.</param>
+    /// <returns>The builder positioned to continue with <c>WHERE</c> / <c>FROM</c> / build.</returns>
+    IUpdateBuilderSet Into(DbTableBase archive, params DbColumn[] columns);
+}

--- a/src/SqlArtisan/Internal/SqlBuilder/Update/IUpdateBuilderOutputInto.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Update/IUpdateBuilderOutputInto.cs
@@ -2,17 +2,17 @@ namespace SqlArtisan.Internal;
 
 /// <summary>
 /// The state after <c>UPDATE ... SET ... OUTPUT ...</c> (SQL Server): optionally
-/// redirect the output <c>INTO</c> an archive table, or continue the statement.
+/// redirect the output <c>INTO</c> a table, or continue the statement.
 /// </summary>
 public interface IUpdateBuilderOutputInto : IUpdateBuilderSet
 {
     /// <summary>
-    /// Appends <c>INTO archive (col, ...)</c> (SQL Server), redirecting the
-    /// <c>OUTPUT</c> rows into <paramref name="archive"/> instead of returning them
+    /// Appends <c>INTO table (col, ...)</c> (SQL Server), redirecting the
+    /// <c>OUTPUT</c> rows into <paramref name="table"/> instead of returning them
     /// to the caller.
     /// </summary>
-    /// <param name="archive">The table the output rows are inserted into.</param>
-    /// <param name="columns">The archive columns to populate, in output order; omit to target the archive's columns positionally.</param>
+    /// <param name="table">The table the output rows are inserted into.</param>
+    /// <param name="columns">The columns to populate, in output order; omit to target the table's columns positionally.</param>
     /// <returns>The builder positioned to continue with <c>WHERE</c> / <c>FROM</c> / build.</returns>
-    IUpdateBuilderSet Into(DbTableBase archive, params DbColumn[] columns);
+    IUpdateBuilderSet Into(DbTableBase table, params DbColumn[] columns);
 }

--- a/src/SqlArtisan/Internal/SqlBuilder/Update/IUpdateBuilderSetOutput.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Update/IUpdateBuilderSetOutput.cs
@@ -1,0 +1,17 @@
+namespace SqlArtisan.Internal;
+
+/// <summary>
+/// The state after <c>UPDATE ... SET</c>: as <see cref="IUpdateBuilderSet"/>, and
+/// additionally return affected-row data with SQL Server's <c>OUTPUT</c>.
+/// </summary>
+public interface IUpdateBuilderSetOutput : IUpdateBuilderSet
+{
+    /// <summary>
+    /// Appends <c>OUTPUT expr, ...</c> (SQL Server) to read values from the updated
+    /// rows — reference the <c>INSERTED</c> / <c>DELETED</c> pseudo-tables via
+    /// <see cref="Sql.Inserted(DbColumn)"/> / <see cref="Sql.Deleted(DbColumn)"/>.
+    /// </summary>
+    /// <param name="items">The columns or expressions to output; literals are auto-parameterized and <c>.As(...)</c> aliases are allowed.</param>
+    /// <returns>The builder positioned to redirect the output <c>Into(...)</c> an archive table, or continue with <c>WHERE</c> / <c>FROM</c> / build.</returns>
+    IUpdateBuilderOutputInto Output(params object[] items);
+}

--- a/src/SqlArtisan/Internal/SqlBuilder/Update/IUpdateBuilderUpdate.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Update/IUpdateBuilderUpdate.cs
@@ -38,6 +38,6 @@ public interface IUpdateBuilderUpdate : ISqlBuilder
     /// Appends <c>SET col = value, ...</c> from <c>column == value</c> assignments.
     /// </summary>
     /// <param name="assignments">The per-column updates; each left side names a column and each right side its new value (literals are auto-parameterized).</param>
-    /// <returns>The builder positioned for <c>WHERE</c>, <c>RETURNING</c>, or build.</returns>
-    IUpdateBuilderSet Set(params EqualityBasedCondition[] assignments);
+    /// <returns>The builder positioned for <c>OUTPUT</c>, <c>WHERE</c>, <c>RETURNING</c>, or build.</returns>
+    IUpdateBuilderSetOutput Set(params EqualityBasedCondition[] assignments);
 }

--- a/src/SqlArtisan/Internal/SqlBuilder/Update/UpdateBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Update/UpdateBuilder.cs
@@ -7,7 +7,9 @@ internal sealed class UpdateBuilder(DbTableBase table, DmlJoinState state, param
     IUpdateBuilderJoinOn,
     IUpdateBuilderJoined,
     IUpdateBuilderJoinedSet,
+    IUpdateBuilderOutputInto,
     IUpdateBuilderSet,
+    IUpdateBuilderSetOutput,
     IUpdateBuilderUpdate,
     IUpdateBuilderWhere
 {
@@ -64,6 +66,12 @@ internal sealed class UpdateBuilder(DbTableBase table, DmlJoinState state, param
         return this;
     }
 
+    public IUpdateBuilderSet Into(DbTableBase archive, params DbColumn[] columns)
+    {
+        AddPart(new OutputIntoClause(archive, columns));
+        return this;
+    }
+
     public IUpdateBuilderJoinOn LeftJoin(TableReference joined)
     {
         AddJoin(new LeftJoinClause(joined));
@@ -88,6 +96,13 @@ internal sealed class UpdateBuilder(DbTableBase table, DmlJoinState state, param
         return this;
     }
 
+    public IUpdateBuilderOutputInto Output(params object[] items)
+    {
+        CollectionGuard.ThrowIfEmpty(items, "OUTPUT requires at least one expression.");
+        AddPart(new OutputClause(SelectItemResolver.Resolve(items)));
+        return this;
+    }
+
     public IReturningBuilder Returning(params object[] expressions) =>
         ReturningBuilder.Create(this, expressions);
 
@@ -103,7 +118,7 @@ internal sealed class UpdateBuilder(DbTableBase table, DmlJoinState state, param
         return this;
     }
 
-    public IUpdateBuilderSet Set(params EqualityBasedCondition[] assignments)
+    public IUpdateBuilderSetOutput Set(params EqualityBasedCondition[] assignments)
     {
         AddPart(UpdateSetClause.Parse(assignments, state));
         return this;

--- a/src/SqlArtisan/Internal/SqlBuilder/Update/UpdateBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/Update/UpdateBuilder.cs
@@ -66,9 +66,9 @@ internal sealed class UpdateBuilder(DbTableBase table, DmlJoinState state, param
         return this;
     }
 
-    public IUpdateBuilderSet Into(DbTableBase archive, params DbColumn[] columns)
+    public IUpdateBuilderSet Into(DbTableBase table, params DbColumn[] columns)
     {
-        AddPart(new OutputIntoClause(archive, columns));
+        AddPart(new OutputIntoClause(table, columns));
         return this;
     }
 

--- a/src/SqlArtisan/Internal/SqlBuilder/With/WithBuilder.cs
+++ b/src/SqlArtisan/Internal/SqlBuilder/With/WithBuilder.cs
@@ -14,7 +14,7 @@ internal sealed class WithBuilder : IWithBuilderWith
         _withPart = withClause;
     }
 
-    public IDeleteBuilderDelete DeleteFrom(DbTableBase table)
+    public IDeleteBuilderDeleteOutput DeleteFrom(DbTableBase table)
     {
         DmlJoinState state = new();
         DeleteClause deleteClause = new(table, state);
@@ -36,7 +36,7 @@ internal sealed class WithBuilder : IWithBuilderWith
             _withPart,
             new InsertIntoClause(table));
 
-    public IInsertBuilderColumns InsertInto(DbTableBase table, params DbColumn[] columns) =>
+    public IInsertBuilderColumnsOutput InsertInto(DbTableBase table, params DbColumn[] columns) =>
         new InsertBuilder(table, _withPart, new InsertIntoClause(table, columns));
 
     public ISelectBuilderSelect Select(params object[] selectItems) =>

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Output/OutputClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Output/OutputClause.cs
@@ -1,0 +1,15 @@
+namespace SqlArtisan.Internal;
+
+internal sealed class OutputClause : SqlPart
+{
+    private readonly SqlPart[] _items;
+
+    internal OutputClause(SqlPart[] items)
+    {
+        _items = items;
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append($"{Keywords.Output} ")
+        .AppendSelectItems(_items);
+}

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Output/OutputIntoClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Output/OutputIntoClause.cs
@@ -1,17 +1,17 @@
 namespace SqlArtisan.Internal;
 
-// The `INTO archive (cols)` redirect of a SQL Server OUTPUT clause, emitted as a
+// The `INTO table (cols)` redirect of a SQL Server OUTPUT clause, emitted as a
 // separate part right after the OUTPUT part so space-joining yields
-// `OUTPUT ... INTO archive (cols)`.
-internal sealed class OutputIntoClause(DbTableBase archive, DbColumn[] columns) : SqlPart
+// `OUTPUT ... INTO table (cols)`.
+internal sealed class OutputIntoClause(DbTableBase table, DbColumn[] columns) : SqlPart
 {
-    private readonly DbTableBase _archive = archive;
+    private readonly DbTableBase _table = table;
     private readonly DbColumn[] _columns = columns;
 
     internal override void Format(SqlBuildingBuffer buffer)
     {
         buffer.Append($"{Keywords.Into} ");
-        _archive.FormatAsDmlTarget(buffer);
+        _table.FormatAsDmlTarget(buffer);
 
         if (_columns.Length > 0)
         {

--- a/src/SqlArtisan/Internal/SqlPart/Clause/Output/OutputIntoClause.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Clause/Output/OutputIntoClause.cs
@@ -1,0 +1,24 @@
+namespace SqlArtisan.Internal;
+
+// The `INTO archive (cols)` redirect of a SQL Server OUTPUT clause, emitted as a
+// separate part right after the OUTPUT part so space-joining yields
+// `OUTPUT ... INTO archive (cols)`.
+internal sealed class OutputIntoClause(DbTableBase archive, DbColumn[] columns) : SqlPart
+{
+    private readonly DbTableBase _archive = archive;
+    private readonly DbColumn[] _columns = columns;
+
+    internal override void Format(SqlBuildingBuffer buffer)
+    {
+        buffer.Append($"{Keywords.Into} ");
+        _archive.FormatAsDmlTarget(buffer);
+
+        if (_columns.Length > 0)
+        {
+            buffer.AppendSpace()
+                .OpenParenthesis()
+                .AppendUnqualifiedColumnsCsv(_columns)
+                .CloseParenthesis();
+        }
+    }
+}

--- a/src/SqlArtisan/Internal/SqlPart/Expression/DeletedColumn.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/DeletedColumn.cs
@@ -1,0 +1,20 @@
+namespace SqlArtisan.Internal;
+
+/// <summary>
+/// References a column of the <c>DELETED</c> pseudo-table inside a SQL Server
+/// <c>OUTPUT</c> clause — the pre-image of a deleted or updated row. Renders as
+/// <c>DELETED.col</c>.
+/// </summary>
+public sealed class DeletedColumn : SqlExpression
+{
+    private readonly string _columnName;
+
+    internal DeletedColumn(DbColumn column)
+    {
+        _columnName = column.Name;
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append($"{Keywords.Deleted}.")
+        .Append(_columnName);
+}

--- a/src/SqlArtisan/Internal/SqlPart/Expression/InsertedColumn.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Expression/InsertedColumn.cs
@@ -1,0 +1,20 @@
+namespace SqlArtisan.Internal;
+
+/// <summary>
+/// References a column of the <c>INSERTED</c> pseudo-table inside a SQL Server
+/// <c>OUTPUT</c> clause — the post-image of an inserted or updated row. Renders as
+/// <c>INSERTED.col</c>.
+/// </summary>
+public sealed class InsertedColumn : SqlExpression
+{
+    private readonly string _columnName;
+
+    internal InsertedColumn(DbColumn column)
+    {
+        _columnName = column.Name;
+    }
+
+    internal override void Format(SqlBuildingBuffer buffer) => buffer
+        .Append($"{Keywords.Inserted}.")
+        .Append(_columnName);
+}

--- a/src/SqlArtisan/Internal/SqlPart/Keywords.cs
+++ b/src/SqlArtisan/Internal/SqlPart/Keywords.cs
@@ -42,6 +42,7 @@ internal static class Keywords
     internal const string Datetrunc = "DATETRUNC";
     internal const string Decode = "DECODE";
     internal const string Delete = "DELETE";
+    internal const string Deleted = "DELETED";
     internal const string DenseRank = "DENSE_RANK";
     internal const string Desc = "DESC";
     internal const string Distinct = "DISTINCT";
@@ -76,6 +77,7 @@ internal static class Keywords
     internal const string In = "IN";
     internal const string Inner = "INNER";
     internal const string Insert = "INSERT";
+    internal const string Inserted = "INSERTED";
     internal const string Instr = "INSTR";
     internal const string Intersect = "INTERSECT";
     internal const string Into = "INTO";
@@ -131,6 +133,7 @@ internal static class Keywords
     internal const string Or = "OR";
     internal const string Order = "ORDER";
     internal const string Outer = "OUTER";
+    internal const string Output = "OUTPUT";
     internal const string Over = "OVER";
     internal const string Partition = "PARTITION";
     internal const string PercentileCont = "PERCENTILE_CONT";

--- a/src/SqlArtisan/Sql/Sql.D.cs
+++ b/src/SqlArtisan/Sql/Sql.D.cs
@@ -315,12 +315,22 @@ public static partial class Sql
     /// </summary>
     /// <param name="table">The table to delete rows from.</param>
     /// <returns>A delete builder positioned to accept a <c>WHERE</c> clause.</returns>
-    public static IDeleteBuilderDelete DeleteFrom(DbTableBase table)
+    public static IDeleteBuilderDeleteOutput DeleteFrom(DbTableBase table)
     {
         DmlJoinState state = new();
         DeleteClause deleteClause = new(table, state);
         return new DeleteBuilder(table, state, deleteClause);
     }
+
+    /// <summary>
+    /// References <paramref name="column"/> of the <c>DELETED</c> pseudo-table in
+    /// a SQL Server <c>OUTPUT</c> clause — the row's pre-image before a
+    /// <c>DELETE</c> or <c>UPDATE</c>. Renders as <c>DELETED.col</c>.
+    /// </summary>
+    /// <param name="column">The target-table column whose deleted value to read.</param>
+    /// <returns>A <c>DELETED.col</c> reference.</returns>
+    /// <remarks>SQL Server syntax, valid only inside <c>Output(...)</c>.</remarks>
+    public static DeletedColumn Deleted(DbColumn column) => new(column);
 
     /// <summary>
     /// The <c>DENSE_RANK()</c> analytic function (rank within the window with no

--- a/src/SqlArtisan/Sql/Sql.I.cs
+++ b/src/SqlArtisan/Sql/Sql.I.cs
@@ -24,7 +24,7 @@ public static partial class Sql
     /// <param name="columns">The columns to insert into, emitted as a
     /// parenthesized list after the table.</param>
     /// <returns>An insert builder awaiting the values for the named columns.</returns>
-    public static IInsertBuilderColumns InsertInto(DbTableBase table, params DbColumn[] columns) =>
+    public static IInsertBuilderColumnsOutput InsertInto(DbTableBase table, params DbColumn[] columns) =>
         new InsertBuilder(table, new InsertIntoClause(table, columns));
 
     /// <summary>
@@ -54,6 +54,16 @@ public static partial class Sql
     /// with <c>InsertInto(...).Values(...).OnConflict().DoNothing()</c> instead.</remarks>
     public static IInsertIgnoreBuilderColumns InsertIgnoreInto(DbTableBase table, params DbColumn[] columns) =>
         new InsertBuilder(table, new InsertIgnoreIntoClause(table, columns));
+
+    /// <summary>
+    /// References <paramref name="column"/> of the <c>INSERTED</c> pseudo-table in
+    /// a SQL Server <c>OUTPUT</c> clause — the row's post-image after an
+    /// <c>INSERT</c> or <c>UPDATE</c>. Renders as <c>INSERTED.col</c>.
+    /// </summary>
+    /// <param name="column">The target-table column whose inserted value to read.</param>
+    /// <returns>An <c>INSERTED.col</c> reference.</returns>
+    /// <remarks>SQL Server syntax, valid only inside <c>Output(...)</c>.</remarks>
+    public static InsertedColumn Inserted(DbColumn column) => new(column);
 
     /// <summary>
     /// The <c>INSTR(<paramref name="source"/>, <paramref name="substring"/>)</c>

--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/MatrixSweepCatalog.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/MatrixSweepCatalog.cs
@@ -560,6 +560,22 @@ internal static class MatrixSweepCatalog
                 [Dbms.Oracle] = "Oracle's RETURNING requires INTO with output-parameter binding; the dedicated Oracle test covers it.",
             }));
 
+        // --- OUTPUT (SQL Server) — the other four engines reject it at the OUTPUT token ---
+        AddMutating("Output", _ => InsertInto(u, u.Id, u.Name).Output(Inserted(u.Id)).Values(603, "Sweep"));
+        AddMutating("Inserted", _ => InsertInto(u, u.Id, u.Name).Output(Inserted(u.Id)).Values(604, "Sweep"));
+        AddMutating("Deleted", _ => DeleteFrom(u).Output(Deleted(u.Id)).Where(u.Id == -1));
+        cases.Add(new SweepCase(
+            new MatrixKey("Into", 2),
+            _ =>
+            {
+                OutputArchiveTable archive = new();
+                return DeleteFrom(u)
+                    .Output(Deleted(u.Id), Deleted(u.Name))
+                    .Into(archive, archive.Id, archive.Name)
+                    .Where(u.Id == -1);
+            },
+            Mutating: true));
+
         return cases;
 
         ISqlBuilder ApplyShape(Func<ISelectBuilderFrom, ISubquery, DerivedTableBase, ISqlBuilder> apply)

--- a/tests/SqlArtisan.IntegrationTests/Infrastructure/TestSchema.cs
+++ b/tests/SqlArtisan.IntegrationTests/Infrastructure/TestSchema.cs
@@ -45,6 +45,9 @@ internal static class TestSchema
         "CREATE TABLE users (id INTEGER PRIMARY KEY, name NVARCHAR(100), age INTEGER, department_id INTEGER, created_at DATETIME2, is_active BIT, data NVARCHAR(MAX))",
         "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, amount DECIMAL(10,2))",
         "CREATE SEQUENCE test_seq START WITH 1 INCREMENT BY 1",
+        // OUTPUT ... INTO target — SQL Server only (the other engines reject the
+        // statement at the OUTPUT token before resolving the table).
+        "CREATE TABLE output_archive (id INTEGER, name NVARCHAR(100))",
     ];
 
     // Oracle spells the same shapes NUMBER / VARCHAR2 / DATE.

--- a/tests/SqlArtisan.IntegrationTests/Schema/OutputArchiveTable.cs
+++ b/tests/SqlArtisan.IntegrationTests/Schema/OutputArchiveTable.cs
@@ -1,0 +1,18 @@
+namespace SqlArtisan.IntegrationTests.Schema;
+
+/// <summary>
+/// The <c>output_archive</c> table (SQL Server only) — the <c>OUTPUT ... INTO</c>
+/// redirect target for the OUTPUT sweep and the archive-then-delete test.
+/// </summary>
+internal sealed class OutputArchiveTable : DbTableBase
+{
+    public OutputArchiveTable(string alias = "") : base("output_archive", alias)
+    {
+        Id = new DbColumn(this, "id");
+        Name = new DbColumn(this, "name");
+    }
+
+    public DbColumn Id { get; }
+
+    public DbColumn Name { get; }
+}

--- a/tests/SqlArtisan.IntegrationTests/Tests/SqlServerTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/SqlServerTests.cs
@@ -252,4 +252,49 @@ public sealed class SqlServerTests : IntegrationTestBase, IClassFixture<SqlServe
         Assert.Equal(0, remaining);
         transaction.Rollback();
     }
+
+    [Fact]
+    public void OutputInto_ArchiveThenDelete_Executes()
+    {
+        // The single-statement archive-then-delete: OUTPUT ... INTO copies the
+        // deleted rows into an archive table as they are removed.
+        UsersTable u = new();
+        OutputArchiveTable archive = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        connection.Execute(
+            DeleteFrom(u)
+                .Output(Deleted(u.Id), Deleted(u.Name))
+                .Into(archive, archive.Id, archive.Name)
+                .Where(u.Id == 3),
+            transaction);
+
+        long usersLeft = Convert.ToInt64(connection.ExecuteScalar(
+            Select(Count(u.Id)).From(u).Where(u.Id == 3), transaction));
+        string archivedName = connection
+            .Query<string>(Select(archive.Name).From(archive).Where(archive.Id == 3), transaction)
+            .Single();
+
+        Assert.Equal(0, usersLeft);
+        Assert.Equal("Carol", archivedName);
+        transaction.Rollback();
+    }
+
+    [Fact]
+    public void Output_Insert_ReturnsInsertedId()
+    {
+        UsersTable u = new();
+        using IDbConnection connection = _fixture.OpenConnection();
+        using IDbTransaction transaction = connection.BeginTransaction();
+
+        int inserted = connection
+            .Query<int>(
+                InsertInto(u, u.Id, u.Name).Output(Inserted(u.Id)).Values(700, "Grace"),
+                transaction)
+            .Single();
+
+        Assert.Equal(700, inserted);
+        transaction.Rollback();
+    }
 }

--- a/tests/SqlArtisan.Tests/DeleteTests.cs
+++ b/tests/SqlArtisan.Tests/DeleteTests.cs
@@ -310,4 +310,76 @@ public class DeleteTests
 
         Assert.Equal("FROM requires at least one table.", ex.Message);
     }
+
+    [Fact]
+    public void DeleteFrom_SqlServer_Output_CorrectSql()
+    {
+        TestTable t = new();
+
+        SqlStatement sql =
+            DeleteFrom(t)
+            .Output(Deleted(t.Code))
+            .Where(t.Code == 1)
+            .Build(Dbms.SqlServer);
+
+        StringBuilder expected = new();
+        expected.Append("DELETE FROM test_table ");
+        expected.Append("OUTPUT DELETED.code ");
+        expected.Append("WHERE code = @0");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+        Assert.Equal(1, sql.Parameters.Get<int>("@0"));
+    }
+
+    [Fact]
+    public void DeleteFrom_SqlServer_OutputInto_CorrectSql()
+    {
+        // The single-statement archive-then-delete form (SQL Server): OUTPUT ...
+        // INTO precedes WHERE.
+        TestTable t = new();
+        ArchiveTable a = new();
+
+        SqlStatement sql =
+            DeleteFrom(t)
+            .Output(Deleted(t.Code), Deleted(t.Name))
+            .Into(a, a.Code, a.Name)
+            .Where(t.Code == 1)
+            .Build(Dbms.SqlServer);
+
+        StringBuilder expected = new();
+        expected.Append("DELETE FROM test_table ");
+        expected.Append("OUTPUT DELETED.code, DELETED.name ");
+        expected.Append("INTO archive_table (code, name) ");
+        expected.Append("WHERE code = @0");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
+
+    [Fact]
+    public void DeleteFrom_SqlServer_OutputAlias_CorrectSql()
+    {
+        // SQL Server permits an OUTPUT column alias, so aliases are not rejected.
+        TestTable t = new();
+
+        SqlStatement sql =
+            DeleteFrom(t)
+            .Output(Deleted(t.Code).As("old_code"))
+            .Where(t.Code == 1)
+            .Build(Dbms.SqlServer);
+
+        Assert.Equal(
+            "DELETE FROM test_table OUTPUT DELETED.code \"old_code\" WHERE code = @0",
+            sql.Text);
+    }
+
+    [Fact]
+    public void DeleteFrom_OutputNoExpressions_ThrowsArgumentException()
+    {
+        TestTable t = new();
+
+        ArgumentException ex = Assert.Throws<ArgumentException>(() =>
+            DeleteFrom(t).Output());
+
+        Assert.Equal("OUTPUT requires at least one expression.", ex.Message);
+    }
 }

--- a/tests/SqlArtisan.Tests/InsertTests.cs
+++ b/tests/SqlArtisan.Tests/InsertTests.cs
@@ -350,4 +350,48 @@ public class InsertTests
             "INSERT IGNORE INTO test_table (code, name) SELECT code, name FROM test_table",
             sql.Text);
     }
+
+    [Fact]
+    public void InsertInto_SqlServer_Output_CorrectSql()
+    {
+        // OUTPUT sits after the column list and before VALUES.
+        TestTable t = new();
+
+        SqlStatement sql =
+            InsertInto(t, t.Code, t.Name)
+            .Output(Inserted(t.Code))
+            .Values(1, "x")
+            .Build(Dbms.SqlServer);
+
+        StringBuilder expected = new();
+        expected.Append("INSERT INTO test_table (code, name) ");
+        expected.Append("OUTPUT INSERTED.code ");
+        expected.Append("VALUES (@0, @1)");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+        Assert.Equal(1, sql.Parameters.Get<int>("@0"));
+        Assert.Equal("x", sql.Parameters.Get<string>("@1"));
+    }
+
+    [Fact]
+    public void InsertInto_SqlServer_OutputInto_CorrectSql()
+    {
+        TestTable t = new();
+        ArchiveTable a = new();
+
+        SqlStatement sql =
+            InsertInto(t, t.Code, t.Name)
+            .Output(Inserted(t.Code), Inserted(t.Name))
+            .Into(a, a.Code, a.Name)
+            .Values(1, "x")
+            .Build(Dbms.SqlServer);
+
+        StringBuilder expected = new();
+        expected.Append("INSERT INTO test_table (code, name) ");
+        expected.Append("OUTPUT INSERTED.code, INSERTED.name ");
+        expected.Append("INTO archive_table (code, name) ");
+        expected.Append("VALUES (@0, @1)");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
 }

--- a/tests/SqlArtisan.Tests/TestFixtures/ArchiveTable.cs
+++ b/tests/SqlArtisan.Tests/TestFixtures/ArchiveTable.cs
@@ -1,0 +1,15 @@
+namespace SqlArtisan.Tests;
+
+// An OUTPUT ... INTO archive target for the SQL Server OUTPUT tests.
+internal sealed class ArchiveTable : DbTableBase
+{
+    public ArchiveTable(string alias = "") : base("archive_table", alias)
+    {
+        Code = new DbColumn(this, "code");
+        Name = new DbColumn(this, "name");
+    }
+
+    public DbColumn Code { get; }
+
+    public DbColumn Name { get; }
+}

--- a/tests/SqlArtisan.Tests/UpdateTests.cs
+++ b/tests/SqlArtisan.Tests/UpdateTests.cs
@@ -453,4 +453,54 @@ public class UpdateTests
 
         Assert.Equal("FROM requires at least one table.", ex.Message);
     }
+
+    [Fact]
+    public void Update_SqlServer_Output_CorrectSql()
+    {
+        // OUTPUT sits after SET and before WHERE; UPDATE sees both pseudo-tables.
+        TestTable t = new();
+
+        SqlStatement sql =
+            Update(t)
+            .Set(t.Name == "a")
+            .Output(Deleted(t.Name), Inserted(t.Name))
+            .Where(t.Code == 1)
+            .Build(Dbms.SqlServer);
+
+        StringBuilder expected = new();
+        expected.Append("UPDATE test_table ");
+        expected.Append("SET name = @0 ");
+        expected.Append("OUTPUT DELETED.name, INSERTED.name ");
+        expected.Append("WHERE code = @1");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+        Assert.Equal("a", sql.Parameters.Get<string>("@0"));
+        Assert.Equal(1, sql.Parameters.Get<int>("@1"));
+    }
+
+    [Fact]
+    public void Update_SqlServer_OutputBeforeJoinedFrom_CorrectSql()
+    {
+        // OUTPUT lands after SET and before the joined FROM.
+        TestTable t = new("t");
+        TestTable s = new("s");
+
+        SqlStatement sql =
+            Update(t)
+            .Set(t.Name == s.Name)
+            .Output(Inserted(t.Name))
+            .From(t)
+            .InnerJoin(s).On(t.Code == s.Code)
+            .Build(Dbms.SqlServer);
+
+        StringBuilder expected = new();
+        expected.Append("UPDATE \"t\" ");
+        expected.Append("SET \"t\".name = \"s\".name ");
+        expected.Append("OUTPUT INSERTED.name ");
+        expected.Append("FROM test_table \"t\" ");
+        expected.Append("INNER JOIN test_table \"s\" ");
+        expected.Append("ON \"t\".code = \"s\".code");
+
+        Assert.Equal(expected.ToString(), sql.Text);
+    }
 }


### PR DESCRIPTION
Closes #259.

SQL Server's `OUTPUT` reads back the rows an `INSERT`/`UPDATE`/`DELETE` affects, from the `INSERTED`/`DELETED` pseudo-tables — the counterpart to `RETURNING`, which SqlArtisan already supports on Oracle/PostgreSQL/SQLite. Unlike `RETURNING`, `OUTPUT` sits **mid-statement** (after the column list on `INSERT`, after `SET` on `UPDATE`, after the target on `DELETE`), so it is modeled as a positioned `.Output(...)` step chained before `VALUES`/`WHERE`/`FROM` rather than a trailing splice.

## What's added

- **`Sql.Inserted(col)` / `Sql.Deleted(col)`** — pseudo-table column references (`INSERTED.x` / `DELETED.x`).
- **`.Output(...)`** on INSERT/UPDATE/DELETE — accepts columns, pseudo-table refs, literals, and `.As(...)` aliases (SQL Server allows OUTPUT aliases). Empty `Output()` throws eagerly.
- **`.Into(archive, cols...)`** after `.Output(...)` — the single-statement archive-then-delete form, the only `OUTPUT` spelling exempt from the AFTER-trigger limitation.
- **Fluent state machine** — two new interfaces per statement make a second `Output`, and `Into` before `Output`, uncompilable through the return type.
- **Analyzer matrix** — SQL Server-only entries for `Output`/`Inserted`/`Deleted` plus an arity-2 `Into` split (reusing the `Using` precedent so it doesn't collide with Oracle's arity-1 `RETURNING … INTO`).

## Emitted SQL (`Build(Dbms.SqlServer)`)

```
INSERT INTO users (id, name) OUTPUT INSERTED.id VALUES (@0, @1)
UPDATE users SET age = @0 OUTPUT DELETED.age, INSERTED.age WHERE id = @1
DELETE FROM rental OUTPUT DELETED.rental_id, DELETED.customer_id INTO rental_archive (rental_id, customer_id) WHERE rental_date < @0
```

## Scope

Column-list INSERT `OUTPUT` shipped; the no-column-list (SET-like) INSERT `OUTPUT` and MERGE `OUTPUT $action` are out of scope. Faithful emission on non-SQL-Server dialects is left to the analyzer/database per the project's faithful-output principle.

## Tests & verification

- Unit tests (exact SQL + `Parameters`) for every shape, empty-`Output()` message, alias-in-OUTPUT.
- New `output_archive` integration table (SQL Server DDL only); mutating matrix-sweep cases and an archive-then-delete + insert-returns-id `SqlServerTests`.
- Full local gates green (build 0-warning, 736 unit + 292 analyzer tests, `dotnet format`), SQLite lane local, and the **integration matrix dispatched against this branch is green on all 5 engines** (run #110).
- Independent fresh-context code + docs reviews: both `mergeable`, no High/Medium findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xbXhZrdViS71YhmJbXMi4

---
_Generated by [Claude Code](https://claude.ai/code/session_016xbXhZrdViS71YhmJbXMi4)_