### PR TITLE
fix(benchmark): Build the shared query in the SqlKata entrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ SqlArtisan minimizes heap allocations — string buffers are recycled from a poo
 | InterpolatedSql_SpecificParams | Builders | 2,749.7 ns | 5.11 KB |
 | DapperSqlBuilder_DapperDynamicParams | Builders | 2,762.2 ns | 5.70 KB |
 | Linq2db_TypedParams | Builders | 44,173.3 ns | 19.13 KB |
-| SqlKata_SpecificParams | Builders | 50,577.6 ns | 40.54 KB |
+| SqlKata_SpecificParams³ | Builders | 50,577.6 ns | 40.54 KB |
 | EfCore_Reference | ORM reference² | 49,728.5 ns | 12.86 KB |
 
 The **allocation lead is firm** (lightweight builders allocate the same bytes every run); treat the timing order as directional, since run-to-run variance grows for the heavier entrants.
 
-¹ Raw `StringBuilder` + Dapper `DynamicParameters` — the floor, with no type safety or dialect handling. ² EF Core is a full-ORM **reference** (different work, caches compiled queries), shown only for scale.
+¹ Raw `StringBuilder` + Dapper `DynamicParameters` — the floor, with no type safety or dialect handling. ² EF Core is a full-ORM **reference** (different work, caches compiled queries), shown only for scale. ³ Understated: this row predates a fix to the SqlKata entrant, which had been building a lighter query than the others; it now allocates about half again as much. Every other row is unaffected, and SqlKata was already the heaviest builder.
 
 *Measured on .NET 8.0.28, i5-1135G7 / 16 GB / Windows 11, PostgreSQL dialect. Query shape, library versions, and re-run instructions are in the [benchmark project's README](https://github.com/h-tacayama/SqlArtisan/blob/main/tests/SqlArtisan.Benchmark/README.md).*
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -96,12 +96,12 @@ SqlArtisan minimizes heap allocations — string buffers are recycled from a poo
 | InterpolatedSql_SpecificParams | Builders | 2,749.7 ns | 5.11 KB |
 | DapperSqlBuilder_DapperDynamicParams | Builders | 2,762.2 ns | 5.70 KB |
 | Linq2db_TypedParams | Builders | 44,173.3 ns | 19.13 KB |
-| SqlKata_SpecificParams | Builders | 50,577.6 ns | 40.54 KB |
+| SqlKata_SpecificParams³ | Builders | 50,577.6 ns | 40.54 KB |
 | EfCore_Reference | ORM reference² | 49,728.5 ns | 12.86 KB |
 
 The **allocation lead is firm** (lightweight builders allocate the same bytes every run); treat the timing order as directional, since run-to-run variance grows for the heavier entrants.
 
-¹ Raw `StringBuilder` + Dapper `DynamicParameters` — the floor, with no type safety or dialect handling. ² EF Core is a full-ORM **reference** (different work, caches compiled queries), shown only for scale.
+¹ Raw `StringBuilder` + Dapper `DynamicParameters` — the floor, with no type safety or dialect handling. ² EF Core is a full-ORM **reference** (different work, caches compiled queries), shown only for scale. ³ Understated: this row predates a fix to the SqlKata entrant, which had been building a lighter query than the others; it now allocates about half again as much. Every other row is unaffected, and SqlKata was already the heaviest builder.
 
 *Measured on .NET 8.0.28, i5-1135G7 / 16 GB / Windows 11, PostgreSQL dialect. Query shape, library versions, and re-run instructions are in the [benchmark project's README](https://github.com/h-tacayama/SqlArtisan/blob/main/tests/SqlArtisan.Benchmark/README.md).*
 

--- a/tests/SqlArtisan.Benchmark/Benchmark/BenchmarkValidation.cs
+++ b/tests/SqlArtisan.Benchmark/Benchmark/BenchmarkValidation.cs
@@ -1,21 +1,38 @@
+using System.Text.RegularExpressions;
 using LinqToDB.Data;
 using SqlArtisan.Benchmark.EfCoreModel;
 
 namespace SqlArtisan.Benchmark;
 
-// Runs outside the measured loop (`dotnet run -- validate`). Only the parameter count is
-// asserted — SQL text differs legitimately by dialect and alias generation, so the logical
-// query is merely printed, which is how the SqlKata drift (#382) got through.
+// Runs outside the measured loop (`dotnet run -- validate`). Asserts the shape every
+// comparison entrant must share rather than the SQL text, which differs legitimately by
+// dialect and alias generation — a parameter-count-only check let #382 through.
 public static class BenchmarkValidation
 {
+    private static readonly Regex AggregateCall = new(@"\bCOUNT\s*\(", RegexOptions.IgnoreCase);
+
+    // Each dialect spells the keys differently, so only their number is comparable.
+    private static readonly Regex GroupByKeys = new(
+        @"GROUP BY (?<keys>.*?)(?: ORDER BY | HAVING |$)",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+    // linq2db pretty-prints across lines, so the clause boundaries only line up once
+    // every run of whitespace is one space.
+    private static readonly Regex Whitespace = new(@"\s+");
+
+    // #382 hid an expression inside a quoted identifier — "COUNT(orders"."id)" — which
+    // reads as both an aggregate and two GROUP BY keys until the quotes are collapsed.
+    private static readonly Regex QuotedIdentifier = new("\"[^\"]*\"");
+
     public static int Run()
     {
         const int expectedParameters = 2;
+        const int expectedGroupByKeys = 2;
 
         using DataConnection linq2db = Linq2dbBenchmark.CreateConnection();
         using BenchmarkDbContext efCore = EfCoreBenchmark.CreateContext();
 
-        (string Name, Func<(string Sql, int ParameterCount)> Build, bool MustParameterize)[] entrants =
+        (string Name, Func<(string Sql, int ParameterCount)> Build, bool InComparison)[] entrants =
         [
             ("StringBuilder", StringBuilderBenchmark.Run, true),
             ("DapperSqlBuilder", DapperSqlBuilderBenchmark.Run, true),
@@ -29,24 +46,47 @@ public static class BenchmarkValidation
         ];
 
         bool ok = true;
-        foreach ((string name, Func<(string Sql, int ParameterCount)> build, bool mustParameterize) in entrants)
+        foreach ((string name, Func<(string Sql, int ParameterCount)> build, bool inComparison) in entrants)
         {
             (string sql, int parameterCount) = build();
-            bool entrantOk = !mustParameterize || parameterCount == expectedParameters;
-            ok &= entrantOk;
+            string? drift = inComparison
+                ? Drift(sql, parameterCount, expectedParameters, expectedGroupByKeys)
+                : null;
+            ok &= drift is null;
 
-            Console.WriteLine($"=== {name} === parameters: {parameterCount}{(entrantOk ? "" : $"  <-- EXPECTED {expectedParameters}")}");
+            Console.WriteLine($"=== {name} === parameters: {parameterCount}{(drift is null ? "" : $"  <-- {drift}")}");
             Console.WriteLine(sql);
             Console.WriteLine();
         }
 
         if (ok)
         {
-            Console.WriteLine($"OK: every parameterizing entrant produced {expectedParameters} parameters.");
+            Console.WriteLine(
+                $"OK: every comparison entrant built the shared query with {expectedParameters} bind parameters.");
             return 0;
         }
 
-        Console.WriteLine("FAIL: an entrant did not parameterize the query as expected.");
+        Console.WriteLine("FAIL: an entrant did not build the shared query as expected.");
         return 1;
+    }
+
+    private static string? Drift(string sql, int parameters, int expectedParameters, int expectedKeys)
+    {
+        if (parameters != expectedParameters)
+        {
+            return $"EXPECTED {expectedParameters} PARAMETERS";
+        }
+
+        string bare = QuotedIdentifier.Replace(Whitespace.Replace(sql, " "), "_");
+
+        if (!AggregateCall.IsMatch(bare))
+        {
+            return "NO AGGREGATE — not the shared query";
+        }
+
+        Match groupBy = GroupByKeys.Match(bare);
+        int keys = groupBy.Success ? groupBy.Groups["keys"].Value.Split(',').Length : 0;
+
+        return keys == expectedKeys ? null : $"GROUP BY NAMES {keys} KEYS, EXPECTED {expectedKeys}";
     }
 }

--- a/tests/SqlArtisan.Benchmark/Benchmark/BenchmarkValidation.cs
+++ b/tests/SqlArtisan.Benchmark/Benchmark/BenchmarkValidation.cs
@@ -11,7 +11,8 @@ public static class BenchmarkValidation
 {
     private static readonly Regex AggregateCall = new(@"\bCOUNT\s*\(", RegexOptions.IgnoreCase);
 
-    // Each dialect spells the keys differently, so only their number is comparable.
+    // Each dialect spells the keys differently, so only their number is comparable —
+    // counted by comma, which is exact while every entrant groups by bare columns.
     private static readonly Regex GroupByKeys = new(
         @"GROUP BY (?<keys>.*?)(?: ORDER BY | HAVING |$)",
         RegexOptions.IgnoreCase | RegexOptions.Singleline);
@@ -32,7 +33,7 @@ public static class BenchmarkValidation
         using DataConnection linq2db = Linq2dbBenchmark.CreateConnection();
         using BenchmarkDbContext efCore = EfCoreBenchmark.CreateContext();
 
-        (string Name, Func<(string Sql, int ParameterCount)> Build, bool InComparison)[] entrants =
+        (string Name, Func<(string Sql, int ParameterCount)> Build, bool BuildsSharedQuery)[] entrants =
         [
             ("StringBuilder", StringBuilderBenchmark.Run, true),
             ("DapperSqlBuilder", DapperSqlBuilderBenchmark.Run, true),
@@ -46,10 +47,10 @@ public static class BenchmarkValidation
         ];
 
         bool ok = true;
-        foreach ((string name, Func<(string Sql, int ParameterCount)> build, bool inComparison) in entrants)
+        foreach ((string name, Func<(string Sql, int ParameterCount)> build, bool shared) in entrants)
         {
             (string sql, int parameterCount) = build();
-            string? drift = inComparison
+            string? drift = shared
                 ? Drift(sql, parameterCount, expectedParameters, expectedGroupByKeys)
                 : null;
             ok &= drift is null;
@@ -62,7 +63,7 @@ public static class BenchmarkValidation
         if (ok)
         {
             Console.WriteLine(
-                $"OK: every comparison entrant built the shared query with {expectedParameters} bind parameters.");
+                $"OK: every checked entrant built the shared query with {expectedParameters} bind parameters.");
             return 0;
         }
 
@@ -79,7 +80,11 @@ public static class BenchmarkValidation
 
         string bare = QuotedIdentifier.Replace(Whitespace.Replace(sql, " "), "_");
 
-        if (!AggregateCall.IsMatch(bare))
+        // Sqlify sorts by COUNT(*), so searching the whole statement would let an
+        // aggregate in ORDER BY vouch for a projection that is no longer there.
+        int sort = bare.LastIndexOf(" ORDER BY ", StringComparison.OrdinalIgnoreCase);
+
+        if (!AggregateCall.IsMatch(sort < 0 ? bare : bare[..sort]))
         {
             return "NO AGGREGATE — not the shared query";
         }
@@ -87,6 +92,8 @@ public static class BenchmarkValidation
         Match groupBy = GroupByKeys.Match(bare);
         int keys = groupBy.Success ? groupBy.Groups["keys"].Value.Split(',').Length : 0;
 
-        return keys == expectedKeys ? null : $"GROUP BY NAMES {keys} KEYS, EXPECTED {expectedKeys}";
+        return keys == expectedKeys
+            ? null
+            : $"GROUP BY NAMES {keys} {(keys == 1 ? "KEY" : "KEYS")}, EXPECTED {expectedKeys}";
     }
 }

--- a/tests/SqlArtisan.Benchmark/Benchmark/SqlKataBenchmark.cs
+++ b/tests/SqlArtisan.Benchmark/Benchmark/SqlKataBenchmark.cs
@@ -6,13 +6,16 @@ public static class SqlKataBenchmark
 {
     public static (string Sql, int ParameterCount) Run()
     {
+        // Select() quotes what it is given as an identifier, so the aggregate needs
+        // SelectRaw and each GROUP BY key its own argument (#382).
         Query query = new Query()
-            .Select("users.id AS user_id", "users.name AS user_name", "COUNT(orders.id) AS order_count")
+            .Select("users.id AS user_id", "users.name AS user_name")
+            .SelectRaw("COUNT(orders.id) AS order_count")
             .From("users")
             .Join("orders", j => j.On("users.id", "orders.user_id"))
             .Where("orders.order_date", ">=", new DateTime(2024, 1, 1))
             .Where("orders.order_date", "<", new DateTime(2025, 1, 1))
-            .GroupBy("users.id, users.name")
+            .GroupBy("users.id", "users.name")
             .OrderByDesc("order_count");
 
         var compiler = new SqlKata.Compilers.PostgresCompiler();

--- a/tests/SqlArtisan.Benchmark/Benchmark/SqlKataBenchmark.cs
+++ b/tests/SqlArtisan.Benchmark/Benchmark/SqlKataBenchmark.cs
@@ -6,8 +6,8 @@ public static class SqlKataBenchmark
 {
     public static (string Sql, int ParameterCount) Run()
     {
-        // Select() quotes what it is given as an identifier, so the aggregate needs
-        // SelectRaw and each GROUP BY key its own argument (#382).
+        // Every clause builder quotes what it is given as one identifier, so the aggregate
+        // needs SelectRaw and each GROUP BY key its own argument (#382).
         Query query = new Query()
             .Select("users.id AS user_id", "users.name AS user_name")
             .SelectRaw("COUNT(orders.id) AS order_count")

--- a/tests/SqlArtisan.Benchmark/README.md
+++ b/tests/SqlArtisan.Benchmark/README.md
@@ -20,12 +20,12 @@ Keep the filter quoted. Run from the project directory instead and the unquoted
 pattern matches `SqlBuilderBenchmarks.cs`, so the shell hands BenchmarkDotNet a
 filename that matches no benchmark.
 
-`validate` asserts that every entrant required to parameterize the query produced
-exactly two bind parameters, and prints each entrant's SQL so the logical query
-can be compared by eye — that half is not asserted, so an entrant that drifts
-into building a *different* query still passes. Run it after touching any
-entrant; a change that quietly stops parameterizing would otherwise look like a
-win.
+`validate` asserts that every entrant in the comparison built the shared query:
+exactly two bind parameters, an aggregate, and two `GROUP BY` keys. It checks the
+shape rather than the text, because dialects, alias generation and EF Core's
+pipeline all spell the same query differently. Run it after touching any entrant
+— a change that quietly stops parameterizing, or stops aggregating, would
+otherwise look like a win.
 
 **Release configuration is required.** BenchmarkDotNet refuses to run a Debug
 build, and a measurement taken on a shared or virtualized host is not comparable
@@ -34,7 +34,7 @@ to the root README's figures.
 ## What is measured
 
 Every entrant builds the SQL string **and** its bind-parameter collection for the
-same logical query, so the comparison is meant to be like-for-like:
+same logical query, so the comparison is like-for-like:
 
 ```csharp
 Select(u.Id.As("user_id"), u.Name.As("user_name"), Count(o.Id).As("order_count"))
@@ -59,10 +59,6 @@ Entrants fall into three categories, and only one of them is a comparison:
 | `Builders` | SqlArtisan (twice — specific and Dapper dynamic parameters), Dapper.SqlBuilder, InterpolatedSql, linq2db, Sqlify, SqlKata | The like-for-like set |
 | `Baseline` | A hand-written `StringBuilder` + Dapper `DynamicParameters` | The floor — no type safety, no dialect handling |
 | `ORM reference` | EF Core | Materially different work; shown only for scale |
-
-One `Builders` row is not comparable today: the SqlKata entrant builds a
-different query — no aggregate, and a mangled `GROUP BY` key — which `validate`
-does not catch for the reason above. Tracked as #382.
 
 linq2db and EF Core reuse a connection object and a `DbContext` created once in
 `[GlobalSetup]` — neither is ever opened — and EF Core caches the compiled query

--- a/tests/SqlArtisan.Benchmark/README.md
+++ b/tests/SqlArtisan.Benchmark/README.md
@@ -20,12 +20,13 @@ Keep the filter quoted. Run from the project directory instead and the unquoted
 pattern matches `SqlBuilderBenchmarks.cs`, so the shell hands BenchmarkDotNet a
 filename that matches no benchmark.
 
-`validate` asserts that every entrant in the comparison built the shared query:
-exactly two bind parameters, an aggregate, and two `GROUP BY` keys. It checks the
-shape rather than the text, because dialects, alias generation and EF Core's
-pipeline all spell the same query differently. Run it after touching any entrant
-— a change that quietly stops parameterizing, or stops aggregating, would
-otherwise look like a win.
+`validate` asserts that each entrant built the shared query: exactly two bind
+parameters, an aggregate outside the sort, and two `GROUP BY` keys. It checks
+that shape rather than the text, because dialects and alias generation spell the
+same query differently — and it checks nothing else, so a wrong join or filter
+would still pass. The EF Core reference is printed but not checked. Run it after
+touching any entrant; a change that quietly stops parameterizing, or stops
+aggregating, would otherwise look like a win.
 
 **Release configuration is required.** BenchmarkDotNet refuses to run a Debug
 build, and a measurement taken on a shared or virtualized host is not comparable
@@ -91,11 +92,13 @@ and caching assemblies) move in lockstep with the direct pin above them.
 
 The runtime is part of this list too, and it has moved: the project targets
 `net10.0`, while the root README's figures were taken on .NET 8. A fresh run
-reproduces the *allocation* ordering and lands within a few percent of the
-published bytes, but **not** the timing ordering — the mid- and heavy-weight
-entrants change places (a full run put Dapper.SqlBuilder ahead of InterpolatedSql
-and SqlKata ahead of linq2db). Compare a fresh run against another fresh run, not
-against the published table.
+reproduces the *allocation* ordering, but **not** the timing ordering — the mid-
+and heavy-weight entrants change places (a full run put Dapper.SqlBuilder ahead
+of InterpolatedSql and SqlKata ahead of linq2db). Most rows land within a few
+percent of the published bytes; SqlKata does not, because its entrant was
+rebuilt after that table was measured (#382) and now allocates about half again
+as much. Compare a fresh run against another fresh run, not against the published
+table.
 
 ## Reading the results
 

--- a/tests/SqlArtisan.Tests/BenchmarkDocsTests.cs
+++ b/tests/SqlArtisan.Tests/BenchmarkDocsTests.cs
@@ -102,8 +102,11 @@ public class BenchmarkDocsTests
         Assert.True(expected.Success, $"BenchmarkValidation no longer declares {constant}.");
         Assert.Contains(
             string.Format(phrasing, NumberWord(expected.Groups["count"].Value)),
-            ReadDocs(root));
+            Unwrapped(ReadDocs(root)));
     }
+
+    // The claim is the subject here, not the line layout it happens to be wrapped at.
+    private static string Unwrapped(string markdown) => Regex.Replace(markdown, @"\s+", " ");
 
     private static string ReadDocs(string root) =>
         File.ReadAllText(Path.Combine(root, BenchmarkDir, "README.md"));

--- a/tests/SqlArtisan.Tests/BenchmarkDocsTests.cs
+++ b/tests/SqlArtisan.Tests/BenchmarkDocsTests.cs
@@ -88,18 +88,20 @@ public class BenchmarkDocsTests
         }
     }
 
-    [Fact]
-    public void ValidateDescription_ExpectedParameterCount_MatchesTheSource()
+    [Theory]
+    [InlineData("expectedParameters", "exactly {0} bind parameters")]
+    [InlineData("expectedGroupByKeys", "{0} `GROUP BY` keys")]
+    public void ValidateDescription_AssertedShape_MatchesTheSource(string constant, string phrasing)
     {
         string root = FindRepoRoot();
         string source = File.ReadAllText(
             Path.Combine(root, BenchmarkDir, "Benchmark", "BenchmarkValidation.cs"));
 
-        Match expected = Regex.Match(source, @"const int expectedParameters = (?<count>\d+);");
+        Match expected = Regex.Match(source, $@"const int {constant} = (?<count>\d+);");
 
-        Assert.True(expected.Success, "BenchmarkValidation no longer names its expected count.");
+        Assert.True(expected.Success, $"BenchmarkValidation no longer declares {constant}.");
         Assert.Contains(
-            $"exactly {NumberWord(expected.Groups["count"].Value)} bind parameters",
+            string.Format(phrasing, NumberWord(expected.Groups["count"].Value)),
             ReadDocs(root));
     }
 


### PR DESCRIPTION
## Summary

SqlKata's clause builders quote what they are given as a *single identifier*, so
`Benchmark/SqlKataBenchmark.cs` passing expressions produced SQL with no
aggregate in it at all:

```
"COUNT(orders"."id)" AS "order_count"          -- a quoted column name, not a call
GROUP BY "users"."id, users"."name"            -- one mangled key, not two
```

PostgreSQL 16 rejects it outright:

```
ERROR:  missing FROM-clause entry for table "COUNT(orders"
```

So one of the seven `Builders` rows was measuring materially less work than the
rest, in a table whose premise is that every entrant builds the same query.

## The fix

`SelectRaw` for the aggregate, one argument per `GROUP BY` key. Verified on a
live PostgreSQL 16 — identical column names, ordering and values:

```
### SqlArtisan entrant              ### SqlKata entrant (fixed)
 user_id | user_name | order_count   user_id | user_name | order_count
---------+-----------+-------------  --------+-----------+-------------
       3 | c         |           3         3 | c         |           3
       1 | a         |           2         1 | a         |           2
       2 | b         |           1         2 | b         |           1
       4 | d         |           1         4 | d         |           1
```

## This makes a published number wrong, and it is disclosed

The entrant now does strictly more work, so the row measured before the fix
understates it by half:

| | Allocated |
|---|---|
| pre-fix entrant, this runtime | 39.48 KB |
| post-fix entrant, measured | **60.94 KB** |
| published at `README.md:88` | 40.54 KB |

`README.md:88` gains a footnote saying so, and the benchmark page's "a fresh run
lands within a few percent of the published bytes" — accurate at −2.6 % before,
false by +50 % after — is corrected for that row. Re-measuring the table needs
the reference hardware and belongs to #374, which this unblocks.

Every other row is unaffected, and `README.md:77`'s "lowest-allocation and
fastest builder" is untouched in either direction: SqlKata was already the
heaviest builder, so correcting it moves it further from the lead.

## validate now checks the shape, not just the count

`validate` asserted the parameter count and nothing else, which is exactly why
this survived — SqlKata parameterized both dates correctly, so it passed. It now
also requires an aggregate *outside the sort* and two `GROUP BY` keys.

Two rounds of mutation testing shaped this check, and each caught a version that
did not work:

- The first version searched the raw SQL. `\bCOUNT\s*\(` matches inside
  `"COUNT(orders"`, and the mangled key `"users"."id, users"."name"` contains a
  comma — so the broken SQL read as *both* an aggregate and two keys. Quoted
  identifiers are now collapsed first.
- The second searched the whole statement, so an aggregate in `ORDER BY` alone
  would vouch for a missing projection. Not hypothetical: the Sqlify entrant
  emits `GROUP BY u.id, u.name ORDER BY COUNT(*) DESC`, so deleting its
  projection validated clean. The search now excludes the sort.

Each half bites independently, proven by breaking the entrants:

| Mutation | Result |
|---|---|
| original #382 defect restored | `<-- NO AGGREGATE — not the shared query`, exit 1 |
| `GROUP BY` mangled only | `<-- GROUP BY NAMES 1 KEY, EXPECTED 2`, exit 1 |
| Sqlify's `COUNT` projection removed | `<-- NO AGGREGATE — not the shared query`, exit 1 |
| none | all nine entrants pass, exit 0 |

What it does **not** check — the join, the filter, the select list, the ordering
— is now stated on the page rather than implied away.

## Also

- `BuildsSharedQuery` replaces the `InComparison` flag, which marked the
  `Baseline` entrant as part of a comparison the page says it is not in.
- The benchmark page no longer cites EF Core's pipeline as a reason for the
  shape check; EF Core is printed, not checked.
- `BenchmarkDocsTests` compares the documented shape to the constants that
  enforce it, whitespace-normalised so the assertion tracks the claim rather
  than the line it wraps at.

## Verification

- Live PostgreSQL 16: pre-fix SQL errors, post-fix SQL returns SqlArtisan's rows
- Real BenchmarkDotNet run of the fixed entrant for the allocation figure above
- `dotnet run --project tests/SqlArtisan.Benchmark -c Release -- validate` — exit 0
- `dotnet test` — 824 / 614 / 132 passing (`llms-full.txt` regenerated for the
  README footnote; its byte-for-byte gate covers it)
- `dotnet format SqlArtisan.sln --verify-no-changes` — exit 0
- The four bundled docs scripts — green, SQL examples 100/100

Closes #382

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBXFM2WmG8tRiY9vWeqdn4)_