### PR TITLE
docs: Give the benchmark project the README the root one promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,20 +79,20 @@ SqlArtisan minimizes heap allocations — string buffers are recycled from a poo
 | Method | Category | Mean | Allocated |
 | :--- | :--- | ---: | ---: |
 | StringBuilder_DapperDynamicParams | Baseline¹ | 630.9 ns | 1.92 KB |
-| **SqlArtisan_SpecificParams** | Builder | **1,451.6 ns** | **2.16 KB** |
-| Sqlify_SpecificParams | Builder | 1,871.0 ns | 3.13 KB |
-| **SqlArtisan_DapperDynamicParams** | Builder | 1,892.5 ns | 2.84 KB |
-| InterpolatedSql_SpecificParams | Builder | 2,749.7 ns | 5.11 KB |
-| DapperSqlBuilder_DapperDynamicParams | Builder | 2,762.2 ns | 5.70 KB |
-| Linq2db_TypedParams | Builder | 44,173.3 ns | 19.13 KB |
-| SqlKata_SpecificParams | Builder | 50,577.6 ns | 40.54 KB |
+| **SqlArtisan_SpecificParams** | Builders | **1,451.6 ns** | **2.16 KB** |
+| Sqlify_SpecificParams | Builders | 1,871.0 ns | 3.13 KB |
+| **SqlArtisan_DapperDynamicParams** | Builders | 1,892.5 ns | 2.84 KB |
+| InterpolatedSql_SpecificParams | Builders | 2,749.7 ns | 5.11 KB |
+| DapperSqlBuilder_DapperDynamicParams | Builders | 2,762.2 ns | 5.70 KB |
+| Linq2db_TypedParams | Builders | 44,173.3 ns | 19.13 KB |
+| SqlKata_SpecificParams | Builders | 50,577.6 ns | 40.54 KB |
 | EfCore_Reference | ORM reference² | 49,728.5 ns | 12.86 KB |
 
 The **allocation lead is firm** (lightweight builders allocate the same bytes every run); treat the timing order as directional, since run-to-run variance grows for the heavier entrants.
 
 ¹ Raw `StringBuilder` + Dapper `DynamicParameters` — the floor, with no type safety or dialect handling. ² EF Core is a full-ORM **reference** (different work, caches compiled queries), shown only for scale.
 
