### PR TITLE
docs: Tune review skills for Claude Opus 5 behavior

### DIFF
--- a/.claude/agents/sa-review-orchestrator.md
+++ b/.claude/agents/sa-review-orchestrator.md
@@ -52,7 +52,7 @@ You are the orchestrator for SqlArtisan code review. Your role is to:
    touch core logic.
 
 5. **Never execute the review yourself** — you only classify and route.
-   Sonnet reviewers do the actual review execution.
+   The execution-stage reviewer agents do the actual review execution.
 
 ## Constraints
 

--- a/.claude/agents/sa-reviewer.md
+++ b/.claude/agents/sa-reviewer.md
@@ -43,7 +43,7 @@ not from how the change describes itself.
 
 ## Adversarial-verification missions
 
-The review skills end with a mandatory adversarial pass, and you are its
+The review skills end with an adversarial pass (not skippable), and you are its
 executor — a caller may spawn you with a refutation mission ("try to refute
 these claims/findings") instead of a full review. On such a mission:
 

--- a/.claude/skills/sa-code-review-deep/SKILL.md
+++ b/.claude/skills/sa-code-review-deep/SKILL.md
@@ -37,7 +37,7 @@ requirement.
 
 ## Adversarial pass (inherited)
 
-The mandatory adversarial verification pass (`sa-code-review` §9) is
+The adversarial verification pass (`sa-code-review` §9, not skippable) is
 inherited and runs **once**, after this improvement pass, covering both
 reports. Suggestions themselves are opinions, not refutation targets — but
 any factual claim inside one (e.g. "API X already covers this case") gets

--- a/.claude/skills/sa-code-review/SKILL.md
+++ b/.claude/skills/sa-code-review/SKILL.md
@@ -180,6 +180,14 @@ behavior — this is the mechanics of *where* to look; §8 sets the bar for
 
 ## 8. What counts as a defect
 
+Find candidates without limiting yourself upfront — list everything that
+looks off first, then classify each one against the rule below. Filtering by
+"is this reportable" belongs at classification time, not at detection time —
+narrowing the search itself under-reports real defects. Only the defect
+classification below reaches the report; a candidate that turns out to be a
+non-defect "better way to write this" suggestion is discarded here, not
+reported (it belongs to `sa-code-review-deep` instead, on a separate run).
+
 Everything reported here must be **wrong** — not merely improvable. A
 "this would read better as..." suggestion with no rule/ADR/precedent to cite
 belongs to `sa-code-review-deep`, not here; this skill never reports one, not
@@ -226,17 +234,20 @@ contributor) — plus `CLAUDE.md`, `docs/adr/**`, `.claude/skills/**`,
 - Any "better way to write this" suggestion with no rule/ADR/precedent to
   cite, for code or docs — run `sa-code-review-deep` for that pass instead.
 
-## 9. Adversarial verification (mandatory final pass)
+## 9. Adversarial verification (final pass)
 
 A confirming review checks that things look right; only a refuting pass
 reliably catches the plausible overclaim (#267/#319: a neutral docs pass
 accepted "every analyzer entry is executed against a live engine" — the
 adversarial pass read `MatrixSweepCatalog.cs` and found the two excluded
-entries). **This pass is not optional.**
+entries). Run this pass — an independent-context refutation catches
+overclaims your own drafting pass cannot see past.
 
-After the findings are drafted, spawn an independent subagent
-(`sa-reviewer`) with an explicitly adversarial mission — "try to refute
-this", never "check this is right":
+Spawn **one** independent subagent (`sa-reviewer`) with an explicitly
+adversarial mission — "try to refute this", never "check this is right".
+One subagent covering all findings is the right shape here; do not spawn
+several to split the work or to re-verify each other — this is refutation of
+the draft, not a parallelizable search:
 
 - **Refute both directions** — the deliverable's own claims (docs, XML docs,
   CHANGELOG, commit-message wording) *and* your draft findings.
@@ -271,6 +282,15 @@ with no notification, `TaskStop` on the agent's ID doubles as a status probe:
 an error (e.g. "no task found") confirms it already ended without notifying,
 and is the cue to run the fallback pass yourself rather than continue waiting.
 
