### PR TITLE
chore(skills): Report only what you are asking someone to change

### DIFF
--- a/.claude/agents/sa-reviewer.md
+++ b/.claude/agents/sa-reviewer.md
@@ -37,9 +37,17 @@ not from how the change describes itself.
 - You review; you do not fix. Do not modify the repository, commit, push, or
   comment on GitHub. Repo-mutating Bash is off-limits — Bash is for read-only
   git commands, the gates, and the `/tmp` harness only.
-- Distinguish "must fix" (bugs, ADR violations, invalid/wrong SQL, policy
-  violations) from "discuss" (trade-offs the ADRs deliberately leave open).
-  A convention the rules permit is not a finding.
+- Report only what you would change. A convention the rules permit is not a
+  finding, and neither is anything you conclude is fine as is, already covered
+  elsewhere, or worth knowing but needing no action — it does not belong in the
+  report as a caveat, an observation, or a passing mention. Ask one question at
+  classification time: **am I asking for a change?** No means it does not
+  appear. **Returning no findings is a complete, good answer** — you are under
+  standing pressure to produce *something* to justify the run; do not.
+- The one exception is a genuine open decision only the author can settle (a
+  trade-off the ADRs deliberately leave open, or two valid fixes with different
+  costs). Phrase it as a question you are putting to them, not as a filed
+  observation.
 
 ## Adversarial-verification missions
 
@@ -70,3 +78,7 @@ and a one-paragraph summary. Then findings ordered by severity
 statement, and the concrete failure scenario — with the verbatim probe output
 that demonstrates it where one exists. End with what you verified empirically
 (dialects probed, gates run) so the caller knows the coverage of this review.
+
+When nothing needs changing, say so plainly and let the empirical-coverage
+section carry the report — that section is what makes "no findings"
+trustworthy, so it matters most exactly when the findings list is empty.

--- a/.claude/skills/sa-code-review-deep/SKILL.md
+++ b/.claude/skills/sa-code-review-deep/SKILL.md
@@ -49,3 +49,10 @@ Append a **Suggestions (optional, non-blocking)** zone after
 `sa-code-review`'s must-fix findings, each tagged `file:line`. Never mix a
 suggestion into the must-fix zone, and never let one block the mergeable
 verdict.
+
+A suggestion is still something you are proposing the author *do* — a change
+they could apply. An observation with no change attached ("worth knowing",
+"already fine") is not a suggestion and belongs nowhere in the report. **An
+empty suggestions zone is a normal result**: being invoked as the deep variant
+does not oblige you to find something, and inventing a suggestion to fill the
+zone costs the author more attention than it returns.

--- a/.claude/skills/sa-code-review/SKILL.md
+++ b/.claude/skills/sa-code-review/SKILL.md
@@ -235,6 +235,15 @@ contributor) — plus `CLAUDE.md`, `docs/adr/**`, `.claude/skills/**`,
   only whether the words stayed *true and complete*, not how many there are.
 - Any "better way to write this" suggestion with no rule/ADR/precedent to
   cite, for code or docs — run `sa-code-review-deep` for that pass instead.
+- **Anything you would not change.** If your own conclusion is "this is fine as
+  is", "already covered elsewhere", or "worth knowing but needs no action", the
+  classification is done and the answer is silence. Do not relabel it as a
+  caveat, an observation, a note, or a "weakest point" to keep it in the
+  report — a reader cannot act on it, and it dilutes the findings that need
+  action.
+
+The test at classification time is one question: **am I asking for a change?**
+No means it does not appear anywhere in the output.
 
 ## 9. Adversarial verification (final pass)
 
@@ -261,6 +270,12 @@ the draft, not a parallelizable search:
   in-repo primary sources but **cannot check a DBMS-vendor-spec / version /
   grammar claim** against the vendor's docs — keep those with the orchestrator's
   WebSearch, and don't read subagent silence on them as verification.
+- **Hold the subagent to §8's bar too**, and say so in its mission: it reports
+  what it would change, and "nothing falls" is a complete answer. A refuting
+  pass is under more pressure than any other to produce *something* — that is
+  exactly how non-actionable "worth the caller's attention" items get into a
+  report. Anything it returns that you would not act on is dropped, not
+  forwarded.
 - **Severity + evidence on every surviving finding** — High/Medium/Low plus
   the evidence that survived refutation: verbatim probe output or the
   primary source's `file:line`.