-*Measured on .NET 8.0.28, i5-1135G7 / 16 GB / Windows 11, PostgreSQL dialect. Query shape, library versions, and re-run instructions are in the [benchmark project](https://github.com/h-tacayama/SqlArtisan/tree/main/tests/SqlArtisan.Benchmark).*
+*Measured on .NET 8.0.28, i5-1135G7 / 16 GB / Windows 11, PostgreSQL dialect. Query shape, library versions, and re-run instructions are in the [benchmark project's README](https://github.com/h-tacayama/SqlArtisan/blob/main/tests/SqlArtisan.Benchmark/README.md).*
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -90,20 +90,20 @@ SqlArtisan minimizes heap allocations — string buffers are recycled from a poo
 | Method | Category | Mean | Allocated |
 | :--- | :--- | ---: | ---: |
 | StringBuilder_DapperDynamicParams | Baseline¹ | 630.9 ns | 1.92 KB |
-| **SqlArtisan_SpecificParams** | Builder | **1,451.6 ns** | **2.16 KB** |
-| Sqlify_SpecificParams | Builder | 1,871.0 ns | 3.13 KB |
-| **SqlArtisan_DapperDynamicParams** | Builder | 1,892.5 ns | 2.84 KB |
-| InterpolatedSql_SpecificParams | Builder | 2,749.7 ns | 5.11 KB |
-| DapperSqlBuilder_DapperDynamicParams | Builder | 2,762.2 ns | 5.70 KB |
-| Linq2db_TypedParams | Builder | 44,173.3 ns | 19.13 KB |
-| SqlKata_SpecificParams | Builder | 50,577.6 ns | 40.54 KB |
+| **SqlArtisan_SpecificParams** | Builders | **1,451.6 ns** | **2.16 KB** |
+| Sqlify_SpecificParams | Builders | 1,871.0 ns | 3.13 KB |
+| **SqlArtisan_DapperDynamicParams** | Builders | 1,892.5 ns | 2.84 KB |
+| InterpolatedSql_SpecificParams | Builders | 2,749.7 ns | 5.11 KB |
+| DapperSqlBuilder_DapperDynamicParams | Builders | 2,762.2 ns | 5.70 KB |
+| Linq2db_TypedParams | Builders | 44,173.3 ns | 19.13 KB |
+| SqlKata_SpecificParams | Builders | 50,577.6 ns | 40.54 KB |
 | EfCore_Reference | ORM reference² | 49,728.5 ns | 12.86 KB |
 
 The **allocation lead is firm** (lightweight builders allocate the same bytes every run); treat the timing order as directional, since run-to-run variance grows for the heavier entrants.
 
 ¹ Raw `StringBuilder` + Dapper `DynamicParameters` — the floor, with no type safety or dialect handling. ² EF Core is a full-ORM **reference** (different work, caches compiled queries), shown only for scale.
 
-*Measured on .NET 8.0.28, i5-1135G7 / 16 GB / Windows 11, PostgreSQL dialect. Query shape, library versions, and re-run instructions are in the [benchmark project](https://github.com/h-tacayama/SqlArtisan/tree/main/tests/SqlArtisan.Benchmark).*
+*Measured on .NET 8.0.28, i5-1135G7 / 16 GB / Windows 11, PostgreSQL dialect. Query shape, library versions, and re-run instructions are in the [benchmark project's README](https://github.com/h-tacayama/SqlArtisan/blob/main/tests/SqlArtisan.Benchmark/README.md).*
 
 ---
 

--- a/tests/SqlArtisan.Benchmark/Benchmark/BenchmarkValidation.cs
+++ b/tests/SqlArtisan.Benchmark/Benchmark/BenchmarkValidation.cs
@@ -3,12 +3,9 @@ using SqlArtisan.Benchmark.EfCoreModel;
 
 namespace SqlArtisan.Benchmark;
 
-// One-time equivalence check, run *outside* the measured loop (via `dotnet run -- validate`).
-// It prints each entrant's parameter count and SQL, and asserts every entrant that must
-// parameterize the query (the baseline and all builders) produced exactly two bind
-// parameters. SQL text is not required to be byte-identical — dialects, alias generation,
-// and EF Core's pipeline all differ — only the logical query and the parameter count must
-// match. EF Core is reported for reference only and is not asserted.
+// Runs outside the measured loop (`dotnet run -- validate`). Only the parameter count is
+// asserted — SQL text differs legitimately by dialect and alias generation, so the logical
+// query is merely printed, which is how the SqlKata drift (#382) got through.
 public static class BenchmarkValidation
 {
     public static int Run()

--- a/tests/SqlArtisan.Benchmark/README.md
+++ b/tests/SqlArtisan.Benchmark/README.md
@@ -6,19 +6,26 @@ The numbers live there and only there; this page is how you reproduce them.
 
 ## Running it
 
+From the repo root. No database is needed — every entrant generates SQL offline,
+so nothing here opens a connection.
+
 ```bash
-dotnet run -c Release -- validate                          # equivalence check, not a measurement
-dotnet run -c Release -- --filter *SqlBuilderBenchmarks*   # the cross-library comparison
-dotnet run -c Release                                      # pick a suite interactively
+P=tests/SqlArtisan.Benchmark
+dotnet run --project $P -c Release -- validate                        # not a measurement
+dotnet run --project $P -c Release -- --filter '*SqlBuilderBenchmarks*'
+dotnet run --project $P -c Release                                    # pick a suite
 ```
 
-`validate` is the one-time check that the entrants are actually comparable. It
-prints each entrant's SQL and parameter count and asserts that everyone required
-to parameterize the query produced exactly two bind parameters. SQL text is *not*
-required to be byte-identical — dialects, alias generation, and EF Core's
-pipeline all differ — only the logical query and the parameter count. Run it
-after touching any entrant; a change that quietly stops parameterizing would
-otherwise look like a win.
+Quote the filter: unquoted, the shell expands `*SqlBuilderBenchmarks*` against
+the project directory and BenchmarkDotNet is handed `SqlBuilderBenchmarks.cs`,
+which matches nothing.
+
+`validate` asserts that every entrant required to parameterize the query produced
+exactly two bind parameters, and prints each entrant's SQL so the logical query
+can be compared by eye — that half is not asserted, so an entrant that drifts
+into building a *different* query still passes. Run it after touching any
+entrant; a change that quietly stops parameterizing would otherwise look like a
+win.
 
 **Release configuration is required.** BenchmarkDotNet refuses to run a Debug
 build, and a measurement taken on a shared or virtualized host is not comparable
@@ -41,9 +48,9 @@ Select(u.Id.As("user_id"), u.Name.As("user_name"), Count(o.Id).As("order_count")
 ```
 
 An `INNER JOIN` plus a `GROUP BY` aggregate, filtered by two date parameters, on
-the PostgreSQL dialect. Each `[Benchmark]` returns the produced
-`(Sql, ParameterCount)` tuple so BenchmarkDotNet consumes both outputs and cannot
-dead-code-eliminate the work.
+the PostgreSQL dialect. Every entrant in `SqlBuilderBenchmarks` returns the
+produced `(Sql, ParameterCount)` tuple so BenchmarkDotNet consumes both outputs
+and cannot dead-code-eliminate the work.
 
 Entrants fall into three categories, and only one of them is a comparison:
 
@@ -53,28 +60,37 @@ Entrants fall into three categories, and only one of them is a comparison:
 | `Baseline` | A hand-written `StringBuilder` + Dapper `DynamicParameters` | The floor — no type safety, no dialect handling |
 | `ORM reference` | EF Core | Materially different work; shown only for scale |
 
-linq2db and EF Core cache compiled queries and reuse a long-lived connection or
-context created once in `[GlobalSetup]`, so the loop measures warm steady state
-rather than first-call cost.
+linq2db and EF Core reuse a connection object and a `DbContext` created once in
+`[GlobalSetup]` — neither is ever opened — and EF Core caches the compiled query
+plan, so the loop measures warm steady state rather than first-call cost.
 
 `SqlBuildingBufferBenchmark` covers `SqlBuildingBuffer` on its own, away from
 the cross-library comparison.
 
 ## Pinned library versions
 
-The comparison is only meaningful against the versions it was run with. These
-are pinned in `SqlArtisan.Benchmark.csproj`; update this table when they move.
+The comparison is only meaningful against the versions it was run with. The
+direct ones are pinned in `SqlArtisan.Benchmark.csproj`; update this table when
+they move.
 
-| Package | Version |
-|---|---|
-| BenchmarkDotNet | 0.15.8 |
-| Dapper.SqlBuilder | 2.1.66 |
-| InterpolatedSql | 2.5.1 |
-| linq2db | 6.3.0 |
-| Microsoft.EntityFrameworkCore | 8.0.11 |
-| Npgsql.EntityFrameworkCore.PostgreSQL | 8.0.11 |
-| Sqlify | 0.3.14 |
-| SqlKata | 4.0.1 |
+| Package | Version | |
+|---|---|---|
+| BenchmarkDotNet | 0.15.8 | |
+| Dapper.SqlBuilder | 2.1.66 | |
+| InterpolatedSql | 2.5.1 | |
+| linq2db | 6.3.0 | |
+| Microsoft.EntityFrameworkCore | 8.0.11 | |
+| Npgsql.EntityFrameworkCore.PostgreSQL | 8.0.11 | |
+| Sqlify | 0.3.14 | |
+| SqlKata | 4.0.1 | |
+| Dapper | 2.1.66 | transitive; measured by the baseline and `SqlArtisan+Dapper` |
+| Npgsql | 8.0.6 | transitive; under the EF Core reference |
+
+The runtime is part of this list too, and it has moved: the project targets
+`net10.0`, while the root README's figures were taken on .NET 8. Re-running here
+reproduces the ordering but not the exact numbers — allocations shift by a few
+percent on the newer runtime — so compare a fresh run against another fresh run,
+not against the published table.
 
 ## Reading the results
 

--- a/tests/SqlArtisan.Benchmark/README.md
+++ b/tests/SqlArtisan.Benchmark/README.md
@@ -16,9 +16,9 @@ dotnet run --project $P -c Release -- --filter '*SqlBuilderBenchmarks*'
 dotnet run --project $P -c Release                                    # pick a suite
 ```
 
-Quote the filter: unquoted, the shell expands `*SqlBuilderBenchmarks*` against
-the project directory and BenchmarkDotNet is handed `SqlBuilderBenchmarks.cs`,
-which matches nothing.
+Keep the filter quoted. Run from the project directory instead and the unquoted
+pattern matches `SqlBuilderBenchmarks.cs`, so the shell hands BenchmarkDotNet a
+filename that matches no benchmark.
 
 `validate` asserts that every entrant required to parameterize the query produced
 exactly two bind parameters, and prints each entrant's SQL so the logical query

--- a/tests/SqlArtisan.Benchmark/README.md
+++ b/tests/SqlArtisan.Benchmark/README.md
@@ -34,7 +34,7 @@ to the root README's figures.
 ## What is measured
 
 Every entrant builds the SQL string **and** its bind-parameter collection for the
-same logical query, so the comparison is like-for-like:
+same logical query, so the comparison is meant to be like-for-like:
 
 ```csharp
 Select(u.Id.As("user_id"), u.Name.As("user_name"), Count(o.Id).As("order_count"))
@@ -60,6 +60,10 @@ Entrants fall into three categories, and only one of them is a comparison:
 | `Baseline` | A hand-written `StringBuilder` + Dapper `DynamicParameters` | The floor — no type safety, no dialect handling |
 | `ORM reference` | EF Core | Materially different work; shown only for scale |
 
+One `Builders` row is not comparable today: the SqlKata entrant builds a
+different query — no aggregate, and a mangled `GROUP BY` key — which `validate`
+does not catch for the reason above. Tracked as #382.
+
 linq2db and EF Core reuse a connection object and a `DbContext` created once in
 `[GlobalSetup]` — neither is ever opened — and EF Core caches the compiled query
 plan, so the loop measures warm steady state rather than first-call cost.
@@ -71,7 +75,10 @@ the cross-library comparison.
 
 The comparison is only meaningful against the versions it was run with. The
 direct ones are pinned in `SqlArtisan.Benchmark.csproj`; update this table when
-they move.
+they move. The last two rows are transitive — listed because their versions
+float free of any direct pin, so a restore can move them without touching the
+csproj. Other transitive packages in the measured path (EF Core's `Relational`
+and caching assemblies) move in lockstep with the direct pin above them.
 
 | Package | Version | |
 |---|---|---|
@@ -83,14 +90,16 @@ they move.
 | Npgsql.EntityFrameworkCore.PostgreSQL | 8.0.11 | |
 | Sqlify | 0.3.14 | |
 | SqlKata | 4.0.1 | |
-| Dapper | 2.1.66 | transitive; measured by the baseline and `SqlArtisan+Dapper` |
+| Dapper | 2.1.66 | transitive; `DynamicParameters` is measured by the baseline, Dapper.SqlBuilder and `SqlArtisan+Dapper` |
 | Npgsql | 8.0.6 | transitive; under the EF Core reference |
 
 The runtime is part of this list too, and it has moved: the project targets
-`net10.0`, while the root README's figures were taken on .NET 8. Re-running here
-reproduces the ordering but not the exact numbers — allocations shift by a few
-percent on the newer runtime — so compare a fresh run against another fresh run,
-not against the published table.
+`net10.0`, while the root README's figures were taken on .NET 8. A fresh run
+reproduces the *allocation* ordering and lands within a few percent of the
+published bytes, but **not** the timing ordering — the mid- and heavy-weight
+entrants change places (a full run put Dapper.SqlBuilder ahead of InterpolatedSql
+and SqlKata ahead of linq2db). Compare a fresh run against another fresh run, not
+against the published table.
 
 ## Reading the results
 

--- a/tests/SqlArtisan.Benchmark/README.md
+++ b/tests/SqlArtisan.Benchmark/README.md
@@ -1,0 +1,84 @@
+# SqlArtisan.Benchmark
+
+The [BenchmarkDotNet](https://benchmarkdotnet.org/) suite behind the numbers in
+the root [README's Performance section](https://github.com/h-tacayama/SqlArtisan/blob/main/README.md#performance).
+The numbers live there and only there; this page is how you reproduce them.
+
+## Running it
+
+```bash
+dotnet run -c Release -- validate                          # equivalence check, not a measurement
+dotnet run -c Release -- --filter *SqlBuilderBenchmarks*   # the cross-library comparison
+dotnet run -c Release                                      # pick a suite interactively
+```
+
+`validate` is the one-time check that the entrants are actually comparable. It
+prints each entrant's SQL and parameter count and asserts that everyone required
+to parameterize the query produced exactly two bind parameters. SQL text is *not*
+required to be byte-identical — dialects, alias generation, and EF Core's
+pipeline all differ — only the logical query and the parameter count. Run it
+after touching any entrant; a change that quietly stops parameterizing would
+otherwise look like a win.
+
+**Release configuration is required.** BenchmarkDotNet refuses to run a Debug
+build, and a measurement taken on a shared or virtualized host is not comparable
+to the root README's figures.
+
+## What is measured
+
+Every entrant builds the SQL string **and** its bind-parameter collection for the
+same logical query, so the comparison is like-for-like:
+
+```csharp
+Select(u.Id.As("user_id"), u.Name.As("user_name"), Count(o.Id).As("order_count"))
+    .From(u)
+    .InnerJoin(o).On(u.Id == o.UserId)
+    .Where(o.OrderDate >= new DateTime(2024, 1, 1)
+        & o.OrderDate < new DateTime(2025, 1, 1))
+    .GroupBy(u.Id, u.Name)
+    .OrderBy(Count(o.Id).As("order_count").Desc)
+    .Build();
+```
+
+An `INNER JOIN` plus a `GROUP BY` aggregate, filtered by two date parameters, on
+the PostgreSQL dialect. Each `[Benchmark]` returns the produced
+`(Sql, ParameterCount)` tuple so BenchmarkDotNet consumes both outputs and cannot
+dead-code-eliminate the work.
+
+Entrants fall into three categories, and only one of them is a comparison:
+
+| Category | Entrants | Why |
+|---|---|---|
+| `Builders` | SqlArtisan (twice — specific and Dapper dynamic parameters), Dapper.SqlBuilder, InterpolatedSql, linq2db, Sqlify, SqlKata | The like-for-like set |
+| `Baseline` | A hand-written `StringBuilder` + Dapper `DynamicParameters` | The floor — no type safety, no dialect handling |
+| `ORM reference` | EF Core | Materially different work; shown only for scale |
+
+linq2db and EF Core cache compiled queries and reuse a long-lived connection or
+context created once in `[GlobalSetup]`, so the loop measures warm steady state
+rather than first-call cost.
+
+`SqlBuildingBufferBenchmark` covers `SqlBuildingBuffer` on its own, away from
+the cross-library comparison.
+
+## Pinned library versions
+
+The comparison is only meaningful against the versions it was run with. These
+are pinned in `SqlArtisan.Benchmark.csproj`; update this table when they move.
+
+| Package | Version |
+|---|---|
+| BenchmarkDotNet | 0.15.8 |
+| Dapper.SqlBuilder | 2.1.66 |
+| InterpolatedSql | 2.5.1 |
+| linq2db | 6.3.0 |
+| Microsoft.EntityFrameworkCore | 8.0.11 |
+| Npgsql.EntityFrameworkCore.PostgreSQL | 8.0.11 |
+| Sqlify | 0.3.14 |
+| SqlKata | 4.0.1 |
+
+## Reading the results
+
+The allocation column is the firm one — the lightweight builders allocate the
+same bytes every run. Treat the timing order as directional: run-to-run variance
+grows for the heavier entrants, and it grows further on any host you do not
+control.

--- a/tests/SqlArtisan.Benchmark/SqlBuilderBenchmarks.cs
+++ b/tests/SqlArtisan.Benchmark/SqlBuilderBenchmarks.cs
@@ -5,17 +5,9 @@ using SqlArtisan.Benchmark.EfCoreModel;
 
 namespace SqlArtisan.Benchmark;
 
-// Every entrant builds the SQL string *and* its bind-parameter collection for the same
-// logical query (an INNER JOIN + GROUP BY aggregate filtered by two date parameters), so
-// the comparison is apples-to-apples. Each [Benchmark] returns the produced
-// (Sql, ParameterCount) tuple so BenchmarkDotNet consumes both outputs and cannot
-// dead-code-eliminate the work.
-//
-// Builder libraries sit in the "Builders" category. The hand-written StringBuilder is a
-// labeled "Baseline" floor and EF Core a labeled "ORM reference"; both do materially
-// different work, so they are kept out of the builder comparison. linq2db and EF Core
-// cache compiled queries and reuse a long-lived connection/context created once in
-// [GlobalSetup], so the loop measures realistic warm steady-state.
+// Returning the (Sql, ParameterCount) tuple is what stops BenchmarkDotNet
+// dead-code-eliminating the work. The Baseline and ORM-reference entrants are labeled out
+// of the comparison rather than dropped: a floor and a scale marker. See README.md.
 [MemoryDiagnoser]
 [CategoriesColumn]
 [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]

--- a/tests/SqlArtisan.Tests/BenchmarkDocsTests.cs
+++ b/tests/SqlArtisan.Tests/BenchmarkDocsTests.cs
@@ -1,0 +1,156 @@
+using System.Text.RegularExpressions;
+
+namespace SqlArtisan.Tests;
+
+// The benchmark project's README states facts that live in its source: the pinned
+// versions, the entrant categories, the tuple every entrant returns, the parameter
+// count validate asserts. Prose drifts silently and a docs review only catches it
+// by luck (#381 shipped three such errors in one page), so the checkable half is
+// gated here rather than re-read each time.
+public class BenchmarkDocsTests
+{
+    private const string BenchmarkDir = "tests/SqlArtisan.Benchmark";
+
+    private static readonly Regex PackageReferencePattern = new(
+        @"<PackageReference Include=""(?<name>[^""]+)"" Version=""(?<version>[^""]+)""",
+        RegexOptions.Compiled);
+
+    private static readonly Regex CategoryConstantPattern = new(
+        @"private const string \w+ = ""(?<category>[^""]+)"";",
+        RegexOptions.Compiled);
+
+    private static readonly Regex BenchmarkMethodPattern = new(
+        @"\[Benchmark\]\s*\r?\n\s*\[BenchmarkCategory\([^)]*\)\]\s*\r?\n\s*public (?<returns>[^\r\n]+?) (?<name>\w+)\(\)",
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void PinnedVersionTable_DirectPackages_MatchTheCsproj()
+    {
+        string root = FindRepoRoot();
+        string csproj = File.ReadAllText(
+            Path.Combine(root, BenchmarkDir, "SqlArtisan.Benchmark.csproj"));
+
+        Dictionary<string, string> pinned = [];
+        foreach (Match match in PackageReferencePattern.Matches(csproj))
+        {
+            pinned[match.Groups["name"].Value] = match.Groups["version"].Value;
+        }
+
+        Assert.Equal(pinned, DocumentedVersions(root, transitive: false));
+    }
+
+    // Transitive rows earn their place by floating free of a direct pin, so they are
+    // the ones a restore can move without touching the csproj.
+    [Fact]
+    public void PinnedVersionTable_TransitivePackages_MatchTheRestoredGraph()
+    {
+        string root = FindRepoRoot();
+        string assets = File.ReadAllText(
+            Path.Combine(root, BenchmarkDir, "obj", "project.assets.json"));
+
+        foreach (KeyValuePair<string, string> row in DocumentedVersions(root, transitive: true))
+        {
+            Assert.Contains($"\"{row.Key}/{row.Value}\"", assets);
+        }
+    }
+
+    [Fact]
+    public void EntrantTable_Categories_MatchTheBenchmarkSource()
+    {
+        string root = FindRepoRoot();
+        string source = File.ReadAllText(
+            Path.Combine(root, BenchmarkDir, "SqlBuilderBenchmarks.cs"));
+
+        string[] declared = [.. CategoryConstantPattern.Matches(source)
+            .Select(m => m.Groups["category"].Value)
+            .Order()];
+
+        string[] documented = [.. TableRows(ReadDocs(root), "| Category |")
+            .Select(cells => cells[0].Trim('`', ' '))
+            .Order()];
+
+        Assert.Equal(declared, documented);
+    }
+
+    [Fact]
+    public void CrossLibraryEntrants_EveryBenchmark_ReturnsSqlAndParameterCount()
+    {
+        string root = FindRepoRoot();
+        string source = File.ReadAllText(
+            Path.Combine(root, BenchmarkDir, "SqlBuilderBenchmarks.cs"));
+
+        MatchCollection entrants = BenchmarkMethodPattern.Matches(source);
+
+        Assert.NotEmpty(entrants);
+        foreach (Match entrant in entrants)
+        {
+            Assert.Equal("(string Sql, int ParameterCount)", entrant.Groups["returns"].Value);
+        }
+    }
+
+    [Fact]
+    public void ValidateDescription_ExpectedParameterCount_MatchesTheSource()
+    {
+        string root = FindRepoRoot();
+        string source = File.ReadAllText(
+            Path.Combine(root, BenchmarkDir, "Benchmark", "BenchmarkValidation.cs"));
+
+        Match expected = Regex.Match(source, @"const int expectedParameters = (?<count>\d+);");
+
+        Assert.True(expected.Success, "BenchmarkValidation no longer names its expected count.");
+        Assert.Contains(
+            $"exactly {NumberWord(expected.Groups["count"].Value)} bind parameters",
+            ReadDocs(root));
+    }
+
+    private static string ReadDocs(string root) =>
+        File.ReadAllText(Path.Combine(root, BenchmarkDir, "README.md"));
+
+    // The version table's third column annotates transitive rows and is empty on the
+    // direct ones, which is what separates the two halves.
+    private static Dictionary<string, string> DocumentedVersions(string root, bool transitive)
+    {
+        Dictionary<string, string> documented = [];
+        foreach (string[] cells in TableRows(ReadDocs(root), "| Package |"))
+        {
+            if (cells.Length > 2 && cells[2].Trim().Length > 0 == transitive)
+            {
+                documented[cells[0].Trim()] = cells[1].Trim();
+            }
+        }
+
+        return documented;
+    }
+
+    private static IEnumerable<string[]> TableRows(string markdown, string header)
+    {
+        string[] lines = markdown.Split('\n');
+        int start = Array.FindIndex(lines, line => line.StartsWith(header, StringComparison.Ordinal));
+
+        Assert.True(start >= 0, $"The docs no longer contain a table headed '{header}'.");
+
+        for (int i = start + 2; i < lines.Length && lines[i].StartsWith('|'); i++)
+        {
+            yield return lines[i].Trim().Trim('|').Split('|');
+        }
+    }
+
+    private static string NumberWord(string count) => count switch
+    {
+        "2" => "two",
+        _ => count,
+    };
+
+    private static string FindRepoRoot()
+    {
+        DirectoryInfo? dir = new(AppContext.BaseDirectory);
+
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "SqlArtisan.sln")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+        return dir.FullName;
+    }
+}


### PR DESCRIPTION
## Summary

`README.md:95` closed the Performance section by pointing at the benchmark
project for *"query shape, library versions, and re-run instructions"*. There was
no README there — the link landed on a source directory.

All three facts existed, just scattered:

| Promised | Was at |
|---|---|
| re-run instructions | a comment in `Program.cs:4-5` |
| library versions | the `PackageReference` list in the `.csproj` |
| query shape | a header comment in `SqlBuilderBenchmarks.cs:8-18` |

A reader had to open three files and know which. The new page assembles them, so
the root README's sentence is now true as written.

## What the page adds beyond assembly

Things only running the suite teaches, which no comment recorded:

- **`validate` is not an equivalence check.** It asserts only that every entrant
  required to parameterize produced exactly two bind parameters. The SQL is
  printed for eye-comparison and never asserted — so an entrant that drifts into
  building a *different* query still passes. That is not hypothetical: it is how
  the SqlKata drift below went unnoticed.
- **Release is required.** BenchmarkDotNet refuses a Debug build.
- **Only one of the three categories is a comparison.** `Builders` is the
  like-for-like set; `Baseline` (hand-written `StringBuilder`) and
  `ORM reference` (EF Core) do materially different work and are kept out of it.
- **No database is needed.** Every entrant generates SQL offline. Verified by
  running the full suite inside a network namespace with no interfaces.
- **A fresh run does not reproduce the published timing order.** It reproduces
  the *allocation* order and lands within a few percent of the published bytes,
  but the mid- and heavy-weight entrants change places on the current runtime.

## Two defects found while writing it

- **#382 (filed)** — the SqlKata entrant builds a different query: `COUNT(orders.id)`
  is passed as an identifier, so the compiler emits `"COUNT(orders"."id)"` with no
  aggregate at all, and the `GROUP BY` key is mangled into one identifier. Its
  published row is not like-for-like. The page discloses this rather than
  restating the fairness premise it breaks.
- **The `Builder` category label** — the root table's Category column read
  `Builder`; the code constant is `"Builders"` (`SqlBuilderBenchmarks.cs:25`), so
  anyone re-running the suite compared their output against a label they would
  never see. Aligned to the code, seven rows.

## The page's checkable claims are gated

`tests/SqlArtisan.Tests/BenchmarkDocsTests.cs` pins the four facts the page
restates from source — pinned versions (direct and transitive), entrant
categories, the `(Sql, ParameterCount)` return type, and the parameter count
`validate` asserts. All five assertions were mutation-checked: each mutation
fails exactly one test.

This is the point of the file. Three review rounds on this PR each found prose
that had drifted from the code, including prose written to fix the previous
round. Gating what can be gated is what ends that loop; the two source comments
that duplicated the page (and had already drifted from it) are trimmed to a
pointer for the same reason.

## No numbers here

They live in the root README, and #374 will re-measure them on real hardware. A
second copy would only be a second thing to forget — so this page carries
commands, pinned versions, and query shape, and nothing that a re-measurement
would invalidate.

## Verification

- `dotnet run --project tests/SqlArtisan.Benchmark -c Release -- validate` — exit 0
- Full nine-entrant `SqlBuilderBenchmarks` run — completed, no environment warnings
- `dotnet build SqlArtisan.sln -c Release` — 0 errors, 0 warnings
- `dotnet test` — 823 / 614 / 132 passing (`llms-full.txt` regenerated; its
  byte-for-byte gate covers the root README edit)
- `dotnet format SqlArtisan.sln --verify-no-changes` — exit 0
- The four bundled docs scripts — all green, SQL examples 100/100

Closes #376


---
_Generated by [Claude Code](https://claude.ai/code/session_01CBXFM2WmG8tRiY9vWeqdn4)_