### PR TITLE
chore: Prepare 0.7.0-beta.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [0.7.0-beta.1] - 2026-07-24
 ### Added
 - Added `Sql.BindNull(dbType)`, an explicit bind-parameter handle for a SQL `NULL` — unlike a bare `null` literal, which inlines the `NULL` keyword directly into the SQL text, this reserves a real parameter marker, so the statement's shape stays identical whether or not the value is null. `Bind(value)` still rejects `null`; reach for `BindNull()` when you deliberately want a bound `NULL`, e.g. so an array-bind execution batch keeps one fixed command text across rows regardless of which rows are null. (#90)
 - Added the `SqlArtisan.ArrayBind` package — Oracle array-bind execution via ODP.NET (`OracleCommand.ArrayBindCount`): `connection.ExecuteArrayBind(statements)` / `ExecuteArrayBindAsync(...)` run N independently built SqlArtisan statements of identical shape (e.g. one `INSERT`/`UPDATE` per row) in one round trip, and fail loudly on an empty statement set, mismatched SQL text, a bound value's type with no Oracle mapping, or a position whose rows don't all bind the same type (including a `Sql.BindNull(dbType)` hint that disagrees with the values there). See the [Oracle array-bind guide](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/guides/oracle-array-bind.md). (#90)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     inherit it, so a release never drifts between packages. (#118)
   -->
   <PropertyGroup>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <VersionSuffix>beta.1</VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
Release-prep for **0.7.0-beta.1** — the version-bump + CHANGELOG finalization that must land on `main` **before** the `v0.7.0-beta.1` tag is pushed. No source or emitted-SQL change.

## Why 0.7.0 (minor), not 0.6.0-beta.2

`v0.6.0-beta.1` shipped; this batch (38 commits) adds `SqlArtisan.ArrayBind` + `Sql.BindNull`, `BindArray`, `Unnest`, analyzer rules `SQLA0003`–`0006`, and several **Breaking:** changes (analyzer ID renumbering, `ValuesTable`→`Values`, removed constructors, compile-time rejection of incomplete statements). Per `docs/versioning.md`, pre-1.0 (0.x) allows breaking changes in any release, and the pre-1.0 convention signals them with a **minor** bump. Bumping `0.6.0` → `0.7.0` communicates "new cycle, expect changes" more honestly than another `0.6.0` beta, and matches the project's own lineage (`0.5.0-beta.2` → `0.6.0-beta.1` bumped the minor for the prior substantive cycle).

## Changes

- `Directory.Build.props` — `VersionPrefix` `0.6.0` → `0.7.0` (`VersionSuffix` stays `beta.1`). Resolved `PackageVersion` = `0.7.0-beta.1` (verified via `dotnet msbuild -getProperty:PackageVersion`), distinct from the published `0.6.0-beta.1`.
- `CHANGELOG.md` — moved `[Unreleased]` content under `## [0.7.0-beta.1] - 2026-07-24`, leaving `[Unreleased]` empty.

## The version bump is load-bearing

`release.yml` takes the package version from `Directory.Build.props`, **not** the tag ("keep the tag in sync with VersionPrefix/VersionSuffix"). Tagging without this bump would re-publish `0.6.0-beta.1` and collide with the existing nuget.org package. This PR is the prerequisite; the `v0.7.0-beta.1` tag push (which triggers `release.yml` → verify → integration matrix → pack & push the 4 packages) is a separate, deliberate step after this merges.

## Test plan

- [x] `dotnet build src/SqlArtisan/SqlArtisan.csproj -c Release` — 0 errors, 0 code warnings
- [x] `dotnet test tests/SqlArtisan.Tests` — 816/816
- [x] `dotnet test tests/SqlArtisan.Analyzers.Tests` — 486/486
- [x] `dotnet format SqlArtisan.sln --verify-no-changes` — clean
- [x] Resolved `PackageVersion` = `0.7.0-beta.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6BeBo8jDCm2UvfziVYT4c)_