+**Do not add more self-verification than this.** The single independent-context
+pass above is the complete verification step for this skill. If you are aware
+you are running as a model with strong built-in self-checking (e.g. Claude
+Opus 5 or later), do not additionally re-verify your own findings before or
+after spawning the subagent, and do not spawn extra subagents "just to be
+sure" — that duplicates work the model already does internally and burns
+tokens without improving the report. If you cannot tell which model you are,
+run exactly the one pass described above; that is correct for every model.
+
 ## Report
 
 Lead with the verdict (mergeable or not) and a short list of recommended
@@ -283,3 +303,7 @@ author / analyzer). Include the adversarial pass's coverage: which claims
 were challenged, what survived, and the DEFECT / OVERREACH / INCONSISTENCY
 classification of what fell. This skill never reports non-defect improvement
 suggestions — re-run as `sa-code-review-deep` for those.
+
+Match the report's length to what the findings need: cover every finding at
+the detail level above, but do not pad with filler recap sections, restated
+summaries, or boilerplate closing paragraphs.

--- a/.claude/skills/sa-code-review/SKILL.md
+++ b/.claude/skills/sa-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sa-code-review
-description: Review a SqlArtisan change, PR, or diff for correctness, ADR conformance, convention consistency, and doc alignment. Use when the user asks to review changes/a PR/a diff in this repo, or to check a feature before pushing. Adds SqlArtisan-specific checks (ADRs, dialect grammar, allocation budget) on top of a generic code review, and verifies behavior empirically by building and running a throwaway harness rather than reasoning from memory. Reports defects only — never idiom/style/"better way to write this" suggestions; use `sa-code-review-deep` for those. Ends with a mandatory adversarial verification pass — an independent subagent attempts to refute the deliverable's claims and the draft findings against primary sources. Accepts an optional scope argument (default: the diff's hunks only; `files`; `paths:<glob>`).
+description: Review a SqlArtisan change, PR, or diff for correctness, ADR conformance, convention consistency, and doc alignment. Use when the user asks to review changes/a PR/a diff in this repo, or to check a feature before pushing. Adds SqlArtisan-specific checks (ADRs, dialect grammar, allocation budget) on top of a generic code review, and verifies behavior empirically by building and running a throwaway harness rather than reasoning from memory. Reports defects only — never idiom/style/"better way to write this" suggestions; use `sa-code-review-deep` for those. Ends with an adversarial verification pass (one independent subagent, not skippable) that attempts to refute the deliverable's claims and the draft findings against primary sources. Accepts an optional scope argument (default: the diff's hunks only; `files`; `paths:<glob>`).
 ---
 
 # Review SqlArtisan changes
@@ -184,9 +184,11 @@ Find candidates without limiting yourself upfront — list everything that
 looks off first, then classify each one against the rule below. Filtering by
 "is this reportable" belongs at classification time, not at detection time —
 narrowing the search itself under-reports real defects. Only the defect
-classification below reaches the report; a candidate that turns out to be a
-non-defect "better way to write this" suggestion is discarded here, not
-reported (it belongs to `sa-code-review-deep` instead, on a separate run).
+classification below reaches this skill's report; a candidate that turns out
+to be a non-defect "better way to write this" suggestion is not reported
+here — it belongs to `sa-code-review-deep`'s improvement pass instead. If you
+are running as `sa-code-review-deep`, that pass is part of the same run: hand
+the candidate to it, don't discard it.
 
 Everything reported here must be **wrong** — not merely improvable. A
 "this would read better as..." suggestion with no rule/ADR/precedent to cite
@@ -283,7 +285,8 @@ an error (e.g. "no task found") confirms it already ended without notifying,
 and is the cue to run the fallback pass yourself rather than continue waiting.
 
 **Do not add more self-verification than this.** The single independent-context
-pass above is the complete verification step for this skill. If you are aware
+pass above is the complete *findings*-verification step (separate from §5's
+empirical harness verification, which still applies). If you are aware
 you are running as a model with strong built-in self-checking (e.g. Claude
 Opus 5 or later), do not additionally re-verify your own findings before or
 after spawning the subagent, and do not spawn extra subagents "just to be

