### PR TITLE
docs: Sharpen the sa-code-review / sa-docs-review skills from this review cycle's misses

### DIFF
--- a/.claude/skills/sa-code-review/SKILL.md
+++ b/.claude/skills/sa-code-review/SKILL.md
@@ -143,7 +143,13 @@ to run for a review:
 
 Wrong-DBMS facts are the easiest way to ship a bug. State each grammar claim as
 something you verified, and prefer a per-dialect API that lets the author pick
-the form. Known sharp edges:
+the form. Verify a version / "landed in X" / rejection claim against the
+vendor's own docs via a WebSearch scoped to the official domain — WebFetch to
+vendor sites is often egress-blocked (403), so WebSearch is the access path,
+not memory. Dialect support resolves at the **arity-specific** matrix entry
+(`[MatrixKey(name, arity)]`), not just the member — check it before trusting a
+per-overload claim (`ToNumber` arity-1 is Oracle-only, the member is
+Oracle+PostgreSQL). Known sharp edges:
 - MySQL `GROUP_CONCAT ... SEPARATOR` requires a **literal** (a `?` placeholder is
   a parse error) and silently truncates at `group_concat_max_len` (1024 B).
 - Oracle `LISTAGG` **requires** `WITHIN GROUP (ORDER BY ...)`.
@@ -238,6 +244,10 @@ this", never "check this is right":
   itself, a test catalog (e.g. `MatrixSweepCatalog.cs`), an ADR, or a live
   harness probe — never against the claim's own text, the diff description,
   or memory.
+- **The subagent has no web access** (Read/Grep/Glob/Bash only): it verifies
+  in-repo primary sources but **cannot check a DBMS-vendor-spec / version /
+  grammar claim** against the vendor's docs — keep those with the orchestrator's
+  WebSearch, and don't read subagent silence on them as verification.
 - **Severity + evidence on every surviving finding** — High/Medium/Low plus
   the evidence that survived refutation: verbatim probe output or the
   primary source's `file:line`.
@@ -247,9 +257,11 @@ this", never "check this is right":
   surface).
 
 Recursion and fallback: if you *are* the adversarial subagent, skip this
-section — no recursion. If the Agent tool is unavailable, run the pass
-yourself as a distinct final phase: re-derive each claim from primary
-sources; do not reread your draft as evidence.
+section — no recursion. If the Agent tool is unavailable — or the subagent
+errors, times out, or never returns — run the pass yourself as a distinct
+final phase: re-derive each claim from primary sources; do not reread your
+draft as evidence. Never report a review as complete with the adversarial
+pass silently skipped — a launched-but-non-returning agent is not a pass.
 
 ## Report
 

--- a/.claude/skills/sa-code-review/SKILL.md
+++ b/.claude/skills/sa-code-review/SKILL.md
@@ -263,6 +263,14 @@ final phase: re-derive each claim from primary sources; do not reread your
 draft as evidence. Never report a review as complete with the adversarial
 pass silently skipped — a launched-but-non-returning agent is not a pass.
 
+**Detecting a stalled/vanished subagent.** There is no reliable "is it still
+running" query, and a background agent can disappear with zero
+notification — no completion, no error. Don't sleep-poll for it; but don't
+wait on it indefinitely either. If work has stalled on the adversarial pass
+with no notification, `TaskStop` on the agent's ID doubles as a status probe:
+an error (e.g. "no task found") confirms it already ended without notifying,
+and is the cue to run the fallback pass yourself rather than continue waiting.
+
 ## Report
 
 Lead with the verdict (mergeable or not) and a short list of recommended

--- a/.claude/skills/sa-docs-review/SKILL.md
+++ b/.claude/skills/sa-docs-review/SKILL.md
@@ -55,6 +55,18 @@ Score the docs against these. The scripts cover 2–5 and parts of 6/10.
    real `sql.Text`. Run it. (`verify_sql_examples.py`.) Remember `sql.Text` is a
    single line and a single condition has no wrapping parens; the `//` comments
    are line-wrapped for readability — don't claim "verbatim".
