### PR TITLE
chore: Add mandatory adversarial verification pass to review skills

### DIFF
--- a/.claude/agents/sa-reviewer.md
+++ b/.claude/agents/sa-reviewer.md
@@ -41,6 +41,27 @@ not from how the change describes itself.
   violations) from "discuss" (trade-offs the ADRs deliberately leave open).
   A convention the rules permit is not a finding.
 
+## Adversarial-verification missions
+
+The review skills end with a mandatory adversarial pass, and you are its
+executor — a caller may spawn you with a refutation mission ("try to refute
+these claims/findings") instead of a full review. On such a mission:
+
+- Target the named claims and findings; do not re-run the full checklist.
+  Gates and empirical probes stay in force — refutation evidence must meet
+  the same bar as review evidence.
+- Check every factual claim against a primary source — the code, a test
+  catalog (e.g. `MatrixSweepCatalog.cs`), an ADR, or a live harness probe —
+  never the claim's own text or memory.
+- Alongside High/Medium/Low, classify fallen claims: **DEFECT** (factually
+  wrong), **OVERREACH** (technically true but misleading — a quantifier
+  like "every" with a real exception), **INCONSISTENCY** (contradicts
+  another surface).
+- You have no Agent tool, so the skills' "spawn an adversarial subagent"
+  step never applies to you: on a refutation mission you *are* that pass
+  (skip the section); as the primary reviewer, run it yourself as a
+  distinct final phase per the skill's fallback.
+
 ## Report (your final message — it is the only thing the caller receives)
 
 Lead with the verdict (mergeable / mergeable-after-must-fix / not mergeable)

--- a/.claude/skills/sa-code-review-deep/SKILL.md
+++ b/.claude/skills/sa-code-review-deep/SKILL.md
@@ -35,6 +35,14 @@ and taste are legitimately in scope here, *because reaching this skill was a
 deliberate choice* — the discipline is that choice, not a citation
 requirement.
 
+## Adversarial pass (inherited)
+
+The mandatory adversarial verification pass (`sa-code-review` §9) is
+inherited and runs **once**, after this improvement pass, covering both
+reports. Suggestions themselves are opinions, not refutation targets — but
+any factual claim inside one (e.g. "API X already covers this case") gets
+the primary-source check before it is reported.
+
 ## Report
 
 Append a **Suggestions (optional, non-blocking)** zone after

--- a/.claude/skills/sa-code-review/SKILL.md
+++ b/.claude/skills/sa-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sa-code-review
-description: Review a SqlArtisan change, PR, or diff for correctness, ADR conformance, convention consistency, and doc alignment. Use when the user asks to review changes/a PR/a diff in this repo, or to check a feature before pushing. Adds SqlArtisan-specific checks (ADRs, dialect grammar, allocation budget) on top of a generic code review, and verifies behavior empirically by building and running a throwaway harness rather than reasoning from memory. Reports defects only — never idiom/style/"better way to write this" suggestions; use `sa-code-review-deep` for those. Accepts an optional scope argument (default: the diff's hunks only; `files`; `paths:<glob>`).
+description: Review a SqlArtisan change, PR, or diff for correctness, ADR conformance, convention consistency, and doc alignment. Use when the user asks to review changes/a PR/a diff in this repo, or to check a feature before pushing. Adds SqlArtisan-specific checks (ADRs, dialect grammar, allocation budget) on top of a generic code review, and verifies behavior empirically by building and running a throwaway harness rather than reasoning from memory. Reports defects only — never idiom/style/"better way to write this" suggestions; use `sa-code-review-deep` for those. Ends with a mandatory adversarial verification pass — an independent subagent attempts to refute the deliverable's claims and the draft findings against primary sources. Accepts an optional scope argument (default: the diff's hunks only; `files`; `paths:<glob>`).
 ---
 
 # Review SqlArtisan changes
@@ -220,6 +220,37 @@ contributor) — plus `CLAUDE.md`, `docs/adr/**`, `.claude/skills/**`,
 - Any "better way to write this" suggestion with no rule/ADR/precedent to
   cite, for code or docs — run `sa-code-review-deep` for that pass instead.
 
