### PR TITLE
refactor: Put SQLA0006 back in ID order, and write down what governs the numbering

### DIFF
--- a/src/SqlArtisan.Analyzers/DiagnosticDescriptors.cs
+++ b/src/SqlArtisan.Analyzers/DiagnosticDescriptors.cs
@@ -9,6 +9,8 @@ namespace SqlArtisan.Analyzers;
 // key), and push everything else to docs/analyzer.md via the help link.
 internal static class DiagnosticDescriptors
 {
+    // Declared in ID order, which is also family order: the dialect rules were
+    // numbered 0001-0006 and the schema rules 0007 up, so one ordering carries both.
     private const string DialectCategory = "SqlArtisan.Dialect";
 
     // Separate from the dialect family (#266): a bulk-severity setting aimed at
@@ -71,6 +73,15 @@ internal static class DiagnosticDescriptors
         id: "SQLA0005",
         title: "Correlated UPDATE or DELETE target is not aliased",
         messageFormat: "The target of a correlated UPDATE or DELETE must be aliased",
+        category: DialectCategory,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        helpLinkUri: HelpLinkUri);
+
+    public static readonly DiagnosticDescriptor IdentifierTooLong = new(
+        id: "SQLA0006",
+        title: "SQL identifier exceeds the dialect's length limit",
+        messageFormat: "Identifier '{0}' exceeds {1}'s identifier limit of {2} {3}",
         category: DialectCategory,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -142,15 +153,6 @@ internal static class DiagnosticDescriptors
         title: "Column compared to a value of another type category",
         messageFormat: "'{0}' is {1}, but this compares it to {2}. Cast one side to say which you mean.",
         category: SchemaCategory,
-        defaultSeverity: DiagnosticSeverity.Warning,
-        isEnabledByDefault: true,
-        helpLinkUri: HelpLinkUri);
-
-    public static readonly DiagnosticDescriptor IdentifierTooLong = new(
-        id: "SQLA0006",
-        title: "SQL identifier exceeds the dialect's length limit",
-        messageFormat: "Identifier '{0}' exceeds {1}'s identifier limit of {2} {3}",
-        category: DialectCategory,
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         helpLinkUri: HelpLinkUri);

--- a/src/SqlArtisan.Analyzers/DiagnosticDescriptors.cs
+++ b/src/SqlArtisan.Analyzers/DiagnosticDescriptors.cs
@@ -10,7 +10,16 @@ namespace SqlArtisan.Analyzers;
 internal static class DiagnosticDescriptors
 {
     // Declared in ID order, which is also family order: the dialect rules were
-    // numbered 0001-0006 and the schema rules 0007 up, so one ordering carries both.
+    // numbered 0001-0006 and the schema rules 0007 up. Within the schema family the
+    // number tracks which metadata fact the rule reads, in the order the facts
+    // landed, so a new one takes the next ID. Renumbering across the families has
+    // happened once (0003 became 0006, #326/#349) — move the declaration with it.
+    //
+    // The dialect range holds no spare number, and renumbering after a release would
+    // break the per-ID suppressions users have written. So a seventh dialect rule
+    // takes the next free ID and ends the family-order half of the rule; keep ID
+    // order and let DiagnosticOrderingTests' category assertion be the place that
+    // says so.
     private const string DialectCategory = "SqlArtisan.Dialect";
 
     // Separate from the dialect family (#266): a bulk-severity setting aimed at

--- a/src/SqlArtisan.Analyzers/DialectUsageAnalyzer.cs
+++ b/src/SqlArtisan.Analyzers/DialectUsageAnalyzer.cs
@@ -35,28 +35,31 @@ public sealed class DialectUsageAnalyzer : DiagnosticAnalyzer
         DiagnosticDescriptors.VersionBoundConstruct,
         DiagnosticDescriptors.ContextRestrictedConstruct,
         DiagnosticDescriptors.CorrelatedDmlTargetNotAliased,
+        DiagnosticDescriptors.IdentifierTooLong,
         DiagnosticDescriptors.ConstantNullPredicate,
         DiagnosticDescriptors.NotInNullableSubquery,
         DiagnosticDescriptors.InsertMissingRequiredColumn,
         DiagnosticDescriptors.CountNullableColumn,
         DiagnosticDescriptors.UnusableIndexPredicate,
-        DiagnosticDescriptors.TypeCategoryMismatch,
-        DiagnosticDescriptors.IdentifierTooLong);
+        DiagnosticDescriptors.TypeCategoryMismatch);
 
     public override void Initialize(AnalysisContext context)
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
 