+   - **Cross-check a table's prose against its own data columns.** A "Why"/notes
+     cell that contradicts the row's own Construct/Dialect/Version columns is a
+     defect — the Oracle set-operator row claimed plain `INTERSECT` landed in
+     21c while its Construct column correctly listed only the `ALL` forms.
+   - **Dialect-support claims resolve at the *arity-specific* matrix entry**
+     (`[MatrixKey(name, arity)]`), not just the member — check it before
+     trusting a per-overload remark (`ToNumber` arity-1 is Oracle-only though
+     the member entry is Oracle+PostgreSQL).
+   - **Version / vendor-spec facts** ("landed in PostgreSQL 15", "MySQL rejects
+     `NOT IN` + `LIMIT`") are verified against the vendor's own docs via a
+     WebSearch scoped to the official domain — WebFetch to vendor sites is often
+     egress-blocked (403), so WebSearch is the access path, not memory.
 
 5. **Consistency — terminology & formatting.** Conform to
    `.claude/rules/docs-style.md`: *table class* (not "table schema class"),
@@ -78,6 +90,11 @@ Score the docs against these. The scripts cover 2–5 and parts of 6/10.
 8. **Conciseness — no redundancy.** Section volume is proportionate (watch the
    longest, usually Quick Start). No near-duplicate sentences across sections
    (e.g. the Why close vs a Key Features bullet) — differentiate the angle.
+   Before flagging redundancy or an inconsistency, check whether a nearby
+   note/column already reconciles it: a version gap an adjacent parenthetical
+   explains is not an inconsistency, and an explanatory column that carries the
+   SQL-token spelling the code-name column hides (`WithRecursive` →
+   `WITH RECURSIVE`) is additive, not a restatement.
 
 9. **AI-consumption readiness.** `llms.txt` exists and its links track the docs;
    each `docs/` page leads with a design-constraints block; examples are
@@ -122,6 +139,10 @@ this", never "check this is right". Prime refutation targets in docs:
   engines", "N engines", "SQLite 3.44+"; the primary source is the test
   catalog (e.g. `MatrixSweepCatalog.cs`), the pinned image list, or a live
   probe.
+- **The subagent has no web access** (Read/Grep/Glob/Bash), so it checks
+  in-repo primary sources but **cannot verify a version / vendor-spec claim**
+  against the vendor's docs — keep those with the orchestrator's WebSearch, and
+  don't read the subagent's silence on them as confirmation.
 
 Mission rules: every factual claim is traced to a primary source (the code,
 a test catalog, an ADR, a live builder/harness run) — never the doc's own
@@ -132,9 +153,11 @@ wrong) / **OVERREACH** (true but misleading) / **INCONSISTENCY** (contradicts
 another surface).
 
 Recursion and fallback: if you *are* the adversarial subagent, skip this
-section — no recursion. If the Agent tool is unavailable, run the pass
-yourself as a distinct final phase, re-deriving each claim from primary
-sources rather than rereading your draft.
+section — no recursion. If the Agent tool is unavailable — or the subagent
+errors, times out, or never returns — run the pass yourself as a distinct
+final phase, re-deriving each claim from primary sources rather than rereading
+your draft. Never report the review as complete with the adversarial pass
+silently skipped — a launched-but-non-returning agent is not a pass.
 
 ## Output
 

--- a/.claude/skills/sa-docs-review/SKILL.md
+++ b/.claude/skills/sa-docs-review/SKILL.md
@@ -159,6 +159,14 @@ final phase, re-deriving each claim from primary sources rather than rereading
 your draft. Never report the review as complete with the adversarial pass
 silently skipped — a launched-but-non-returning agent is not a pass.
 
+**Detecting a stalled/vanished subagent.** There is no reliable "is it still
+running" query, and a background agent can disappear with zero
+notification — no completion, no error. Don't sleep-poll for it; but don't
+wait on it indefinitely either. If work has stalled on the adversarial pass
+with no notification, `TaskStop` on the agent's ID doubles as a status probe:
+an error (e.g. "no task found") confirms it already ended without notifying,
+and is the cue to run the fallback pass yourself rather than continue waiting.
+
 ## Output
 
 Summarise per dimension (pass / findings), list concrete fixes with file:line,


### PR DESCRIPTION
## Summary

Folds seven lessons from the version-bound analyzer review cycle (#349) into the review skills. Each is traceable to a real miss or over-flag observed this cycle, not a hypothetical.

- **Adversarial-pass reliability** (`sa-code-review` §9 + `sa-docs-review`) — fall back to running the pass yourself when a launched `sa-reviewer` subagent errors, times out, or never returns, and never report a review complete with the pass silently skipped. (An FP-hunt subagent vanished without returning this cycle.)
- **Detecting a stalled/vanished subagent** (both) — there is no reliable "is it still running" query; a background agent can disappear with zero notification. `TaskStop` on the agent's ID doubles as a status probe — an error like "no task found" confirms it already ended without notifying, the cue to run the fallback yourself instead of waiting indefinitely. (This is exactly how the vanished subagent above was discovered.)
- **Subagent has no web access** (both) — `sa-reviewer` (Read/Grep/Glob/Bash) cannot verify a DBMS-vendor-spec / version claim against the vendor's docs, so those stay with the orchestrator's WebSearch; don't read subagent silence on them as verification.
- **Cross-check a table's prose against its own data columns** (`sa-docs-review` dim 4) — the Oracle set-operator row claimed plain `INTERSECT` landed in 21c while its own Construct column listed only the `ALL` forms.
- **Resolve dialect-support claims at the arity-specific matrix entry** (both) — `[MatrixKey(name, arity)]`, not just the member: `ToNumber` arity-1 is Oracle-only though the member entry is Oracle+PostgreSQL.
- **Verify version / vendor-spec facts via a domain-scoped WebSearch** (both) — "landed in X" and rejection claims; WebFetch to vendor sites is often egress-blocked (403).
- **Reconcile before flagging** (`sa-docs-review` dim 8) — check for a nearby note/column that already reconciles an apparent redundancy or inconsistency before reporting it (three draft findings the adversarial pass refuted this cycle).

`sa-code-review-deep` inherits `sa-code-review` §9 unchanged, so the adversarial-pass changes apply there too.

## Test plan

- [x] Skill markdown only — no build/test gate (not part of the solution build, not concatenated into `llms-full.txt`); `dotnet format` scope is `.cs`.
- [x] Non-ASCII scan of both edited files clean — no mojibake, only the intended `§` / `—` / `→` / `⇔`.
- [x] Edits mirror the surrounding house style (section references, session-specific examples in the vein of the existing `#267/#319` citation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCLuXjrNVvqSkD1NjFTwg4