### PR TITLE
docs: Point SQLA0011 at the plan for the half it refuses to judge

### DIFF
--- a/docs/analyzer.md
+++ b/docs/analyzer.md
@@ -561,13 +561,6 @@ to range over. The remediation is the same in every case — leave the column ba
 on the filtered side and move the work to the other side, or index the expression
 itself, which the generator then records as unknown and the rule stops reporting.
 
-To learn what the planner actually did, ask the engine: run `sql.Text` with its
-bind parameters through your database's `EXPLAIN` (or its equivalent — SQL
-Server spells it `SET SHOWPLAN_XML ON`), against data of production-like volume.
-That last part is the whole condition: the choice turns on table sizes and
-statistics your test database does not have, so a plan read there describes that
-dataset rather than what production will do with the same query.
-
 Only `WHERE` and `ON` are checked. The same call in a select list or an
 `ORDER BY` costs no index, and `HAVING` filters groups after any index has done
 its work. A condition built apart from its clause is left alone: nothing at that
@@ -590,6 +583,13 @@ column that leads only a partial index stays unknown. On Oracle, one
 function-based index makes **every** column of that table record nothing — its
 expression text is stored in a form the tool does not read, so the whole table
 degrades to unknown rather than guess.
+
+To learn what the planner actually did, ask the engine: run `sql.Text` with its
+bind parameters through your database's `EXPLAIN` (or its equivalent — SQL
+Server spells it `SET SHOWPLAN_XML ON`), against data of production-like volume.
+That last part is the whole condition: the choice turns on table sizes and
+statistics your test database does not have, so a plan read there describes that
+dataset rather than what production will do with the same query.
 
 The sixth can change which rows come back, not just how fast they come back. A
 column compared to a value of another type category leaves the engine to

--- a/docs/analyzer.md
+++ b/docs/analyzer.md
@@ -561,6 +561,12 @@ to range over. The remediation is the same in every case — leave the column ba
 on the filtered side and move the work to the other side, or index the expression
 itself, which the generator then records as unknown and the rule stops reporting.
 
+To learn what the planner actually did, ask the engine: run `sql.Text` with its
+bind parameters through your database's `EXPLAIN` (or its equivalent), against
+data of production-like volume. Read it anywhere else and it will mislead you —
+on a small test dataset a full scan *is* the cheapest plan, so the answer says
+more about the row count than about the query.
+
 Only `WHERE` and `ON` are checked. The same call in a select list or an
 `ORDER BY` costs no index, and `HAVING` filters groups after any index has done
 its work. A condition built apart from its clause is left alone: nothing at that

--- a/docs/analyzer.md
+++ b/docs/analyzer.md
@@ -584,12 +584,15 @@ function-based index makes **every** column of that table record nothing — its
 expression text is stored in a form the tool does not read, so the whole table
 degrades to unknown rather than guess.
 
-To learn what the planner actually did, ask the engine: run `sql.Text` with its
-bind parameters through your database's `EXPLAIN` (or its equivalent — SQL
-Server spells it `SET SHOWPLAN_XML ON`), against data of production-like volume.
-That last part is the whole condition: the choice turns on table sizes and
-statistics your test database does not have, so a plan read there describes that
-dataset rather than what production will do with the same query.
+To learn what the planner actually did, ask the engine: feed `sql.Text` and its
+bind parameters to your engine's plan report, and read it against data of
+production-like volume. The spelling differs — MySQL `EXPLAIN`, Oracle
+`EXPLAIN PLAN` (which writes to `PLAN_TABLE` for you to read back), PostgreSQL
+`EXPLAIN`, SQLite `EXPLAIN QUERY PLAN` (plain `EXPLAIN` there returns bytecode),
+SQL Server the `SET SHOWPLAN_XML ON` session option. That volume condition is
+the whole of it: the choice turns on table sizes and statistics your test
+database does not have, so a plan read there describes that dataset rather than
+what production will do with the same query.
 
 The sixth can change which rows come back, not just how fast they come back. A
 column compared to a value of another type category leaves the engine to

--- a/docs/analyzer.md
+++ b/docs/analyzer.md
@@ -562,10 +562,11 @@ on the filtered side and move the work to the other side, or index the expressio
 itself, which the generator then records as unknown and the rule stops reporting.
 
 To learn what the planner actually did, ask the engine: run `sql.Text` with its
