### PR TITLE
docs: Add .devin/wiki.json to steer DeepWiki generation

### DIFF
--- a/.devin/wiki.json
+++ b/.devin/wiki.json
@@ -1,0 +1,12 @@
+{
+  "repo_notes": [
+    { "content": "SqlArtisan is a type-safe SQL query builder for C# (.NET 8): you write SQL-like C# and it produces the SQL string plus its bind parameters." },
+    { "content": "Core principle: 'The SQL you write is the SQL that runs.' SqlArtisan emits SQL faithfully with NO cross-dialect rewriting or translation. Cross-database portability is a deliberate non-goal — never describe SqlArtisan as a portability or abstraction layer over databases." },
+    { "content": "Supported dialects: MySQL, Oracle, PostgreSQL, SQLite, SQL Server (default: PostgreSQL). Dialect differences are confined to a small dialect layer (alias quoting, parameter markers); function nodes never branch on the target DBMS." },
+    { "content": "Mission: a deterministic guard rail for SQL written alongside generative AI, built as four layers — (1) types: invalid builder chains fail to compile; (2) a bundled Roslyn analyzer (SQLA0001/SQLA0002) that flags constructs unsupported on the configured target dialect at build time; (3) exact-SQL unit tests that pin the emitted SQL; (4) an integration-test matrix verified against live database engines." },
+    { "content": "Opinions live in docs and the analyzer, never in API holes: no legitimate SQL spelling is omitted to steer users." },
+    { "content": "Three NuGet packages: SqlArtisan (the builder, with the analyzer bundled inside — not shipped separately), SqlArtisan.Dapper (sync/async Dapper execution extensions), SqlArtisan.TableClassGen (console tool that generates table classes from a live database)." },
+    { "content": "Terminology: 'table class' (a DbTableBase subclass), never 'table schema class'; 'query builder', not 'SQL builder'. Public factory names mirror SQL tokens with underscores as the only word boundaries (ADD_MONTHS → AddMonths, DATEADD → Dateadd)." },
+    { "content": "Canonical documentation is llms.txt and docs/ in the repository; if this wiki and those files disagree, the repository documentation is authoritative." }
+  ]
+}

--- a/context7.json
+++ b/context7.json
@@ -3,7 +3,7 @@
   "projectTitle": "SqlArtisan",
   "description": "A type-safe SQL query builder for C# (.NET 8): SQL-like C# in, the SQL string plus its bind parameters out — emitted faithfully with no dialect translation.",
   "folders": [],
-  "excludeFolders": ["src", "tests", ".github", ".claude", "docs/adr"],
+  "excludeFolders": ["src", "tests", ".github", ".claude", ".devin", "docs/adr"],
   "excludeFiles": ["CLAUDE.md", "SECURITY.md", "llms.txt", "llms-full.txt"],
   "rules": [
     "SqlArtisan emits SQL faithfully with no dialect translation — always pick the API documented for the target DBMS (MySQL, Oracle, PostgreSQL, SQLite, SQL Server); only bind-parameter markers and alias quoting vary by dialect.",


### PR DESCRIPTION
## Summary

- Add `.devin/wiki.json` with `repo_notes` that inject the project's core premises into DeepWiki's wiki generation: faithful emission ("the SQL you write is the SQL that runs"), cross-database portability as a deliberate non-goal, the four-layer deterministic guard-rail mission, package layout, terminology, and a pointer that the repository docs are authoritative
- `pages` is deliberately omitted — per the DeepWiki docs, `repo_notes` alone guides generation while keeping the automatic page planning; `pages` would freeze the page list and become a maintenance burden
- Exclude `.devin/` from Context7 indexing in `context7.json`, matching the existing meta-file excludes (`.claude`, `docs/adr`, `llms-full.txt`, …)

## Verification

- `dotnet test tests/SqlArtisan.Tests` — 752 passed, 0 failed
- `repo_notes` format follows the documented schema (array of `{content}` objects; well under the 100-note / 10,000-char limits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEdpcVbfYesBVU7Hdt5JUN

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEdpcVbfYesBVU7Hdt5JUN)_