### PR TITLE
fix: Exclude llms-full.txt from Context7 indexing

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -2,7 +2,7 @@
   "$schema": "https://context7.com/schema/context7.json",
   "folders": [],
   "excludeFolders": ["src", "tests", ".github", ".claude"],
-  "excludeFiles": ["CLAUDE.md"],
+  "excludeFiles": ["CLAUDE.md", "llms-full.txt"],
   "rules": [
     "Emit SQL for the caller's chosen dialect; a single call is never rewritten across MySQL, Oracle, PostgreSQL, SQLite, and SQL Server — pick the per-dialect API/factory when they diverge.",
     "Point the assistant at llms.txt or llms-full.txt (repo root) for the full reference; docs/ mirrors the same content."


### PR DESCRIPTION
## Summary

Follow-up to #329, based on Context7's first actual index of the repo:

- **Duplicates**: every `docs/` snippet appeared twice — once from its source page and once from `llms-full.txt`, which is a concatenation of those same pages. `llms-full.txt` exists for direct-URL ingestion (an assistant reading one file); for Context7, which scans the repo itself, it is a pure duplicate source and also produced fragment snippets with no standalone meaning ("DML Aliasing and Ordering"). Added to `excludeFiles`.
- The first index also surfaced a `CLAUDE.md` snippet despite the existing `excludeFiles` entry — likely the index predates the config taking effect. After merging, trigger a **manual refresh** on the Context7 library page; if the `CLAUDE.md` snippet persists after the refresh, the exclusion pattern needs adjusting (a separate follow-up).

One-line diff: `"excludeFiles": ["CLAUDE.md"]` → `["CLAUDE.md", "llms-full.txt"]`.

### Verification

- `context7.json` parses as valid JSON.
- No code/test/docs-content change — `LlmsFullTests` and the rest of the suite are unaffected (the file itself is unchanged; only Context7's view of it changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Qu2NyooCZAde69vW9AUtA

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qu2NyooCZAde69vW9AUtA)_