### PR TITLE
chore: Lock the SQLA0001 operator message and note Mod()'s SQL Server gap

### DIFF
--- a/docs/functions.md
+++ b/docs/functions.md
@@ -22,7 +22,7 @@ SqlArtisan provides C# APIs that map to various SQL functions, enabling you to u
 - `Ceil()` for `CEIL` (Oracle; MySQL/PostgreSQL/SQLite accept both spellings)
 - `Ceiling()` for `CEILING` (SQL Server; MySQL/PostgreSQL/SQLite accept both spellings)
 - `Floor()` for `FLOOR`
-- `Mod()` for `MOD`
+- `Mod()` for `MOD` (not supported by SQL Server — use the `%` operator there)
 - `Power()` for `POWER`
 - `Round()` for `ROUND`
 - `Sign()` for `SIGN`

--- a/src/SqlArtisan/Sql/Sql.M.cs
+++ b/src/SqlArtisan/Sql/Sql.M.cs
@@ -71,6 +71,7 @@ public static partial class Sql
     /// <param name="dividend">The number being divided.</param>
     /// <param name="divisor">The number to divide by.</param>
     /// <returns>The MOD construct.</returns>
+    /// <remarks>Not supported by SQL Server — use the <c>%</c> operator there.</remarks>
     public static ModFunction Mod(object dividend, object divisor) =>
         new(Resolve(dividend), Resolve(divisor));
 

--- a/tests/SqlArtisan.Analyzers.Tests/DialectMatrixIntegrityTests.cs
+++ b/tests/SqlArtisan.Analyzers.Tests/DialectMatrixIntegrityTests.cs
@@ -42,7 +42,7 @@ public class DialectMatrixIntegrityTests
         {
             bool methodMatch = type
                 .GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-                .Where(m => (!m.IsSpecialName || m.Name.StartsWith("op_", StringComparison.Ordinal)) && m.Name == name)
+                .Where(m => (!m.IsSpecialName || IsOperator(m)) && m.Name == name)
                 .Any(m => !arity.HasValue || m.GetParameters().Length == arity.Value);
             if (methodMatch)
             {
@@ -63,4 +63,7 @@ public class DialectMatrixIntegrityTests
 
         return false;
     }
+
+    private static bool IsOperator(MethodInfo method) =>
+        method.Name.StartsWith("op_", StringComparison.Ordinal);
 }

--- a/tests/SqlArtisan.Analyzers.Tests/DialectUsageAnalyzerTests.cs
+++ b/tests/SqlArtisan.Analyzers.Tests/DialectUsageAnalyzerTests.cs
@@ -352,7 +352,12 @@ public class DialectUsageAnalyzerTests
             """;
 
         var test = AnalyzerVerifier.Create(source, editorConfig);
-        test.ExpectedDiagnostics.Add(DiagnosticResult.CompilerWarning("SQLA0001").WithLocation(0));
+
+        // Locks the operator display mapping (the C# glyph, not "op_Modulus") and the
+        // member-level override key the message names — neither is asserted anywhere else.
+        test.ExpectedDiagnostics.Add(DiagnosticResult.CompilerWarning("SQLA0001")
+            .WithLocation(0)
+            .WithArguments("operator %", "Oracle", "sqlartisan_construct_op_modulus"));
 
         await test.RunAsync();
     }

--- a/tests/SqlArtisan.Analyzers.Tests/XmlDocDialectParityTests.cs
+++ b/tests/SqlArtisan.Analyzers.Tests/XmlDocDialectParityTests.cs
@@ -45,6 +45,7 @@ public class XmlDocDialectParityTests
         ["M:SqlArtisan.Sql.Lpad(System.Object,System.Object)", "Lpad", 2],
         ["M:SqlArtisan.Sql.Lpad(System.Object,System.Object,System.Object)", "Lpad", 3],
         ["M:SqlArtisan.SqlExpression.op_Modulus(SqlArtisan.SqlExpression,System.Object)", "op_Modulus", 2],
+        ["M:SqlArtisan.Sql.Mod(System.Object,System.Object)", "Mod", 2],
     ];
 
     [Theory]


### PR DESCRIPTION
## Summary

Follow-ups from the deep review of #327 (three non-blocking suggestions, all landed):

- **Message-text assertion** — `ModulusOperator_OnOracleTarget_ReportsSqla0001` now pins the rendered SQLA0001 arguments with `.WithArguments("operator %", "Oracle", "sqlartisan_construct_op_modulus")` — the glyph display and the override key named in the message were previously verified only by a manual probe. Kill-tested: flipping any argument fails the test.
- **Gate filter shape unified** — `DialectMatrixIntegrityTests` mirrors the coverage gate's `IsOperator()` helper instead of inlining the same `StartsWith`.
- **`Mod()`'s SQL Server gap documented** — the matrix has always said `sqlServer: false` (T-SQL only has the `%` operator), but neither `docs/functions.md` nor the factory's XML docs mentioned it, while siblings like `Substr` carry the remark. Both notes added, plus an `XmlDocDialectParityTests` row so the remark stays gate-checked against the matrix.

No behavior or emitted-SQL change.

### Verification

| Gate | Result |
|---|---|
| `tests/SqlArtisan.Analyzers.Tests` (incl. new parity row + strengthened message assertion) | ✅ 337/337 |
| `tests/SqlArtisan.Tests` | ✅ 750/750 |
| `dotnet format --verify-no-changes` | ✅ |
| Release build | ✅ 0 code warnings |

Deep review (sa-code-review-deep) ran on this diff with an adversarial verification pass: all claims survived, no defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Qu2NyooCZAde69vW9AUtA

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qu2NyooCZAde69vW9AUtA)_