### PR TITLE
test: Pin that generated identifiers never collide with C# keywords (#322)

### DIFF
--- a/tests/SqlArtisan.TableClassGen.Tests/GeneratedIdentifierTests.cs
+++ b/tests/SqlArtisan.TableClassGen.Tests/GeneratedIdentifierTests.cs
@@ -1,0 +1,26 @@
+using SqlArtisan.TableClassGen;
+
+namespace SqlArtisan.TableClassGen.Tests;
+
+public class GeneratedIdentifierTests
+{
+    // PascalCase upper-cases each word's first letter, and every C# keyword is
+    // lowercase, so a generated identifier can never collide with a keyword —
+    // this pins that guarantee (see #322: @-escaping is unnecessary).
+    [Fact]
+    public void GeneratedCode_KeywordCatalogNames_Compiles()
+    {
+        string[] keywords =
+        [
+            "class", "int", "namespace", "public", "static", "void", "return",
+            "null", "true", "false", "for", "if", "else", "new", "using", "this",
+            "base", "var", "async", "await", "record", "yield", "nameof", "value",
+        ];
+
+        List<DbColumnInfo> columns =
+            [.. keywords.Select(keyword => new DbColumnInfo(keyword, "text"))];
+        DbTableInfo table = new("class", columns);
+
+        GeneratedCodeCompiler.AssertCompiles([table.GenerateCode("Generated.Tables")]);
+    }
+}


### PR DESCRIPTION
Closes #322.

## Finding

#322 proposed `@`-escaping C# reserved words in TableClassGen's generated identifiers. On investigation, the escaping is **unnecessary** — the collision it guards against cannot occur:

- `CaseConverter.SnakeToPascalCase` upper-cases the first letter of every word, so every generated identifier starts with an **uppercase** letter (or `_` for a leading digit).
- Every C# keyword — reserved and contextual — is **lowercase** (`class`, `int`, `var`, `await`, `record`, …).
- So a generated property or class name can never *equal* a keyword: `class` → `Class`, `int` → `Int`, `namespace` → `Namespace`, all valid identifiers.

(`@`-escaping only helps with keyword collisions; invalid characters are already stripped by the converter, and leading digits are already `_`-prefixed.)

## Change

Rather than add dead code for an impossible case, this pins the invariant with a regression test: it generates a table whose columns are named after 24 C# keywords and compiles the output via the existing `GeneratedCodeCompiler` Roslyn check. If a future change to `SnakeToPascalCase` ever lowercased an initial, this test would fail.

`#322` is closed as resolved-by-verification.

## Verification
- `dotnet test tests/SqlArtisan.TableClassGen.Tests` — 5/5 pass (the new test compiles the keyword-named table). `dotnet format --verify-no-changes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014H2azHNsdZVpsTckXcphHW

---
_Generated by [Claude Code](https://claude.ai/code/session_014H2azHNsdZVpsTckXcphHW)_