+        // The generic walkers first — they serve SQLA0002/0003 together and key on
+        // the operation kind, not a rule — then one dispatcher per rule in ID order,
+        // then the compilation action, which is not an operation action at all.
         context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
         context.RegisterOperationAction(AnalyzePropertyReference, OperationKind.PropertyReference);
         context.RegisterOperationAction(AnalyzeFieldReference, OperationKind.FieldReference);
         context.RegisterOperationAction(AnalyzeBinaryOperator, OperationKind.Binary);
         context.RegisterOperationAction(AnalyzeCompoundAssignment, OperationKind.CompoundAssignment);
-        context.RegisterOperationAction(AnalyzeIdentifierLength, OperationKind.Invocation);
-        context.RegisterOperationAction(AnalyzeIdentifierLength, OperationKind.ObjectCreation);
         context.RegisterOperationAction(AnalyzeContextRules, OperationKind.Invocation);
         context.RegisterOperationAction(AnalyzeCorrelatedDml, OperationKind.Invocation);
+        context.RegisterOperationAction(AnalyzeIdentifierLength, OperationKind.Invocation);
+        context.RegisterOperationAction(AnalyzeIdentifierLength, OperationKind.ObjectCreation);
         context.RegisterOperationAction(AnalyzeSchemaNullability, OperationKind.PropertyReference);
         context.RegisterOperationAction(AnalyzeNotInSubquery, OperationKind.Invocation);
         context.RegisterOperationAction(AnalyzeInsertColumns, OperationKind.Invocation);

--- a/tests/SqlArtisan.Analyzers.Tests/DiagnosticOrderingTests.cs
+++ b/tests/SqlArtisan.Analyzers.Tests/DiagnosticOrderingTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace SqlArtisan.Analyzers.Tests;
+
+/// <summary>
+/// SQLA0006 spent four releases sitting after the schema rules because nothing
+/// checked (#379). Of the three lists that carry this order, only this one is
+/// reachable by reflection, so it is the one that can be gated.
+/// </summary>
+public class DiagnosticOrderingTests
+{
+    [Fact]
+    public void SupportedDiagnostics_AreDeclaredInIdOrder()
+    {
+        string[] declared = [.. new DialectUsageAnalyzer().SupportedDiagnostics.Select(d => d.Id)];
+
+        Assert.Equal([.. declared.OrderBy(id => id, StringComparer.Ordinal)], declared);
+    }
+
+    // ID order is family order only while the numbering holds: the dialect rules
+    // were given 0001-0006 and the schema rules 0007 up.
+    [Fact]
+    public void EveryDiagnostic_SitsInTheCategoryItsNumberImplies()
+    {
+        foreach (DiagnosticDescriptor descriptor in new DialectUsageAnalyzer().SupportedDiagnostics)
+        {
+            string expected = int.Parse(descriptor.Id.Substring("SQLA".Length)) <= 6
+                ? "SqlArtisan.Dialect"
+                : "SqlArtisan.Schema";
+
+            Assert.Equal(expected, descriptor.Category);
+        }
+    }
+}

--- a/tests/SqlArtisan.Analyzers.Tests/DiagnosticOrderingTests.cs
+++ b/tests/SqlArtisan.Analyzers.Tests/DiagnosticOrderingTests.cs
@@ -19,8 +19,10 @@ public class DiagnosticOrderingTests
         Assert.Equal([.. declared.OrderBy(id => id, StringComparer.Ordinal)], declared);
     }
 
-    // ID order is family order only while the numbering holds: the dialect rules
-    // were given 0001-0006 and the schema rules 0007 up.
+    // ID order doubles as family order only while the dialect rules stop at 0006,
+    // and that range is full. A seventh takes the next free ID rather than a
+    // renumbering that would break released suppressions, and this is where that
+    // shows up — expect to delete this test rather than satisfy it.
     [Fact]
     public void EveryDiagnostic_SitsInTheCategoryItsNumberImplies()
     {
@@ -30,7 +32,11 @@ public class DiagnosticOrderingTests
                 ? "SqlArtisan.Dialect"
                 : "SqlArtisan.Schema";
 
-            Assert.Equal(expected, descriptor.Category);
+            Assert.True(
+                expected == descriptor.Category,
+                $"{descriptor.Id} is {descriptor.Category}, which its number reads as {expected}. "
+                    + "A dialect rule past 0006 ends the family-order half of the numbering; "
+                    + "drop this test rather than renumber a released ID.");
         }
     }
 }