+## 9. Adversarial verification (mandatory final pass)
+
+A confirming review checks that things look right; only a refuting pass
+reliably catches the plausible overclaim (#267/#319: a neutral docs pass
+accepted "every analyzer entry is executed against a live engine" — the
+adversarial pass read `MatrixSweepCatalog.cs` and found the two excluded
+entries). **This pass is not optional.**
+
+After the findings are drafted, spawn an independent subagent
+(`sa-reviewer`) with an explicitly adversarial mission — "try to refute
+this", never "check this is right":
+
+- **Refute both directions** — the deliverable's own claims (docs, XML docs,
+  CHANGELOG, commit-message wording) *and* your draft findings.
+- **Primary sources only.** Every factual claim is checked against the code
+  itself, a test catalog (e.g. `MatrixSweepCatalog.cs`), an ADR, or a live
+  harness probe — never against the claim's own text, the diff description,
+  or memory.
+- **Severity + evidence on every surviving finding** — High/Medium/Low plus
+  the evidence that survived refutation: verbatim probe output or the
+  primary source's `file:line`.
+- **Classify what falls**: **DEFECT** (factually wrong), **OVERREACH**
+  (technically true but misleading — a quantifier like "every"/"all"/
+  "never" with a real exception), or **INCONSISTENCY** (contradicts another
+  surface).
+
+Recursion and fallback: if you *are* the adversarial subagent, skip this
+section — no recursion. If the Agent tool is unavailable, run the pass
+yourself as a distinct final phase: re-derive each claim from primary
+sources; do not reread your draft as evidence.
+
 ## Report
 
 Lead with the verdict (mergeable or not) and a short list of recommended
@@ -228,5 +259,7 @@ and severity (**High/Medium/Low**) — a doc gap can be Low severity and still
 must-fix; severity ranks the queue, it does not gate inclusion. Separate
 "must fix" (bugs, ADR violations, invalid SQL, any doc/comment gap from §8)
 from "discuss" (permissive-API trade-offs the ADRs deliberately leave to the
-author / analyzer). This skill never reports non-defect improvement
+author / analyzer). Include the adversarial pass's coverage: which claims
+were challenged, what survived, and the DEFECT / OVERREACH / INCONSISTENCY
+classification of what fell. This skill never reports non-defect improvement
 suggestions — re-run as `sa-code-review-deep` for those.

--- a/.claude/skills/sa-docs-review/SKILL.md
+++ b/.claude/skills/sa-docs-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sa-docs-review
-description: Review SqlArtisan's user-facing documentation (README, docs/, llms.txt, CHANGELOG) for structure, completeness, accuracy, consistency, links, persuasiveness, and conciseness. Use when asked to review/audit the docs, check the README, validate a docs change before pushing, or confirm docs match the code. Complements sa-code-review (code) with doc-specific checks and bundles scripts that verify links, API coverage, terminology, and emitted SQL empirically.
+description: Review SqlArtisan's user-facing documentation (README, docs/, llms.txt, CHANGELOG) for structure, completeness, accuracy, consistency, links, persuasiveness, and conciseness. Use when asked to review/audit the docs, check the README, validate a docs change before pushing, or confirm docs match the code. Complements sa-code-review (code) with doc-specific checks and bundles scripts that verify links, API coverage, terminology, and emitted SQL empirically. Ends with a mandatory adversarial verification pass — an independent subagent attempts to refute the docs' factual claims against primary sources.
 ---
 
 # Review SqlArtisan documentation
@@ -103,8 +103,43 @@ Score the docs against these. The scripts cover 2–5 and parts of 6/10.
   for wording/ordering/trims that are judgment calls, propose options and
   confirm before applying.
 