-bind parameters through your database's `EXPLAIN` (or its equivalent), against
-data of production-like volume. Read it anywhere else and it will mislead you —
-on a small test dataset a full scan *is* the cheapest plan, so the answer says
-more about the row count than about the query.
+bind parameters through your database's `EXPLAIN` (or its equivalent — SQL
+Server spells it `SET SHOWPLAN_XML ON`), against data of production-like volume.
+That last part is the whole condition: the choice turns on table sizes and
+statistics your test database does not have, so a plan read there describes that
+dataset rather than what production will do with the same query.
 
 Only `WHERE` and `ON` are checked. The same call in a select list or an
 `ORDER BY` costs no index, and `HAVING` filters groups after any index has done

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3559,10 +3559,11 @@ on the filtered side and move the work to the other side, or index the expressio
 itself, which the generator then records as unknown and the rule stops reporting.
 
 To learn what the planner actually did, ask the engine: run `sql.Text` with its
-bind parameters through your database's `EXPLAIN` (or its equivalent), against
-data of production-like volume. Read it anywhere else and it will mislead you —
-on a small test dataset a full scan *is* the cheapest plan, so the answer says
-more about the row count than about the query.
+bind parameters through your database's `EXPLAIN` (or its equivalent — SQL
+Server spells it `SET SHOWPLAN_XML ON`), against data of production-like volume.
+That last part is the whole condition: the choice turns on table sizes and
+statistics your test database does not have, so a plan read there describes that
+dataset rather than what production will do with the same query.
 
 Only `WHERE` and `ON` are checked. The same call in a select list or an
 `ORDER BY` costs no index, and `HAVING` filters groups after any index has done

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3581,12 +3581,15 @@ function-based index makes **every** column of that table record nothing — its
 expression text is stored in a form the tool does not read, so the whole table
 degrades to unknown rather than guess.
 
-To learn what the planner actually did, ask the engine: run `sql.Text` with its
-bind parameters through your database's `EXPLAIN` (or its equivalent — SQL
-Server spells it `SET SHOWPLAN_XML ON`), against data of production-like volume.
-That last part is the whole condition: the choice turns on table sizes and
-statistics your test database does not have, so a plan read there describes that
-dataset rather than what production will do with the same query.
+To learn what the planner actually did, ask the engine: feed `sql.Text` and its
+bind parameters to your engine's plan report, and read it against data of
+production-like volume. The spelling differs — MySQL `EXPLAIN`, Oracle
+`EXPLAIN PLAN` (which writes to `PLAN_TABLE` for you to read back), PostgreSQL
+`EXPLAIN`, SQLite `EXPLAIN QUERY PLAN` (plain `EXPLAIN` there returns bytecode),
+SQL Server the `SET SHOWPLAN_XML ON` session option. That volume condition is
+the whole of it: the choice turns on table sizes and statistics your test
+database does not have, so a plan read there describes that dataset rather than
+what production will do with the same query.
 
 The sixth can change which rows come back, not just how fast they come back. A
 column compared to a value of another type category leaves the engine to

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3558,13 +3558,6 @@ to range over. The remediation is the same in every case — leave the column ba
 on the filtered side and move the work to the other side, or index the expression
 itself, which the generator then records as unknown and the rule stops reporting.
 
-To learn what the planner actually did, ask the engine: run `sql.Text` with its
-bind parameters through your database's `EXPLAIN` (or its equivalent — SQL
-Server spells it `SET SHOWPLAN_XML ON`), against data of production-like volume.
-That last part is the whole condition: the choice turns on table sizes and
-statistics your test database does not have, so a plan read there describes that
-dataset rather than what production will do with the same query.
-
 Only `WHERE` and `ON` are checked. The same call in a select list or an
 `ORDER BY` costs no index, and `HAVING` filters groups after any index has done
 its work. A condition built apart from its clause is left alone: nothing at that
@@ -3587,6 +3580,13 @@ column that leads only a partial index stays unknown. On Oracle, one
 function-based index makes **every** column of that table record nothing — its
 expression text is stored in a form the tool does not read, so the whole table
 degrades to unknown rather than guess.
+
+To learn what the planner actually did, ask the engine: run `sql.Text` with its
+bind parameters through your database's `EXPLAIN` (or its equivalent — SQL
+Server spells it `SET SHOWPLAN_XML ON`), against data of production-like volume.
+That last part is the whole condition: the choice turns on table sizes and
+statistics your test database does not have, so a plan read there describes that
+dataset rather than what production will do with the same query.
 
 The sixth can change which rows come back, not just how fast they come back. A
 column compared to a value of another type category leaves the engine to

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3558,6 +3558,12 @@ to range over. The remediation is the same in every case — leave the column ba
 on the filtered side and move the work to the other side, or index the expression
 itself, which the generator then records as unknown and the rule stops reporting.
 