--- a/.claude/skills/sa-docs-review/SKILL.md
+++ b/.claude/skills/sa-docs-review/SKILL.md
@@ -120,16 +120,19 @@ Score the docs against these. The scripts cover 2–5 and parts of 6/10.
   for wording/ordering/trims that are judgment calls, propose options and
   confirm before applying.
 
-## Adversarial verification (mandatory final pass)
+## Adversarial verification (final pass)
 
 The dimensions above confirm; this pass refutes. A neutral pass accepted
 "every analyzer entry is executed against a live engine" (#267/#319) — the
 adversarial pass read `MatrixSweepCatalog.cs` and found the two excluded
-entries. **This pass is not optional.**
+entries. Run this pass — an independent-context refutation catches
+overclaims your own drafting pass cannot see past.
 
-After the findings are drafted, spawn an independent subagent
-(`sa-reviewer`) with an explicitly adversarial mission — "try to refute
-this", never "check this is right". Prime refutation targets in docs:
+Spawn **one** independent subagent (`sa-reviewer`) with an explicitly
+adversarial mission — "try to refute this", never "check this is right".
+One subagent covering all findings is the right shape here; do not spawn
+several to split the work or to re-verify each other. Prime refutation
+targets in docs:
 
 - **Quantifiers** — every / all / always / never / only. One real exception
   turns the sentence into an OVERREACH.
@@ -167,6 +170,14 @@ with no notification, `TaskStop` on the agent's ID doubles as a status probe:
 an error (e.g. "no task found") confirms it already ended without notifying,
 and is the cue to run the fallback pass yourself rather than continue waiting.
 
+**Do not add more self-verification than this.** The single independent-context
+pass above is the complete verification step for this skill. If you are aware
+you are running as a model with strong built-in self-checking (e.g. Claude
+Opus 5 or later), do not additionally re-verify your own findings before or
+after spawning the subagent, and do not spawn extra subagents "just to be
+sure". If you cannot tell which model you are, run exactly the one pass
+described above; that is correct for every model.
+
 ## Output
 
 Summarise per dimension (pass / findings), list concrete fixes with file:line,
@@ -174,3 +185,7 @@ and state what was verified empirically (links resolve, N/N examples match,
 coverage clean). State which claims the adversarial pass challenged and what
 survived, with the DEFECT / OVERREACH / INCONSISTENCY classification of what
 fell. Re-run the relevant script after fixes to confirm green.
+
+Match this report's length to what the findings need: cover every finding at
+the detail level above, but do not pad with filler recap sections, restated
+summaries, or boilerplate closing paragraphs.

--- a/.claude/skills/sa-docs-review/SKILL.md
+++ b/.claude/skills/sa-docs-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sa-docs-review
-description: Review SqlArtisan's user-facing documentation (README, docs/, llms.txt, CHANGELOG) for structure, completeness, accuracy, consistency, links, persuasiveness, and conciseness. Use when asked to review/audit the docs, check the README, validate a docs change before pushing, or confirm docs match the code. Complements sa-code-review (code) with doc-specific checks and bundles scripts that verify links, API coverage, terminology, and emitted SQL empirically. Ends with a mandatory adversarial verification pass — an independent subagent attempts to refute the docs' factual claims against primary sources.
+description: Review SqlArtisan's user-facing documentation (README, docs/, llms.txt, CHANGELOG) for structure, completeness, accuracy, consistency, links, persuasiveness, and conciseness. Use when asked to review/audit the docs, check the README, validate a docs change before pushing, or confirm docs match the code. Complements sa-code-review (code) with doc-specific checks and bundles scripts that verify links, API coverage, terminology, and emitted SQL empirically. Ends with an adversarial verification pass (one independent subagent, not skippable) that attempts to refute the docs' factual claims against primary sources.
 ---
 
 # Review SqlArtisan documentation
@@ -171,8 +171,9 @@ an error (e.g. "no task found") confirms it already ended without notifying,
 and is the cue to run the fallback pass yourself rather than continue waiting.
 
 **Do not add more self-verification than this.** The single independent-context
-pass above is the complete verification step for this skill. If you are aware
-you are running as a model with strong built-in self-checking (e.g. Claude
+pass above is the complete *findings*-verification step (separate from the
+bundled scripts and empirical SQL checks above, which still apply). If you
+are aware you are running as a model with strong built-in self-checking (e.g. Claude
 Opus 5 or later), do not additionally re-verify your own findings before or
 after spawning the subagent, and do not spawn extra subagents "just to be
 sure". If you cannot tell which model you are, run exactly the one pass

--- a/.claude/workflows/sa-multi-model-code-review.js
+++ b/.claude/workflows/sa-multi-model-code-review.js
@@ -67,7 +67,7 @@ ${FULL_CODEBASE_GLOBS.map((p) => `- ${p}`).join('\n')}
 Exclude bin/ and obj/ build output. Return the full list as changedFiles.`
   : `Report scope="diff" for the current branch.
 
-Per the sa-review-changes skill: local main is often stale, so a raw
+Per the sa-code-review skill: local main is often stale, so a raw
 "git diff main...HEAD" (or a merge-base against local main) can pull in
 unrelated already-merged work — merge-base succeeds even when the local ref
 is stale, so it will not warn you. Always anchor against the remote-tracking
@@ -125,7 +125,7 @@ None — no files in scope.
 
 // ---------------------------------------------------------------------------
 // PHASE 2: Gates — run once, up front, so reviewers don't re-derive
-// failures the toolchain already catches (sa-review-changes skill, step 2).
+// failures the toolchain already catches (sa-code-review skill, step 2).
 // ---------------------------------------------------------------------------
 phase('Gates')
 
@@ -141,7 +141,7 @@ const GATES_SCHEMA = {
 }
 
 const gates = await agent(
-  `Run the SqlArtisan review gates (sa-review-changes skill, step 2) and report
+  `Run the SqlArtisan review gates (sa-code-review skill, step 2) and report
 pass/fail for each. Do not fix anything — detection only.
 
 dotnet build src/SqlArtisan/SqlArtisan.csproj -c Release
@@ -159,7 +159,7 @@ counts against the bar. Summarize any failure in one or two lines.`,
 
 log(`Gates: build=${gates.buildPassed} test=${gates.testsPassed} format=${gates.formatClean}`)
 
-// A failing gate is itself a MUST FIX (sa-review-changes skill: "a finding
+// A failing gate is itself a MUST FIX (sa-code-review skill: "a finding
 // the tools already catch is wasted review budget"). Short-circuit before
 // the expensive Orchestrate/Execute phases instead of spending them on code
 // that may not even compile.
@@ -178,7 +178,7 @@ if (!gates.buildPassed || !gates.testsPassed || !gates.formatClean) {
 Not mergeable
 
 ## Summary
-A review gate failed before the deep review began. Per the sa-review-changes
+A review gate failed before the deep review began. Per the sa-code-review
 skill, a tool-catchable failure is a MUST FIX on its own, and reviewing
 further code before it's fixed wastes review budget — the deep-review phases
 were skipped.


### PR DESCRIPTION
## Summary
- Anthropic's Opus 5 prompting guide flags several patterns in `sa-code-review`/`sa-docs-review` as counterproductive on that model: "report only real defects" framing can suppress detection itself (not just the report), "MUST"/"mandatory" phrasing over-triggers verification, and Opus 5 already self-verifies, so a second review pass on top of the adversarial subagent adds cost without value.
- `sa-code-review/SKILL.md` §8 now separates unrestricted candidate-finding from defect classification, so filtering happens only at output time; §9's tone is softened, subagent delegation is capped at one per pass, and a narrow model-conditional note tells Opus 5-aware sessions to skip redundant self-verification while every other model keeps the current full pass. Report length is bounded.
- Same four changes applied to `sa-docs-review/SKILL.md`.
- Fixed `sa-review-orchestrator.md`'s hardcoded "Sonnet reviewers" reference, which goes stale whenever the execution-stage model changes.

## Test plan
- [x] Docs-only change — no build/test impact
- [ ] Run `sa-code-review` and `sa-docs-review` on a future PR to confirm the tuned wording still produces the expected defect-only / adversarial-pass behavior

---
_Generated by [Claude Code](https://claude.ai/code/session_017sqw8STzYpDAhQRmy4oZB4)_