### PR DESCRIPTION
## Summary

The IDs were numbered so that **ID order is also family order** — the dialect
rules took `SQLA0001`–`SQLA0006`, the schema rules `SQLA0007` up. Three surfaces
honoured that; two did not, and the single reason was `SQLA0006` sitting after
the whole schema block.

`git log -S` explains why, and it is not a slip anyone made twice:
`IdentifierTooLong` was **born as `SQLA0003`** (`5b159bd`, #326) and renumbered to
`SQLA0006` when the families were split. Its declaration was left where it
started. #365 then inserted `SQLA0007`–`SQLA0011` *ahead* of it rather than
moving it, and neither file said what the order was, so each addition had to
guess.

| Surface | Before | After |
|---|---|---|
| `AnalyzerReleases.Unshipped.md` | ID order | unchanged |
| `docs/analyzer.md` rules table | ID order | unchanged |
| `CLAUDE.md` diagnostic list | ID order | unchanged |
| `DiagnosticDescriptors.cs` | `0006` after `0012` | ID order |
| `SupportedDiagnostics` | `0006` last | ID order |
| `Initialize` | `0006` before `0004` | per-rule dispatchers `0004` → `0012` |

Pure relocation — no behaviour changes.

`Initialize` cannot be pure ID order and now says so: the five generic walkers
serve `SQLA0002`/`SQLA0003` together and key on the operation kind rather than a
rule, and `ValidateConfiguration` is a compilation action. Its rule is therefore
*generic walkers → one dispatcher per rule in ID order → the compilation
action.*

## What governs a number inside a family

This was the part nothing recorded, and it was only visible by reading all six
schema descriptors: **the schema family runs in the order the metadata facts it
reads landed**, so a new rule there takes the next ID.

## Where the scheme runs out

Writing that down surfaced a latent problem worth flagging rather than burying.
There are **no spare numbers** — `0001`–`0012` are contiguous, and the dialect
range `0001`–`0006` is full. So a *seventh dialect rule* cannot be numbered
inside its family, and renumbering after a release would break the per-ID
suppressions users have written (`#pragma warning disable SQLA00xx`,
`dotnet_diagnostic.SQLA00xx.severity`). It takes the next free ID and ends the
family-order half of the scheme.

That means the new category test is **designed to fail one day**, so its message
says what to do instead of leaving the next contributor to reverse-engineer it:

```
SQLA0011 is SqlArtisan.Dialect, which its number reads as SqlArtisan.Schema.
A dialect rule past 0006 ends the family-order half of the numbering;
drop this test rather than renumber a released ID.
```

Verified by mutating a category and reading the real output — the worst
available response to that failure is renumbering a released ID, so the message
names it.

## Gate

Of the three lists carrying this order, only `SupportedDiagnostics` is reachable
by reflection, so it is the one a test can hold. `DiagnosticDescriptors`' field
order is not guaranteed by the CLR, and `Initialize`'s registration order is not
observable at all — those stay on the comments.

- `SupportedDiagnostics_AreDeclaredInIdOrder` — recreating the original drift
  fails it (mutation-verified)
- `EveryDiagnostic_SitsInTheCategoryItsNumberImplies` — pins the premise the
  first test rests on

## Verification

- `dotnet build SqlArtisan.sln -c Release` — 0 errors, 0 warnings
- `dotnet test tests/SqlArtisan.Tests` — 818 passing
- `dotnet test tests/SqlArtisan.Analyzers.Tests` — 614 passing (+2)
- `dotnet test tests/SqlArtisan.TableClassGen.Tests` — 132 passing
- `dotnet format SqlArtisan.sln --verify-no-changes` — exit 0

No integration run: nothing here reaches a SQL-emitting path.

Closes #379


---
_Generated by [Claude Code](https://claude.ai/code/session_01CBXFM2WmG8tRiY9vWeqdn4)_