@@ -296,16 +311,28 @@ run exactly the one pass described above; that is correct for every model.
 
 ## Report
 
+**Report only what you are asking the author to change.** A finding earns its
+place by having a fix worth making; if you would not change it, it does not go
+in the report — not as a "discuss" item, not as an observation, not as a
+passing mention. **Zero findings is a normal, good result**, not a sign the
+review was shallow: say "no findings" and stop. A review that was asked for
+does not owe anyone a finding, and padding one out with things that need no
+action buries the ones that do.
+
+The one exception is a genuine **open decision only the author can settle** —
+a permissive-API trade-off the ADRs deliberately leave open, or two valid fixes
+with different costs. That is a question you are putting to them, not an
+observation you are filing; phrase it as a question and keep it to what
+actually blocks you.
+
 Lead with the verdict (mergeable or not) and a short list of recommended
 actions, most important first. Then every finding tagged with a `file:line`
 and severity (**High/Medium/Low**) — a doc gap can be Low severity and still
-must-fix; severity ranks the queue, it does not gate inclusion. Separate
-"must fix" (bugs, ADR violations, invalid SQL, any doc/comment gap from §8)
-from "discuss" (permissive-API trade-offs the ADRs deliberately leave to the
-author / analyzer). Include the adversarial pass's coverage: which claims
-were challenged, what survived, and the DEFECT / OVERREACH / INCONSISTENCY
-classification of what fell. This skill never reports non-defect improvement
-suggestions — re-run as `sa-code-review-deep` for those.
+must-fix; severity ranks the queue, it does not gate inclusion. Include the
+adversarial pass's coverage: which claims were challenged, and the DEFECT /
+OVERREACH / INCONSISTENCY classification of anything that fell — state
+survivals as one line, not an itemised list. This skill never reports
+non-defect improvement suggestions — re-run as `sa-code-review-deep` for those.
 
 Match the report's length to what the findings need: cover every finding at
 the detail level above, but do not pad with filler recap sections, restated

--- a/.claude/skills/sa-docs-review/SKILL.md
+++ b/.claude/skills/sa-docs-review/SKILL.md
@@ -153,7 +153,11 @@ text or memory. Surviving findings carry severity (High/Medium/Low) plus the
 evidence that survived refutation (verbatim probe output or the primary
 source's `file:line`). Fallen claims are classified **DEFECT** (factually
 wrong) / **OVERREACH** (true but misleading) / **INCONSISTENCY** (contradicts
-another surface).
+another surface). Tell the subagent that "nothing falls" is a complete
+answer and that it reports only what it would change — a refuting pass is
+under more pressure than any other to return *something*, which is how
+non-actionable "worth knowing" items reach a report. Drop anything it hands
+back that you would not act on; do not forward it.
 
 Recursion and fallback: if you *are* the adversarial subagent, skip this
 section — no recursion. If the Agent tool is unavailable — or the subagent
@@ -181,11 +185,24 @@ described above; that is correct for every model.
 
 ## Output
 
-Summarise per dimension (pass / findings), list concrete fixes with file:line,
-and state what was verified empirically (links resolve, N/N examples match,
-coverage clean). State which claims the adversarial pass challenged and what
-survived, with the DEFECT / OVERREACH / INCONSISTENCY classification of what
-fell. Re-run the relevant script after fixes to confirm green.
+**Report only what you are asking to change.** A finding earns its place by
+having a fix worth making. If your own conclusion is "this is fine", "already
+covered elsewhere", or "worth knowing but needs no action", it does not go in
+the report — not as a caveat, an observation, or a passing mention. **Zero
+findings is a normal, good result**, not evidence the review was shallow: say
+the docs are clean and stop. Being asked for a review does not oblige you to
+return a finding, and padding one out with non-actionable items buries the ones
+that need action. The test is one question — **am I asking for a change?** No
+means it does not appear.
+
+List concrete fixes with file:line, and state what was verified empirically
+(links resolve, N/N examples match, coverage clean) — that evidence is the
+report's substance when there are no findings. Give the per-dimension rundown
+only where a dimension produced a fix; a dimension that passed needs no
+paragraph. Name the DEFECT / OVERREACH / INCONSISTENCY classification of
+whatever the adversarial pass knocked down, and cover its survivals in one
+line rather than itemising them. Re-run the relevant script after fixes to
+confirm green.
 
 Match this report's length to what the findings need: cover every finding at
 the detail level above, but do not pad with filler recap sections, restated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,11 @@ sa-run-integration-tests, sa-run-sql-harness, sa-write-xml-docs.
   `docs/`, not in the README.
 - Comment the **why** / **why-not**, never the **what**; keep comments short. See
   `.claude/rules/code-comments.md`.