+## Adversarial verification (mandatory final pass)
+
+The dimensions above confirm; this pass refutes. A neutral pass accepted
+"every analyzer entry is executed against a live engine" (#267/#319) — the
+adversarial pass read `MatrixSweepCatalog.cs` and found the two excluded
+entries. **This pass is not optional.**
+
+After the findings are drafted, spawn an independent subagent
+(`sa-reviewer`) with an explicitly adversarial mission — "try to refute
+this", never "check this is right". Prime refutation targets in docs:
+
+- **Quantifiers** — every / all / always / never / only. One real exception
+  turns the sentence into an OVERREACH.
+- **Superlatives and rankings** — fastest / lowest-allocation; the benchmark
+  suite output is the primary source, not the README's own table.
+- **Counts, version bounds, capability claims** — "verified against live
+  engines", "N engines", "SQLite 3.44+"; the primary source is the test
+  catalog (e.g. `MatrixSweepCatalog.cs`), the pinned image list, or a live
+  probe.
+
+Mission rules: every factual claim is traced to a primary source (the code,
+a test catalog, an ADR, a live builder/harness run) — never the doc's own
+text or memory. Surviving findings carry severity (High/Medium/Low) plus the
+evidence that survived refutation (verbatim probe output or the primary
+source's `file:line`). Fallen claims are classified **DEFECT** (factually
+wrong) / **OVERREACH** (true but misleading) / **INCONSISTENCY** (contradicts
+another surface).
+
+Recursion and fallback: if you *are* the adversarial subagent, skip this
+section — no recursion. If the Agent tool is unavailable, run the pass
+yourself as a distinct final phase, re-deriving each claim from primary
+sources rather than rereading your draft.
+
 ## Output
 
 Summarise per dimension (pass / findings), list concrete fixes with file:line,
 and state what was verified empirically (links resolve, N/N examples match,
-coverage clean). Re-run the relevant script after fixes to confirm green.
+coverage clean). State which claims the adversarial pass challenged and what
+survived, with the DEFECT / OVERREACH / INCONSISTENCY classification of what
+fell. Re-run the relevant script after fixes to confirm green.

--- a/.claude/workflows/sa-multi-model-code-review.js
+++ b/.claude/workflows/sa-multi-model-code-review.js
@@ -1,12 +1,13 @@
 export const meta = {
   name: 'sa-multi-model-code-review',
-  description: 'Fable orchestrates, Sonnet (via sa-reviewer) executes a deep multi-dimensional SqlArtisan review',
+  description: 'Fable orchestrates, Sonnet (via sa-reviewer) executes and adversarially verifies a deep multi-dimensional SqlArtisan review',
   phases: [
     { title: 'Scope', model: 'haiku', detail: 'Detect branch-point diff (cheap, mechanical)' },
     { title: 'Gates', model: 'haiku', detail: 'Run build/test/format gates once, up front' },
     { title: 'Orchestrate', model: 'fable', detail: 'Classify files and assign review dimensions' },
     { title: 'Execute', model: 'sonnet', detail: 'Deep review per file chunk via sa-reviewer' },
-    { title: 'Synthesize', model: 'fable', detail: 'Integrate findings and produce final verdict' },
+    { title: 'Verify', model: 'sonnet', detail: 'Adversarially verify each chunk\'s findings against primary sources' },
+    { title: 'Synthesize', model: 'fable', detail: 'Integrate verified findings and produce final verdict' },
   ],
 }
 
@@ -115,7 +116,7 @@ None — no files in scope.
 ## Coverage
 - Scope: ${scopeInfo.scope}
 - Files in scope: 0
-- Gates/Orchestrate/Execute/Synthesize: skipped (empty scope)
+- Gates/Orchestrate/Execute/Verify/Synthesize: skipped (empty scope)
 
 ## Recommendations (ranked)
 1. No action needed.`,
@@ -191,7 +192,7 @@ were skipped.
 - Scope: ${scopeInfo.scope}
 - Files in scope: ${scopeInfo.changedFiles.length}
 - Gates: build=${gates.buildPassed} test=${gates.testsPassed} format=${gates.formatClean}
-- Orchestrate/Execute/Synthesize: skipped (fail-fast on gate failure)
+- Orchestrate/Execute/Verify/Synthesize: skipped (fail-fast on gate failure)
 
 ## Recommendations (ranked)
 1. Fix the failing gate(s) above, then re-run this workflow.`,
@@ -319,16 +320,22 @@ if (!coverageClean) {
 }
 
 // ---------------------------------------------------------------------------