+To learn what the planner actually did, ask the engine: run `sql.Text` with its
+bind parameters through your database's `EXPLAIN` (or its equivalent), against
+data of production-like volume. Read it anywhere else and it will mislead you —
+on a small test dataset a full scan *is* the cheapest plan, so the answer says
+more about the row count than about the query.
+
 Only `WHERE` and `ON` are checked. The same call in a select list or an
 `ORDER BY` costs no index, and `HAVING` filters groups after any index has done
 its work. A condition built apart from its clause is left alone: nothing at that


### PR DESCRIPTION
SQLA0011's section states that cost questions stay out — "statistics and data volume are the optimizer's domain" — and then stops. The reader's next question ("so did it use the index or not?") had no answer on the page, which left the section ending on a refusal.

This adds one paragraph at the end of that section: where to get the answer, each engine's spelling for it, and the condition without which reading it misleads.

## Changes

- `docs/analyzer.md` — the new paragraph, closing SQLA0011's discussion.
- `llms-full.txt` — regenerated, since it embeds `docs/analyzer.md` verbatim and is gated byte-for-byte.

Two files, +20 lines. No code, no API, no behavior change.

## What this closes

**Closes #363**, which proposed a whole guide for this. Planning it out is what disqualified it: the content reduced to each engine's own documentation plus plain ADO.NET, against a standing maintenance cost here (the `llms-full.txt` byte-for-byte gate, index rows in `docs/README.md` and the root README, and five per-engine verification tests whose lanes would have to track each engine's spelling).

The CI-side variant does not rescue it either. Diff-only checking *is* achievable — the exact-SQL pins are the only enumerable inventory of a project's queries, so a textual diff identifies what changed with no connection — but time was never the blocker. A CI database is a fixture, and a plan read against it is about the wrong database no matter how few queries you read it for. The analyzer cannot carry it (Roslyn analyzers run on every keystroke and must not do I/O; the no-I/O input is exactly what makes SQLA0001–0012 deterministic), and a gate would need a threshold on plan shape — the cost judgment this project put permanently out of scope. Full reasoning in the issue's closing comment.

## Two claims this branch got wrong and corrected

Both were caught by adversarial review with live probes, not by reasoning:

1. **"On a small test dataset a full scan *is* the cheapest plan."** False on SQLite — it picks the index on a 3-row table, with or without `ANALYZE`, covering or not, and across 3/10/100/10000 rows the plan never moved while wrapping the column in `UPPER` changed it outright. The sentence also inverted this section's own thesis, crediting the row count for what the predicate's form decides. Replaced with the mechanism — the planner reads table sizes and statistics a test database does not have — which a follow-up probe confirmed: at a fixed 10000 rows, `sqlite_stat1` content alone flips the plan between `SEARCH … USING INDEX` and `SCAN`.

2. **"Your database's `EXPLAIN`."** Right on MySQL and PostgreSQL, wrong on the other three. SQLite answers plain `EXPLAIN` with VDBE bytecode rather than a plan (this repo's own code comments already spell `EXPLAIN QUERY PLAN` correctly); Oracle's `EXPLAIN PLAN` writes to `PLAN_TABLE` and returns nothing to read; SQL Server has no `EXPLAIN`, only the `SET SHOWPLAN_XML ON` session option. Naming one divergence and hedging the rest left two engines pointed at a wrong answer that still runs. All five spellings are now named, each verified against that vendor's own reference — SQLite's also against a live probe.

## Verification

- `dotnet test tests/SqlArtisan.Tests` — 831 passed, including `LlmsFullTests` (byte-for-byte) and `DocsIndexTests`
- `dotnet format SqlArtisan.sln --verify-no-changes` — clean
- Docs review scripts: `check_links.py`, `check_api_coverage.py`, `check_terms.py` all clean; `verify_sql_examples.py` — 100/100 examples match the real builder output
- Live probes: SQLite only (no Docker in the authoring environment). MySQL, Oracle, PostgreSQL and SQL Server spellings rest on vendor documentation, not a live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XJRCdF3y9xPu2EHy2qBfJ