+- Report only what you are asking someone to change. Anything you would not
+  change — fine as is, already covered elsewhere, worth knowing but needing no
+  action — stays out entirely, under any label; **finding nothing is a good
+  result**, not a shallow one. Being asked to look does not oblige you to
+  return something.
 
 ## Git
 


### PR DESCRIPTION
## The problem

The review skills read as though a report owes its caller findings. Nothing said so outright, but `sa-code-review`'s Report section offered a "discuss" bucket beside "must fix", and `sa-docs-review` asked for a per-dimension rundown and a list of what the adversarial pass challenged and what survived. Together those make an empty report look like an unfinished one.

The result, in the review that prompted this: three items were filed under "discuss", and **two of them the reviewer had already concluded needed no fix** — a doc sentence judged complete as written because a global rule two paragraphs up already covered the case, and a behaviour change judged correct and verified harmless. Both were reported anyway, as things "worth the caller's attention". That is a decision handed back to the author to re-make, sitting in the same list as the item that did need action.

The adversarial pass is where this starts. A pass whose whole job is to refute is under more pressure than any other step to come back with *something*; when it finds nothing it reaches for "two Low items worth knowing", and the orchestrator forwards them rather than dropping them.

## The rule

One question at classification time: **am I asking for a change?** No means it does not appear anywhere in the output — not as a discuss item, a caveat, an observation, or a passing mention. **Finding nothing is a good result**, and the skills now say that in as many words, because the failure mode is a reviewer who believes silence reads as shallowness.

`discuss` narrows to what it was for: an open decision only the author can settle — a trade-off the ADRs deliberately leave open, or two valid fixes with different costs — phrased as a question being put to them, not an observation being filed.

## Changes

- **`CLAUDE.md`** — the bar as a project invariant. A skill only fires when it is invoked; answering "how does this look?" without one reaches none of the guidance below, and that is where the habit shows up too. It goes here rather than in `.claude/rules/`, which is auto-loaded by file path — a stance about what to report has no path to attach to.
- **`.claude/skills/sa-code-review/SKILL.md`** — the rule at the top of Report; a fifth bullet under §8's "Not a defect — do not report" covering anything you would not change, with the relabelling escape routes named so they are closed; and §9 now tells the orchestrator to hold the subagent to the same bar and drop what it would not act on.
- **`.claude/skills/sa-docs-review/SKILL.md`** — same rule in Output, plus: when there are no findings the empirical-coverage line *is* the report, and a dimension that passed needs no paragraph. Its adversarial-mission rules get the "nothing falls is a complete answer" instruction.
- **`.claude/skills/sa-code-review-deep/SKILL.md`** — an empty suggestions zone is a normal result; a suggestion is a change you are proposing, and an observation with no change attached is not one.
- **`.claude/agents/sa-reviewer.md`** — the agent that executes both passes gets the rule directly, since a skill instruction does not reach it when a caller writes its mission by hand. Its report guidance now covers the no-findings case: say so plainly and let the empirical-coverage section carry the report, which is exactly when that section matters most.

## Verification

Documentation only — no code, no tests, no gates to run. Checked for mojibake and trailing whitespace after editing (clean), kept the new `CLAUDE.md` bullet inside the 100-column limit, and confirmed the only surviving mention of a "discuss" bucket is the sentence that forbids using it as one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XJRCdF3y9xPu2EHy2qBfJ