### PR TITLE
test: Pin the analyzer's DbColumnMetadata strings to the real attribute

### DIFF
--- a/src/SqlArtisan.Analyzers/SchemaMetadata.cs
+++ b/src/SqlArtisan.Analyzers/SchemaMetadata.cs
@@ -15,7 +15,7 @@ namespace SqlArtisan.Analyzers;
 /// </remarks>
 internal static class SchemaMetadata
 {
-    private const string AttributeName = "SqlArtisan.DbColumnMetadataAttribute";
+    public const string AttributeName = "SqlArtisan.DbColumnMetadataAttribute";
 
     public const string NullableArgument = "Nullable";
 

--- a/tests/SqlArtisan.Analyzers.Tests/SchemaMetadataParityTests.cs
+++ b/tests/SqlArtisan.Analyzers.Tests/SchemaMetadataParityTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace SqlArtisan.Analyzers.Tests;
+
+/// <summary>
+/// Ties <see cref="SchemaMetadata"/>'s strings to the real
+/// <see cref="DbColumnMetadataAttribute"/>, which the analyzer matches by name
+/// rather than by a type reference (ADR 0009).
+/// </summary>
+/// <remarks>
+/// Other suites go red on a symptom — a diagnostic that stopped firing, or a
+/// member with no matrix exclusion — and the obvious fix for each leaves the
+/// coupling broken. Past that fix, an unread fact reaches this gate alone.
+/// </remarks>
+public class SchemaMetadataParityTests
+{
+    private static readonly Type AttributeType = typeof(DbColumnMetadataAttribute);
+
+    // Collected by suffix, so a new *Argument constant joins the gate on its own.
+    private static readonly IReadOnlyDictionary<string, string> ArgumentConstants =
+        typeof(SchemaMetadata)
+            .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static
+                | BindingFlags.DeclaredOnly)
+            .Where(f => f.IsLiteral
+                && f.FieldType == typeof(string)
+                && f.Name.EndsWith("Argument", StringComparison.Ordinal))
+            .ToDictionary(f => f.Name, f => (string)f.GetRawConstantValue()!, StringComparer.Ordinal);
+
+    private static readonly IReadOnlyList<string> SettableProperties =
+        [.. AttributeType
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(p => p.CanWrite)
+            .Select(p => p.Name)];
+
+    [Fact]
+    public void AttributeName_MatchesTheRealAttributesFullName() =>
+        Assert.Equal(SchemaMetadata.AttributeName, AttributeType.FullName);
+
+    [Fact]
+    public void EveryArgumentConstant_NamesASettablePropertyOnTheAttribute()
+    {
+        List<string> orphaned =
+        [
+            .. ArgumentConstants
+                .Where(c => !SettableProperties.Contains(c.Value, StringComparer.Ordinal))
+                .Select(c => $"SchemaMetadata.{c.Key} = \"{c.Value}\""),
+        ];
+
+        Assert.True(
+            orphaned.Count == 0,
+            $"{orphaned.Count} constant(s) in SchemaMetadata.cs name no property on "
+                + $"{AttributeType.Name}, so the rules reading them can never match:\n  "
+                + string.Join("\n  ", orphaned));
+    }
+
+    [Fact]
+    public void EverySettableProperty_HasAnArgumentConstant()
+    {
+        List<string> unread =
+        [
+            .. SettableProperties
+                .Where(p => !ArgumentConstants.Values.Contains(p, StringComparer.Ordinal)),
+        ];
+
+        Assert.True(
+            unread.Count == 0,
+            $"{unread.Count} propert(y|ies) on {AttributeType.Name} have no constant in "
+                + "SchemaMetadata.cs, and the rules read facts only through those "
+                + $"constants:\n  {string.Join("\n  ", unread)}");
+    }
+}


### PR DESCRIPTION
## Summary

The analyzer takes no build reference to the core (ADR 0009), so
`SchemaMetadata` matches `DbColumnMetadataAttribute` by fully qualified name
string, never a type reference. Nothing tied those strings to the real type.

**Drift does not ship silently today** — on every shape probed (renaming a
property, adding one, changing the attribute's name, moving its namespace)
either the schema rules' own analyzer suites or `DialectMatrixCoverageTests`
goes red. But they go red on a *symptom*, and the obvious fix for each leaves
the coupling broken: add a fact, then add the matrix exclusion that unblocks
CI — the #362 shape — and this gate is the only one still red.

- Added `SchemaMetadataParityTests.cs` with three reflection-based assertions,
  both directions:
  - the attribute's full name matches `SchemaMetadata.AttributeName`
  - every `*Argument` constant names a settable property on the attribute
  - every settable property on the attribute has a naming constant
- The reverse direction is the one that bites #362 — a fact the core declares
  that no constant names can never reach a rule.
- Widened `SchemaMetadata.AttributeName` from `private const` to `public
  const`, matching its three sibling constants (the class itself stays
  `internal`, so effective accessibility outside the assembly is unchanged;
  `InternalsVisibleTo` reaches `internal` but not `private`).

## What this gate does not cover

Recorded so the next reader does not over-trust it:

- A fact added as a **constructor parameter** is invisible here — and
  `SchemaMetadata.Fact` reads only named arguments, so such a fact could never
  be read at all.
- A fact declared as a **public field** is outside the gate, which inspects
  properties only — yet `Fact` does read it, since Roslyn's `NamedArguments`
  covers fields.
- A **surplus constant** duplicating an already-covered property passes both
  directional tests. (A constant whose value collides with another property
  while leaving one uncovered *is* caught, by the reverse direction.)
- The gate checks that a constant exists, not that a rule reads it.

## Verification

- Mutation-tested against copies of the working tree; the repo was verified
  clean before and after. Renaming a core property fails both directional
  tests, adding a property fails the reverse one, and drifting `AttributeName`
  fails the full-name test — each naming `SchemaMetadata.cs` and the offending
  member. The gaps listed above were each confirmed by their own mutation.
- `dotnet build SqlArtisan.sln -c Release` — 0 errors
- `dotnet test tests/SqlArtisan.Analyzers.Tests` — 584 passing (+3)
- `dotnet test tests/SqlArtisan.Tests` — 818 passing
- `dotnet test tests/SqlArtisan.TableClassGen.Tests` — 89 passing
- `dotnet format SqlArtisan.sln --verify-no-changes` — exit 0

Closes #370
