### PR TITLE
docs: Tighten Context7 config — metadata, ADR exclusion, usage rules

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,10 +1,14 @@
 {
   "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "SqlArtisan",
+  "description": "A type-safe SQL query builder for C# (.NET 8): SQL-like C# in, the SQL string plus its bind parameters out — emitted faithfully with no dialect translation.",
   "folders": [],
-  "excludeFolders": ["src", "tests", ".github", ".claude"],
-  "excludeFiles": ["CLAUDE.md", "llms-full.txt"],
+  "excludeFolders": ["src", "tests", ".github", ".claude", "docs/adr"],
+  "excludeFiles": ["CLAUDE.md", "SECURITY.md", "llms.txt", "llms-full.txt"],
   "rules": [
-    "Emit SQL for the caller's chosen dialect; a single call is never rewritten across MySQL, Oracle, PostgreSQL, SQLite, and SQL Server — pick the per-dialect API/factory when they diverge.",
-    "Point the assistant at llms.txt or llms-full.txt (repo root) for the full reference; docs/ mirrors the same content."
+    "SqlArtisan emits SQL faithfully with no dialect translation — always pick the API documented for the target DBMS (MySQL, Oracle, PostgreSQL, SQLite, SQL Server); only bind-parameter markers and alias quoting vary by dialect.",
+    "Reference database tables through their table classes (one DbTableBase subclass per table); never name a table or column with a string literal.",
+    "A builder chain is single-use — build a fresh chain per statement; never hold a partially built query for reuse.",
+    "Treat SQLA0001 analyzer warnings as errors to fix, not suppress; pin every new or changed query with an exact-SQL unit test asserting sql.Text and its bind parameters."
   ]
 }


### PR DESCRIPTION
## Summary

Adversarial review of `context7.json` (added in #329, amended in #330) surfaced one policy inconsistency, one factual inaccuracy, and one self-defeating rule. This PR fixes all of them in the config file only.

- **Add `projectTitle` / `description`** — the Context7-recommended metadata fields were missing; the description reuses the summary that `llms.txt` front-loads.
- **Exclude `docs/adr` from indexing** — `llms-full.txt` deliberately omits the ADRs (design records including rejected alternatives), and the docs-style rule keeps ADR references off AI-ingestion surfaces; Context7 was the one channel still indexing them.
- **Exclude `llms.txt` and `SECURITY.md`** — `llms.txt` is a link index whose raw URLs are unresolvable through Context7's snippet channel (`llms-full.txt` was already excluded in #330); `SECURITY.md` is not usage documentation.
- **Replace both rules with the vetted usage rules** from `docs/guides/ai-assistants.md`:
  - The old dialect rule ("a single call is never rewritten across …") overstated — bind-parameter markers and alias quoting do vary per dialect — and its phrasing ("Emit SQL for the caller's chosen dialect") read as if the library translates SQL, the exact misconception the docs fight.
  - The old doc-pointer rule told the assistant to fetch `llms.txt` from "repo root", which an assistant consuming Context7 snippets cannot resolve — and Context7 itself is already the docs channel.
  - The replacement carries the four rules the repo already ships for agent files: faithful emission / pick the target-DBMS API, table classes over string literals, single-use builder chains, and SQLA0001-as-error plus exact-SQL test pinning.

## Verification

- JSON syntax validated (`python3 -m json.tool`).
- Confirmed `llms-full.txt` contains no ADR content (its 12 sources are README, `docs/` pages, and CHANGELOG), and that per-dialect variance is limited to `ParameterMarker` / `AliasQuote` in `IDbmsDialect`.
- No tests reference `context7.json`; no `src/` changes, so the test suites are unaffected. No CHANGELOG entry, matching #330's treatment of indexing-config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ryVbRwnrakSn2SRGD5BM3

---
_Generated by [Claude Code](https://claude.ai/code/session_014ryVbRwnrakSn2SRGD5BM3)_