### PR TITLE
test: Gate the root README capability map against section drift

### DIFF
--- a/.claude/rules/docs-style.md
+++ b/.claude/rules/docs-style.md
@@ -80,4 +80,5 @@ with availability left to the database"). ADR cross-references belong in
 - Adding/renaming/moving a `## ` section in `docs/expressions.md` or
   `docs/functions.md` must update `docs/README.md`'s index **and** the root
   README capability-map row, both **in page order** — `DocsIndexTests` gates
-  both (#210, #340) — and usually `llms.txt` (descriptor prose, ungated).
+  missing links on both, plus order and stale anchors on the root README row
+  (#210, #340) — and usually `llms.txt` (descriptor prose, ungated).

--- a/.claude/rules/docs-style.md
+++ b/.claude/rules/docs-style.md
@@ -78,6 +78,6 @@ with availability left to the database"). ADR cross-references belong in
 - README→docs and docs↔docs links are absolute GitHub `blob/main` URLs;
   `llms.txt` uses `raw.githubusercontent.com` URLs; in-page anchors stay relative.
 - Adding/renaming/moving a `## ` section in `docs/expressions.md` or
-  `docs/functions.md` must update `docs/README.md`'s index **in page order**
-  (and usually the README capability map and `llms.txt`). `DocsIndexTests`
-  fails the unit suite when an index link is missing (#210).
+  `docs/functions.md` must update `docs/README.md`'s index **and** the root
+  README capability-map row, both **in page order** — `DocsIndexTests` gates
+  both (#210, #340) — and usually `llms.txt` (descriptor prose, ungated).

--- a/tests/SqlArtisan.Tests/DocsIndexTests.cs
+++ b/tests/SqlArtisan.Tests/DocsIndexTests.cs
@@ -21,6 +21,15 @@ public class DocsIndexTests
         "docs/functions.md",
     ];
 
+    // Pages whose root-README capability-map row mirrors the full `## ` section
+    // list (#340). The query-statements, cookbook, and analyzer rows deliberately
+    // curate a subset (grouped subsections / highlights), so they stay manual.
+    private static readonly string[] s_capabilityMapMirroredPages =
+    [
+        "docs/expressions.md",
+        "docs/functions.md",
+    ];
+
     [Fact]
     public void DocsReadme_EveryReferenceSection_IsLinked()
     {
@@ -50,6 +59,60 @@ public class DocsIndexTests
                 Assert.True(
                     index.Contains(anchor, StringComparison.Ordinal),
                     $"docs/README.md has no link to \"{heading}\" ({anchor}) — add it to the index in page order.");
+            }
+        }
+    }
+
+    // The root README's capability map ships to nuget.org and drifted the same
+    // way docs/README.md used to (#210), so its full-mirror rows get the same
+    // mechanical gate: every section linked, in page order, no stale anchors.
+    [Fact]
+    public void ReadmeCapabilityMap_MirroredPages_LinkEverySectionInOrder()
+    {
+        string root = FindRepoRoot();
+        string readme = File.ReadAllText(Path.Combine(root, "README.md"));
+
+        foreach (string page in s_capabilityMapMirroredPages)
+        {
+            string[] lines = File.ReadAllLines(Path.Combine(root, page));
+            string fileName = Path.GetFileName(page);
+            List<string> anchors = [];
+
+            foreach (string line in lines)
+            {
+                if (!line.StartsWith("## ", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                string heading = line[3..].Trim();
+
+                if (heading != "Contents")
+                {
+                    anchors.Add($"{fileName}#{ToGitHubAnchor(heading)}");
+                }
+            }
+
+            int position = -1;
+
+            foreach (string anchor in anchors)
+            {
+                int found = readme.IndexOf(anchor, StringComparison.Ordinal);
+
+                Assert.True(
+                    found >= 0,
+                    $"README.md's capability map has no link to {anchor} — add it in page order.");
+                Assert.True(
+                    found > position,
+                    $"README.md's capability map lists {anchor} out of page order.");
+                position = found;
+            }
+
+            foreach (Match link in Regex.Matches(readme, $@"{Regex.Escape(fileName)}#([a-z0-9-]+)"))
+            {
+                Assert.True(
+                    anchors.Contains(link.Value),
+                    $"README.md links {link.Value}, which is not a `## ` section of {page} — fix or remove the stale anchor.");
             }
         }
     }


### PR DESCRIPTION
## Summary

Resolves #340. `DocsIndexTests` gated only `docs/README.md`'s index; the root `README.md` capability map — the same full-mirror shape for the Expressions and Functions rows, and the highest-visibility surface (GitHub landing + nuget.org) — had no test gate. The `sa-docs-review` pass that filed #340 found two same-class staleness instances on ungated surfaces (`llms.txt` descriptor, `functions.md` cross-reference note), so the failure mode is demonstrated, not hypothetical.

- New `ReadmeCapabilityMap_MirroredPages_LinkEverySectionInOrder` test in `DocsIndexTests.cs`, reusing the existing heading-extraction/anchor helpers. It asserts, per mirrored page (`expressions.md`, `functions.md`):
  - every `## ` section's anchor is linked from README (missing-link direction),
  - in page order (order direction),
  - and every `<page>#anchor` link in README resolves to a real section (stale-anchor direction).
- **Anchors, not link text** — the map deliberately abbreviates (`CASE` for "CASE Expressions") and annotates (`(incl. REGEXP_*)`), so text equality would freeze editorial wording; anchor equality captures exactly the drift failure mode.
- The query-statements, cookbook, and analyzer rows deliberately curate a subset (grouped `### ` subsections / highlights), so they stay manual — documented on the new page list, parallel to the existing `s_indexedPages` exclusion comment.
- `.claude/rules/docs-style.md` updated: the README map is now listed as gated (and `llms.txt`'s descriptor prose explicitly noted as the remaining ungated surface).

## Test plan

- [x] `dotnet test tests/SqlArtisan.Tests` — 770 passed (769 + the new gate)
- [x] Gate detection verified by mutation before landing: dropping the Array Operators link, swapping JSON/Array order, and corrupting an anchor each fail the test with the intended message; the intact README passes (README restored byte-identical afterward, `git diff` clean)
- [x] `dotnet format SqlArtisan.sln --verify-no-changes` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqiQAsZre2BPk9XpLwJWeF)_