-// PHASE 4: Execute — Sonnet, via the sa-reviewer agent so every chunk
-// inherits its read-only tool restriction and its pointer to the
-// sa-review-changes / sa-run-sql-harness skills, instead of re-deriving
-// (and risking drift from) that procedure inline in this prompt.
+// PHASE 4+5: Execute, then adversarially Verify — one pipeline, no barrier:
+// each chunk's verification starts as soon as its review lands. Execute runs
+// via the sa-reviewer agent so every chunk inherits its read-only tool
+// restriction and its pointer to the sa-review-changes / sa-run-sql-harness
+// skills, instead of re-deriving (and risking drift from) that procedure
+// inline in this prompt. Verify re-enters sa-reviewer on its
+// adversarial-verification mission (refute, don't confirm) so no finding
+// reaches synthesis unchallenged.
 // ---------------------------------------------------------------------------
 phase('Execute')
 
-const reviewResults = await pipeline(reviewUnits, (unit) =>
-  agent(
-    `Deep-review this SqlArtisan file group as part of a larger multi-group
+const reviewResults = await pipeline(
+  reviewUnits,
+  (unit) =>
+    agent(
+      `Deep-review this SqlArtisan file group as part of a larger multi-group
 pass. Gates already ran and passed/failed as follows — do not re-run them:
 ${gates.summary}
 
@@ -345,25 +352,64 @@ dimensions apply, and use the sa-run-sql-harness skill for any empirical
 verification (DBMS grammar, guard enforcement, allocation) — do not assume
 emitted SQL or allocation behavior from memory. Skip the skill's own gate
 step (already covered above) and skip re-scoping the diff (file list is
-fixed above); otherwise follow it end to end.
+fixed above); otherwise follow it end to end. Skip the skill's adversarial
+verification pass too — this workflow runs it as its own Verify stage on
+your report.
 
 Separate MUST FIX (bugs, ADR violations, invalid/wrong SQL, missing guards)
 from SHOULD DISCUSS (convention trade-offs, coverage gaps, doc drift) and
 NITS. Cite file:line and, for any DBMS-grammar or allocation claim, the
 verbatim probe output that backs it.`,
-    {
-      agentType: 'sa-reviewer',
-      model: 'sonnet',
-      effort: 'high',
-      label: `review:${unit.chunkLabel}`,
-      phase: 'Execute',
-    }
-  )
+      {
+        agentType: 'sa-reviewer',
+        model: 'sonnet',
+        effort: 'high',
+        label: `review:${unit.chunkLabel}`,
+        phase: 'Execute',
+      }
+    ),
+  // Verify stage. A null review (skipped/failed chunk) passes through so the
+  // failed-chunk accounting below still sees it; a null *verifier* result
+  // falls back to the unverified review — losing verification must not lose
+  // the review itself.
+  async (review, unit) => {
+    if (!review) return null
+    const verified = await agent(
+      `Adversarial-verification mission (see your "Adversarial-verification
+missions" section): try to REFUTE this chunk review, not confirm it.
+
+FILES the review covered:
+${unit.chunkFiles.map((f) => `- ${f}`).join('\n')}
+
+CHUNK REVIEW UNDER TEST:
+${review}
+
+For each finding: attempt to refute it against primary sources — the code
+itself, test catalogs, ADRs, or a live /tmp harness probe — never the
+review's own text. Re-output the full review with every finding annotated:
+- CONFIRMED — with the evidence that survived refutation (verbatim probe
+  output or the primary source's file:line)
+- REFUTED — with the disproving evidence
+Then add, as extra findings, any factual claim in the reviewed files
+themselves that the review missed and that falls to refutation, classified
+DEFECT / OVERREACH / INCONSISTENCY with severity and evidence.`,
+      {
+        agentType: 'sa-reviewer',
+        model: 'sonnet',
+        effort: 'high',
+        label: `verify:${unit.chunkLabel}`,
+        phase: 'Verify',
+      }
+    )
+    return verified
+      ? verified
+      : `(adversarial verification unavailable for this chunk — unverified review follows)\n${review}`
+  }
 )
 
 const reviewedUnits = reviewResults.filter(Boolean)
 const failedChunks = reviewUnits.filter((u, i) => !reviewResults[i]).map((u) => u.chunkLabel)
-log(`Execution complete: ${reviewedUnits.length}/${reviewUnits.length} chunk(s) reviewed`)
+log(`Execution complete: ${reviewedUnits.length}/${reviewUnits.length} chunk(s) reviewed and adversarially verified`)
 if (failedChunks.length > 0) {
   log(`Chunk failure: ${failedChunks.length} chunk(s) returned no result — files in them were never reviewed: ${failedChunks.join(', ')}`)
 }
@@ -373,7 +419,7 @@ if (failedChunks.length > 0) {
 // ---------------------------------------------------------------------------
 phase('Synthesize')
 
-const synthesisPrompt = `Synthesize ${reviewUnits.length} independent chunk reviews of a
+const synthesisPrompt = `Synthesize ${reviewUnits.length} adversarially verified chunk reviews of a
 SqlArtisan ${scopeInfo.scope === 'diff' ? 'branch diff' : 'full codebase pass'} into one report.
 
 GATES: ${gates.summary}
@@ -384,14 +430,22 @@ ${missingFiles.length > 0 ? `- Missing (in scope, never assigned to a group): ${
 CHUNK FAILURE — call this out explicitly in the report:
 - ${failedChunks.length} chunk(s) returned no result and were never reviewed: ${failedChunks.join(', ')}
 ` : ''}
-CHUNK REVIEWS:
+ADVERSARIALLY VERIFIED CHUNK REVIEWS (findings annotated CONFIRMED/REFUTED;
+extra DEFECT/OVERREACH/INCONSISTENCY findings may follow each review):
 ${reviewUnits.map((u, i) => `--- ${u.chunkLabel} ---\n${reviewResults[i] ?? '(this chunk failed to return a result — its files were never reviewed)'}`).join('\n\n')}
 
 Tasks:
 1. Merge findings across chunks; surface cross-chunk patterns (e.g. the same
    naming issue in both Public API and Tests) rather than listing duplicates.
-2. Prioritize: MUST FIX > SHOULD DISCUSS > NITS.
-3. Decide a verdict: Mergeable / Mergeable after must-fix / Not mergeable.
+2. Drop REFUTED findings from the verdict — list them briefly in a
+   "Refuted in verification" note so the exclusion is visible, never
+   silent. Route the verifiers' extra DEFECT / OVERREACH / INCONSISTENCY
+   findings by severity: DEFECT to MUST FIX; OVERREACH and INCONSISTENCY to
+   MUST FIX or SHOULD DISCUSS. A chunk marked "(adversarial verification
+   unavailable...)" was never verified — say so in Coverage and treat its
+   findings as unverified.
+3. Prioritize: MUST FIX > SHOULD DISCUSS > NITS.
+4. Decide a verdict: Mergeable / Mergeable after must-fix / Not mergeable.
    A failing gate above is itself a MUST FIX and blocks "Mergeable" — and so
    is a coverage gap (a missing or duplicated file above) and a chunk
    failure (a chunk above that never returned a result): both mean files
@@ -416,10 +470,10 @@ Output as a headed report:
 
 ## Coverage
 - Branch point: ${scopeInfo.branchPoint ?? 'n/a'}
-- Chunks reviewed: ${reviewedUnits.length}/${reviewUnits.length}
+- Chunks reviewed+verified: ${reviewedUnits.length}/${reviewUnits.length} (note any unverified chunks)
 - Files in scope: ${scopeInfo.changedFiles.length}
 - Gates: build=${gates.buildPassed} test=${gates.testsPassed} format=${gates.formatClean}
-- Empirical probes actually run (from chunk reviews): ...
+- Empirical probes actually run (from chunk reviews and verification): ...
 
 ## Recommendations (ranked)
 1. ...`

--- a/.claude/workflows/sa-multi-model-code-review.js
+++ b/.claude/workflows/sa-multi-model-code-review.js
@@ -323,7 +323,7 @@ if (!coverageClean) {
 // PHASE 4+5: Execute, then adversarially Verify — one pipeline, no barrier:
 // each chunk's verification starts as soon as its review lands. Execute runs
 // via the sa-reviewer agent so every chunk inherits its read-only tool
-// restriction and its pointer to the sa-review-changes / sa-run-sql-harness
+// restriction and its pointer to the sa-code-review / sa-run-sql-harness
 // skills, instead of re-deriving (and risking drift from) that procedure
 // inline in this prompt. Verify re-enters sa-reviewer on its
 // adversarial-verification mission (refute, don't confirm) so no finding
@@ -347,7 +347,7 @@ ${unit.chunkFiles.map((f) => `- ${f}`).join('\n')}
 DIMENSIONS TO APPLY:
 ${unit.reviewDimensions.map((d) => `- ${d}`).join('\n')}
 
-Follow the sa-review-changes skill's checklist for whichever of these
+Follow the sa-code-review skill's checklist for whichever of these
 dimensions apply, and use the sa-run-sql-harness skill for any empirical
 verification (DBMS grammar, guard enforcement, allocation) — do not assume
 emitted SQL or allocation behavior from memory. Skip the skill's own gate
@@ -409,18 +409,27 @@ DEFECT / OVERREACH / INCONSISTENCY with severity and evidence.`,
 
 const reviewedUnits = reviewResults.filter(Boolean)
 const failedChunks = reviewUnits.filter((u, i) => !reviewResults[i]).map((u) => u.chunkLabel)
-log(`Execution complete: ${reviewedUnits.length}/${reviewUnits.length} chunk(s) reviewed and adversarially verified`)
+const unverifiedChunks = reviewUnits.filter((u, i) =>
+  reviewResults[i]?.startsWith('(adversarial verification unavailable')
+).map((u) => u.chunkLabel)
+log(`Execution complete: ${reviewedUnits.length}/${reviewUnits.length} chunk(s) reviewed`
+  + (unverifiedChunks.length > 0 ? `, ${unverifiedChunks.length} unverified` : ' and adversarially verified'))
 if (failedChunks.length > 0) {
   log(`Chunk failure: ${failedChunks.length} chunk(s) returned no result — files in them were never reviewed: ${failedChunks.join(', ')}`)
 }
+if (unverifiedChunks.length > 0) {
+  log(`Verification gap: ${unverifiedChunks.length} chunk(s) fell back to an unverified review — see Coverage: ${unverifiedChunks.join(', ')}`)
+}
 
 // ---------------------------------------------------------------------------
-// PHASE 5: Synthesize — Fable integrates findings into one report.
+// PHASE 6: Synthesize — Fable integrates findings into one report.
 // ---------------------------------------------------------------------------
 phase('Synthesize')
 
-const synthesisPrompt = `Synthesize ${reviewUnits.length} adversarially verified chunk reviews of a
+const synthesisPrompt = `Synthesize ${reviewUnits.length} chunk reviews of a
 SqlArtisan ${scopeInfo.scope === 'diff' ? 'branch diff' : 'full codebase pass'} into one report.
+Each chunk went through adversarial verification, except any listed below as
+unverified (its review stands as drafted, unchallenged).
 
 GATES: ${gates.summary}
 BRANCH POINT: ${scopeInfo.branchPoint ?? 'n/a'}
@@ -429,9 +438,13 @@ COVERAGE GAP — call this out explicitly in the report:
 ${missingFiles.length > 0 ? `- Missing (in scope, never assigned to a group): ${missingFiles.join(', ')}\n` : ''}${duplicateFiles.length > 0 ? `- Duplicated (assigned to more than one group, reviewed redundantly): ${duplicateFiles.join(', ')}\n` : ''}` : ''}${failedChunks.length > 0 ? `
 CHUNK FAILURE — call this out explicitly in the report:
 - ${failedChunks.length} chunk(s) returned no result and were never reviewed: ${failedChunks.join(', ')}
+` : ''}${unverifiedChunks.length > 0 ? `
+UNVERIFIED CHUNKS — call this out explicitly in Coverage; treat their findings as unconfirmed:
+- ${unverifiedChunks.join(', ')}
 ` : ''}
-ADVERSARIALLY VERIFIED CHUNK REVIEWS (findings annotated CONFIRMED/REFUTED;
-extra DEFECT/OVERREACH/INCONSISTENCY findings may follow each review):
+CHUNK REVIEWS (verified chunks have findings annotated CONFIRMED/REFUTED,
+plus any extra DEFECT/OVERREACH/INCONSISTENCY findings the verifier added;
+unverified chunks carry the "(adversarial verification unavailable...)" marker):
 ${reviewUnits.map((u, i) => `--- ${u.chunkLabel} ---\n${reviewResults[i] ?? '(this chunk failed to return a result — its files were never reviewed)'}`).join('\n\n')}
 
 Tasks:
@@ -470,7 +483,8 @@ Output as a headed report:
 
 ## Coverage
 - Branch point: ${scopeInfo.branchPoint ?? 'n/a'}
-- Chunks reviewed+verified: ${reviewedUnits.length}/${reviewUnits.length} (note any unverified chunks)
+- Chunks reviewed: ${reviewedUnits.length}/${reviewUnits.length}
+- Chunks adversarially verified: ${reviewedUnits.length - unverifiedChunks.length}/${reviewedUnits.length}${unverifiedChunks.length > 0 ? ` (unverified: ${unverifiedChunks.join(', ')})` : ''}
 - Files in scope: ${scopeInfo.changedFiles.length}
 - Gates: build=${gates.buildPassed} test=${gates.testsPassed} format=${gates.formatClean}
 - Empirical probes actually run (from chunk reviews and verification): ...


### PR DESCRIPTION
## Summary

Reviews now end with an independent subagent on a refutation mission: attempt to refute the deliverable's claims and the draft findings, trace every factual claim to a primary source (code, test catalogs, ADRs, live harness probes), and attach severity plus refutation-surviving evidence to each finding. Fallen claims classify as **DEFECT** (factually wrong) / **OVERREACH** (true but misleading) / **INCONSISTENCY** (contradicts another surface).

Pattern proven on #267/#319: a neutral docs review pass accepted "every analyzer entry is executed against a live engine" — a follow-up adversarial pass read `MatrixSweepCatalog.cs` and found the two entries actually excluded from the sweep.

## Changes (5 files)

- **`sa-code-review`** — new §9 "Adversarial verification (mandatory final pass)": spawns `sa-reviewer` with a refutation mission, primary-source rule, severity + evidence requirement, recursion/fallback guard
- **`sa-docs-review`** — same pass, plus docs-specific refutation targets (quantifiers, superlatives, counts/version/capability claims)
- **`sa-code-review-deep`** — inherits the pass from `sa-code-review` (runs once, after the improvement pass); suggestions stay opinion-exempt, but their factual claims get the primary-source check
- **`sa-reviewer` agent** — new "Adversarial-verification missions" mode + recursion guard (it has no Agent tool, so on a refutation mission it *is* the pass; as primary reviewer it runs the pass inline)
- **`sa-multi-model-code-review` workflow** — new Verify pipeline stage between Execute and Synthesize (no barrier — verification starts per chunk as its review lands); REFUTED findings are dropped non-silently; a verifier-null chunk falls back to its unverified review rather than losing the review entirely

## Self-test

The new pass was run against itself: an `sa-reviewer` instance was spawned with a refutation mission against these five files. It confirmed the #267/#319 anecdote against `MatrixSweepCatalog.cs` and git history, confirmed all cross-references resolve, and found three low-severity issues in the new workflow code (all now fixed in this branch):
- a stale `sa-review-changes` skill name (renamed to `sa-code-review` in #309) in newly-added prompt/comment text
- an unrenumbered `PHASE 5` comment after Execute/Verify became phases 4/5
- a completion log/Coverage line overclaiming "verified" for chunks whose verifier returned null

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test tests/SqlArtisan.Tests` — 750/750 passed (no code changes; sanity check)
- [x] `dotnet format --verify-no-changes` — clean
- [x] Workflow JS syntax-checked (wrapped as an async function body, matching the runtime's execution model)
- [x] Adversarial self-test run against all five changed files; findings fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeKa4dbMBLf6xUQ4Tt4i1d

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeKa4dbMBLf6xUQ4Tt4i1d)_