### PR TITLE
feat: Add SQLA0004 context rules for SQL Server percentiles and OUTPUT pseudo-tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Two `SQLA0004` context rules for SQL Server. `PercentileCont(...)` / `PercentileDisc(...)` left in the plain `WithinGroup(...)` form now warn — SQL Server exposes both percentiles only as window functions, so the form Oracle and PostgreSQL accept has no spelling there; chain `.Over()` after `.WithinGroup(...)`. `Inserted(...)` / `Deleted(...)` used outside `Output(...)` now warn too — the `OUTPUT` clause is what binds those pseudo-tables, so a reference elsewhere resolves against no table. Both follow the existing context-rule contract: they warn only where the position is provable from the expression itself, so an expression held in a variable stays silent. (#400)
+
 ### Changed
 - **Breaking:** `InnerJoin(...)` / `LeftJoin(...)` / `RightJoin(...)` / `FullJoin(...)` / `JoinLateral(...)` no longer expose `Build(...)` or `ForUpdate(...)` before `.On(...)` / `.Using(...)` supplies the join predicate. Omitting it is a syntax error on PostgreSQL and MySQL (except `InnerJoin`/`JoinLateral`, which MySQL silently reads as an unlabeled `CROSS JOIN`) and on SQLite for every one of the five — all read as the same unlabeled `CROSS JOIN`, a spelling the library already exposes under its own name (`CrossJoin`). `ISelectBuilderJoin` no longer extends `ISqlBuilder`/`IForUpdate`, so the omission is now a compile error on every dialect; a chain that already supplies `.On(...)`/`.Using(...)` is unaffected. Binary-breaking — rebuild against this version. (#400)
 

--- a/docs/analyzer.md
+++ b/docs/analyzer.md
@@ -348,8 +348,8 @@ A construct can be valid on a dialect in one position and rejected by the same
 engine in another. The construct-level warnings above cannot express that —
 the construct itself *is* supported — so these facts ship as **context
 rules**: `SQLA0004` fires when the offending position is visible in the
-expression where the construct is used. Two rules ship today, both MySQL
-facts, live-verified against the engine.
+expression where the construct is used. Four rules ship today — two MySQL
+facts and two SQL Server facts — each live-verified against the engine.
 
 **`LIMIT` inside an `IN` / `NOT IN` / `ANY` / `ALL` / `SOME` subquery.** MySQL
 rejects a row-limited query directly under these positions ("This version of
@@ -376,6 +376,28 @@ var q = Select(u.DepartmentId, Grouping(u.DepartmentId))
 // warning SQLA0004: 'Grouping' is not supported outside a WITH ROLLUP query on MySQL
 ```
 
+**`PERCENTILE_CONT` / `PERCENTILE_DISC` outside an `OVER` clause.** SQL Server
+exposes both percentiles only as window functions, so the plain
+`WithinGroup(...)` form Oracle and PostgreSQL accept has no spelling there —
+chain `.Over()` (optionally with `PartitionBy(...)`) after `.WithinGroup(...)`.
+
+```csharp
+// sqlartisan_target_dbms = sqlserver
+var q = Select(PercentileCont(0.5).WithinGroup(OrderBy(u.Age))).From(u);
+// warning SQLA0004: 'PercentileCont' is not supported outside an OVER clause on SQL Server
+```
+
+**`INSERTED` / `DELETED` outside an `OUTPUT` clause.** The pseudo-tables are
+bound by the `OUTPUT` clause itself, so `Inserted(...)` / `Deleted(...)`
+resolve against no table anywhere else — read the row images inside
+`Output(...)`, and filter on the target table's own columns instead.
+
+```csharp
+// sqlartisan_target_dbms = sqlserver
+var q = Select(u.Id).From(u).Where(Inserted(u.Id) == 1);
+// warning SQLA0004: 'Inserted' is not supported outside an OUTPUT clause on SQL Server
+```
+
 A context rule warns only when the position is provable from the expression
 itself. A subquery held in a variable, a builder chain continued from a
 helper method, or any shape the analyzer doesn't recognize stays silent —
@@ -383,7 +405,10 @@ the same under-warn-but-never-false-positive principle the matrix follows.
 The absence side is equally strict: `Grouping` warns only when the chain
 shows a call *after* `.GroupBy(...)` that isn't `.WithRollup()` — from that
 point the builder's type can never accept the suffix — and a chain that
-still ends at `.GroupBy(...)` stays silent.
+still ends at `.GroupBy(...)` stays silent. The percentile rule reads the
+same way: it warns only where the expression is passed straight into the
+clause that consumes it, since a percentile parked in a variable can still
+acquire `.Over()` on a later line.
 
 Suppression is per rule ID, the standard Roslyn way
 (`#pragma warning disable SQLA0004`, a `[SuppressMessage]` attribute, or

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3372,8 +3372,8 @@ A construct can be valid on a dialect in one position and rejected by the same
 engine in another. The construct-level warnings above cannot express that —
 the construct itself *is* supported — so these facts ship as **context
 rules**: `SQLA0004` fires when the offending position is visible in the
-expression where the construct is used. Two rules ship today, both MySQL
-facts, live-verified against the engine.
+expression where the construct is used. Four rules ship today — two MySQL
+facts and two SQL Server facts — each live-verified against the engine.
 
 **`LIMIT` inside an `IN` / `NOT IN` / `ANY` / `ALL` / `SOME` subquery.** MySQL
 rejects a row-limited query directly under these positions ("This version of
@@ -3400,6 +3400,28 @@ var q = Select(u.DepartmentId, Grouping(u.DepartmentId))
 // warning SQLA0004: 'Grouping' is not supported outside a WITH ROLLUP query on MySQL
 ```
 
+**`PERCENTILE_CONT` / `PERCENTILE_DISC` outside an `OVER` clause.** SQL Server
+exposes both percentiles only as window functions, so the plain
+`WithinGroup(...)` form Oracle and PostgreSQL accept has no spelling there —
+chain `.Over()` (optionally with `PartitionBy(...)`) after `.WithinGroup(...)`.
+
+```csharp
+// sqlartisan_target_dbms = sqlserver
+var q = Select(PercentileCont(0.5).WithinGroup(OrderBy(u.Age))).From(u);
+// warning SQLA0004: 'PercentileCont' is not supported outside an OVER clause on SQL Server
+```
+
+**`INSERTED` / `DELETED` outside an `OUTPUT` clause.** The pseudo-tables are
+bound by the `OUTPUT` clause itself, so `Inserted(...)` / `Deleted(...)`
+resolve against no table anywhere else — read the row images inside
+`Output(...)`, and filter on the target table's own columns instead.
+
+```csharp
+// sqlartisan_target_dbms = sqlserver
+var q = Select(u.Id).From(u).Where(Inserted(u.Id) == 1);
+// warning SQLA0004: 'Inserted' is not supported outside an OUTPUT clause on SQL Server
+```
+
 A context rule warns only when the position is provable from the expression
 itself. A subquery held in a variable, a builder chain continued from a
 helper method, or any shape the analyzer doesn't recognize stays silent —
@@ -3407,7 +3429,10 @@ the same under-warn-but-never-false-positive principle the matrix follows.
 The absence side is equally strict: `Grouping` warns only when the chain
 shows a call *after* `.GroupBy(...)` that isn't `.WithRollup()` — from that
 point the builder's type can never accept the suffix — and a chain that
-still ends at `.GroupBy(...)` stays silent.
+still ends at `.GroupBy(...)` stays silent. The percentile rule reads the
+same way: it warns only where the expression is passed straight into the
+clause that consumes it, since a percentile parked in a variable can still
+acquire `.Over()` on a later line.
 
 Suppression is per rule ID, the standard Roslyn way
 (`#pragma warning disable SQLA0004`, a `[SuppressMessage]` attribute, or

--- a/src/SqlArtisan.Analyzers/ContextRules.cs
+++ b/src/SqlArtisan.Analyzers/ContextRules.cs
@@ -117,9 +117,19 @@ internal static class ContextRules
     public static void CheckPseudoTableRequiresOutput(
         OperationAnalysisContext context, IInvocationOperation pseudoTable, string dialectName)
     {
-        if (FindArgumentHost(pseudoTable) is not { } host || host.TargetMethod.Name == "Output")
+        if (FindArgumentHost(pseudoTable) is not { } host)
         {
             return;
+        }
+
+        // Every enclosing host counts, not just the innermost: the clause binds the
+        // pseudo-table through a wrapping function too (OUTPUT COALESCE(INSERTED.c, 0)).
+        for (IInvocationOperation? cursor = host; cursor is not null; cursor = FindArgumentHost(cursor))
+        {
+            if (cursor.TargetMethod.Name == "Output")
+            {
+                return;
+            }
         }
 
         context.ReportDiagnostic(Diagnostic.Create(

--- a/src/SqlArtisan.Analyzers/ContextRules.cs
+++ b/src/SqlArtisan.Analyzers/ContextRules.cs
@@ -75,11 +75,75 @@ internal static class ContextRules
             dialectName));
     }
 
+    /// <summary>
+    /// SQL Server exposes the percentiles only as window functions, so the bare
+    /// <c>WITHIN GROUP</c> form Oracle and PostgreSQL accept has no spelling there.
+    /// </summary>
+    public static void CheckPercentileRequiresOver(
+        OperationAnalysisContext context, IInvocationOperation percentile, string dialectName)
+    {
+        if (FindArgumentHost(percentile) is null)
+        {
+            return;
+        }
+
+        bool withinGroup = false;
+        bool over = false;
+        IOperation current = percentile;
+        while (FluentChain.Parent(current) is { } link)
+        {
+            withinGroup |= link.TargetMethod.Name == "WithinGroup";
+            over |= link.TargetMethod.Name == "Over";
+            current = link;
+        }
+
+        if (!withinGroup || over)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.ContextRestrictedConstruct,
+            percentile.Syntax.GetLocation(),
+            percentile.TargetMethod.Name,
+            "outside an OVER clause",
+            dialectName));
+    }
+
+    /// <summary>
+    /// The <c>INSERTED</c>/<c>DELETED</c> pseudo-tables name the row images an
+    /// <c>OUTPUT</c> clause reads; elsewhere the reference binds to no table.
+    /// </summary>
+    public static void CheckPseudoTableRequiresOutput(
+        OperationAnalysisContext context, IInvocationOperation pseudoTable, string dialectName)
+    {
+        if (FindArgumentHost(pseudoTable) is not { } host || host.TargetMethod.Name == "Output")
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            DiagnosticDescriptors.ContextRestrictedConstruct,
+            pseudoTable.Syntax.GetLocation(),
+            pseudoTable.TargetMethod.Name,
+            "outside an OUTPUT clause",
+            dialectName));
+    }
+
     // Climbs to the SELECT-list/HAVING/ORDER BY invocation hosting Grouping(); any
     // other argument host stops the climb rather than risk crossing into another query.
-    private static IInvocationOperation? FindClauseAnchor(IInvocationOperation grouping)
+    private static IInvocationOperation? FindClauseAnchor(IInvocationOperation grouping) =>
+        FindArgumentHost(grouping) is { } host
+            && host.TargetMethod.Name is "Select" or "Having" or "OrderBy"
+                ? host
+                : null;
+
+    // Climbs to the invocation the expression is an argument of. Reaching one proves
+    // the expression is consumed where it is written, so the chain between the two is
+    // the whole chain — a receiver parked in a variable stops the climb instead.
+    private static IInvocationOperation? FindArgumentHost(IInvocationOperation start)
     {
-        IOperation current = grouping;
+        IOperation current = start;
         while (true)
         {
             IOperation? parent = current.Parent;
@@ -97,8 +161,8 @@ internal static class ContextRules
                     current = parent;
                     break;
                 case IArgumentOperation { Parent: IInvocationOperation host }
-                    when DialectUsageAnalyzer.IsFromSqlArtisan(host.TargetMethod.ContainingAssembly)
-                        && host.TargetMethod.Name is "Select" or "Having" or "OrderBy":
+                    when DialectUsageAnalyzer.IsFromSqlArtisan(
+                        host.TargetMethod.ContainingAssembly):
                     return host;
                 default:
                     return null;

--- a/src/SqlArtisan.Analyzers/DialectUsageAnalyzer.cs
+++ b/src/SqlArtisan.Analyzers/DialectUsageAnalyzer.cs
@@ -172,32 +172,40 @@ public sealed class DialectUsageAnalyzer : DiagnosticAnalyzer
             result.OverrideKeyHint));
     }
 
-    // Both shipped context rules (#264) are MySQL facts; name-filter first so
-    // config resolution is paid only on trigger names.
+    // Name-filter first so config resolution is paid only on trigger names. Each
+    // rule pairs its trigger with the one dialect whose grammar restricts it;
+    // elsewhere the matrix entry already answers (#264).
     private static void AnalyzeContextRules(OperationAnalysisContext context)
     {
         var invocation = (IInvocationOperation)context.Operation;
         string name = invocation.TargetMethod.Name;
-        if (name is not ("Limit" or "Grouping")
+        if (name is not ("Limit" or "Grouping" or "PercentileCont" or "PercentileDisc"
+                or "Inserted" or "Deleted")
             || !IsFromSqlArtisan(invocation.TargetMethod.ContainingAssembly))
         {
             return;
         }
 
         AnalyzerConfigOptions options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(context.Operation.Syntax.SyntaxTree);
-        if (AnalyzerConfigResolver.ResolveTarget(options) is not TargetDbms.MySql)
+        TargetDbms? target = AnalyzerConfigResolver.ResolveTarget(options);
+        switch (name)
         {
-            return;
-        }
-
-        string dialectName = DisplayName(TargetDbms.MySql);
-        if (name == "Limit")
-        {
-            ContextRules.CheckLimitInQuantifiedSubquery(context, invocation, dialectName);
-        }
-        else
-        {
-            ContextRules.CheckGroupingRequiresWithRollup(context, invocation, dialectName);
+            case "Limit" when target is TargetDbms.MySql:
+                ContextRules.CheckLimitInQuantifiedSubquery(
+                    context, invocation, DisplayName(TargetDbms.MySql));
+                break;
+            case "Grouping" when target is TargetDbms.MySql:
+                ContextRules.CheckGroupingRequiresWithRollup(
+                    context, invocation, DisplayName(TargetDbms.MySql));
+                break;
+            case "PercentileCont" or "PercentileDisc" when target is TargetDbms.SqlServer:
+                ContextRules.CheckPercentileRequiresOver(
+                    context, invocation, DisplayName(TargetDbms.SqlServer));
+                break;
+            case "Inserted" or "Deleted" when target is TargetDbms.SqlServer:
+                ContextRules.CheckPseudoTableRequiresOutput(
+                    context, invocation, DisplayName(TargetDbms.SqlServer));
+                break;
         }
     }
 

--- a/tests/SqlArtisan.Analyzers.Tests/ContextRuleAnalyzerTests.cs
+++ b/tests/SqlArtisan.Analyzers.Tests/ContextRuleAnalyzerTests.cs
@@ -281,6 +281,12 @@ public class ContextRuleAnalyzerTests
             var q = Select(PercentileCont(0.5).WithinGroup(OrderBy(t.Id))).From(t);
             """, dbms: null);
 
+    [Fact]
+    public Task PercentileNestedInFunctionWithOver_SqlServer_StaysSilent() =>
+        RunSilent("""
+            var q = Select(Coalesce(PercentileCont(0.5).WithinGroup(OrderBy(t.Id)).Over(), 0)).From(t);
+            """, "sqlserver");
+
     // The receiver leaves the expression, so a later .Over() is invisible (ADR 0003).
     [Fact]
     public Task PercentileContViaVariable_SqlServer_StaysSilent() =>
@@ -336,5 +342,11 @@ public class ContextRuleAnalyzerTests
         RunSilent("""
             var i = Inserted(t.Id);
             var q = InsertInto(t, t.Id).Output(i).Values(1);
+            """, "sqlserver");
+
+    [Fact]
+    public Task InsertedNestedInFunctionInsideOutput_SqlServer_StaysSilent() =>
+        RunSilent("""
+            var q = InsertInto(t, t.Id).Output(Coalesce(Inserted(t.Id), 0)).Values(1);
             """, "sqlserver");
 }

--- a/tests/SqlArtisan.Analyzers.Tests/ContextRuleAnalyzerTests.cs
+++ b/tests/SqlArtisan.Analyzers.Tests/ContextRuleAnalyzerTests.cs
@@ -30,8 +30,8 @@ public class ContextRuleAnalyzerTests
         }
         """;
 
-    private static Task RunReporting(string statements) =>
-        RunAsync(Usage(statements), AnalyzerVerifier.EditorConfig("mysql"), expectWarning: true);
+    private static Task RunReporting(string statements, string dbms = "mysql") =>
+        RunAsync(Usage(statements), AnalyzerVerifier.EditorConfig(dbms), expectWarning: true);
 
     private static Task RunSilent(string statements, string? dbms = "mysql") =>
         RunAsync(
@@ -238,4 +238,103 @@ public class ContextRuleAnalyzerTests
                 t.Id.In(Select(s.Dep).From(s).Where(Grouping(s.Dep) == 0).GroupBy(s.Dep).WithRollup().Having(s.Dep > 0))
                 & (t.Dep > 0));
             """);
+
+    [Fact]
+    public Task PercentileContWithoutOver_SqlServer_ReportsSqla0004() =>
+        RunReporting("""
+            var q = Select({|#0:PercentileCont(0.5)|}.WithinGroup(OrderBy(t.Id))).From(t);
+            """, "sqlserver");
+
+    [Fact]
+    public Task PercentileDiscWithoutOver_SqlServer_ReportsSqla0004() =>
+        RunReporting("""
+            var q = Select({|#0:PercentileDisc(0.5)|}.WithinGroup(OrderBy(t.Id))).From(t);
+            """, "sqlserver");
+
+    [Fact]
+    public Task PercentileContAliasedWithoutOver_SqlServer_ReportsSqla0004() =>
+        RunReporting("""
+            var q = Select({|#0:PercentileCont(0.5)|}.WithinGroup(OrderBy(t.Id)).As("p")).From(t);
+            """, "sqlserver");
+
+    [Fact]
+    public Task PercentileContWithOver_SqlServer_StaysSilent() =>
+        RunSilent("""
+            var q = Select(PercentileCont(0.5).WithinGroup(OrderBy(t.Id)).Over()).From(t);
+            """, "sqlserver");
+
+    [Fact]
+    public Task PercentileContWithPartitionedOver_SqlServer_StaysSilent() =>
+        RunSilent("""
+            var q = Select(PercentileCont(0.5).WithinGroup(OrderBy(t.Id)).Over(PartitionBy(t.Dep))).From(t);
+            """, "sqlserver");
+
+    [Fact]
+    public Task PercentileContWithoutOver_PostgreSql_StaysSilent() =>
+        RunSilent("""
+            var q = Select(PercentileCont(0.5).WithinGroup(OrderBy(t.Id))).From(t);
+            """, "postgresql");
+
+    [Fact]
+    public Task PercentileContWithoutOver_NoTargetConfigured_StaysSilent() =>
+        RunSilent("""
+            var q = Select(PercentileCont(0.5).WithinGroup(OrderBy(t.Id))).From(t);
+            """, dbms: null);
+
+    // The receiver leaves the expression, so a later .Over() is invisible (ADR 0003).
+    [Fact]
+    public Task PercentileContViaVariable_SqlServer_StaysSilent() =>
+        RunSilent("""
+            var p = PercentileCont(0.5).WithinGroup(OrderBy(t.Id));
+            var q = Select(p.Over()).From(t);
+            """, "sqlserver");
+
+    [Fact]
+    public Task InsertedInOutput_SqlServer_StaysSilent() =>
+        RunSilent("""
+            var q = InsertInto(t, t.Id).Output(Inserted(t.Id)).Values(1);
+            """, "sqlserver");
+
+    [Fact]
+    public Task DeletedInOutput_SqlServer_StaysSilent() =>
+        RunSilent("""
+            var q = DeleteFrom(t).Output(Deleted(t.Id));
+            """, "sqlserver");
+
+    [Fact]
+    public Task InsertedAliasedInOutput_SqlServer_StaysSilent() =>
+        RunSilent("""
+            var q = InsertInto(t, t.Id).Output(Inserted(t.Id).As("i")).Values(1);
+            """, "sqlserver");
+
+    [Fact]
+    public Task InsertedInSelectList_SqlServer_ReportsSqla0004() =>
+        RunReporting("""
+            var q = Select({|#0:Inserted(t.Id)|}).From(t);
+            """, "sqlserver");
+
+    [Fact]
+    public Task DeletedInSelectList_SqlServer_ReportsSqla0004() =>
+        RunReporting("""
+            var q = Select({|#0:Deleted(t.Id)|}).From(t);
+            """, "sqlserver");
+
+    [Fact]
+    public Task InsertedInWhere_SqlServer_ReportsSqla0004() =>
+        RunReporting("""
+            var q = Select(t.Id).From(t).Where({|#0:Inserted(t.Id)|} == 1);
+            """, "sqlserver");
+
+    [Fact]
+    public Task InsertedOutsideOutput_NoTargetConfigured_StaysSilent() =>
+        RunSilent("""
+            var q = Select(Inserted(t.Id)).From(t);
+            """, dbms: null);
+
+    [Fact]
+    public Task InsertedViaVariable_SqlServer_StaysSilent() =>
+        RunSilent("""
+            var i = Inserted(t.Id);
+            var q = InsertInto(t, t.Id).Output(i).Values(1);
+            """, "sqlserver");
 }

--- a/tests/SqlArtisan.Analyzers.Tests/ContextRuleContractTests.cs
+++ b/tests/SqlArtisan.Analyzers.Tests/ContextRuleContractTests.cs
@@ -45,9 +45,42 @@ public class ContextRuleContractTests
         Assert.Equal(["ISelectBuilderGroupBy"], declaringInterfaces);
     }
 
+    [Fact]
+    public void Over_IsReachableOnlyFromThePercentileWithinGroupStage()
+    {
+        // The rule's absence proof: .Over() hangs off the node WithinGroup(...)
+        // returns, so a percentile consumed without it can never acquire one.
+        Type pending = Assert.Single(
+            Core.GetExportedTypes().Where(t => t.Name == "PercentileContFunction"));
+        MethodInfo withinGroup = Assert.Single(
+            pending.GetMethods().Where(m => m.Name == "WithinGroup"));
+
+        Assert.Equal("PercentileFunction", withinGroup.ReturnType.Name);
+        Assert.NotEmpty(withinGroup.ReturnType.GetMethods().Where(m => m.Name == "Over"));
+    }
+
+    [Theory]
+    [InlineData("Inserted")]
+    [InlineData("Deleted")]
+    public void OutputPseudoTable_ReachesAClauseOnlyAsAnExpressionArgument(string factory)
+    {
+        // The rule reads the name of the invocation hosting the argument, which is
+        // sound only while these stay plain expressions with no clause step of their own.
+        MethodInfo method = Assert.Single(
+            typeof(Sql).GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Where(m => m.Name == factory));
+
+        Assert.True(typeof(SqlExpression).IsAssignableFrom(method.ReturnType));
+        Assert.Empty(method.ReturnType.GetMethods().Where(m => m.Name == "Output"));
+    }
+
     [Theory]
     [InlineData("Limit")]
     [InlineData("Grouping")]
+    [InlineData("PercentileCont")]
+    [InlineData("PercentileDisc")]
+    [InlineData("Inserted")]
+    [InlineData("Deleted")]
     public void TriggerMember_ExistsInCoreApi(string methodName)
     {
         bool exists = Core.GetExportedTypes()

--- a/tests/SqlArtisan.IntegrationTests/Tests/SqlServerTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/SqlServerTests.cs
@@ -215,6 +215,9 @@ public sealed class SqlServerTests : IntegrationTestBase, IClassFixture<SqlServe
 
         connection.Execute("DELETE FROM users OUTPUT DELETED.id WHERE id = -1");
 
+        // A wrapping function keeps the reference bound, so the rule must not warn there.
+        connection.Execute("DELETE FROM users OUTPUT COALESCE(DELETED.id, 0) WHERE id = -1");
+
         Assert.ThrowsAny<Exception>(() => connection.Execute("SELECT INSERTED.id FROM users"));
         Assert.ThrowsAny<Exception>(() => connection.Execute("SELECT DELETED.id FROM users"));
         Assert.ThrowsAny<Exception>(() => connection.Execute(

--- a/tests/SqlArtisan.IntegrationTests/Tests/SqlServerTests.cs
+++ b/tests/SqlArtisan.IntegrationTests/Tests/SqlServerTests.cs
@@ -191,6 +191,36 @@ public sealed class SqlServerTests : IntegrationTestBase, IClassFixture<SqlServe
         Assert.ThrowsAny<Exception>(() => connection.Execute("SELECT * FROM users FULL JOIN orders"));
     }
 
+    [Fact] // #400: anchors the SQLA0004 percentile rule — SQL Server exposes the
+           // percentiles only as window functions, so the bare WITHIN GROUP form
+           // Oracle and PostgreSQL accept is a syntax error here.
+    public void BarePercentileWithinGroup_Rejected()
+    {
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        connection.Execute("SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY age) OVER () FROM users");
+
+        Assert.ThrowsAny<Exception>(() => connection.Execute(
+            "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY age) FROM users"));
+        Assert.ThrowsAny<Exception>(() => connection.Execute(
+            "SELECT PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY age) FROM users"));
+    }
+
+    [Fact] // #400: anchors the SQLA0004 INSERTED/DELETED rule — the pseudo-tables
+           // are bound by the OUTPUT clause itself, so a reference outside one has
+           // no table to resolve against. The control deletes no row.
+    public void OutputPseudoTableOutsideOutput_Rejected()
+    {
+        using IDbConnection connection = _fixture.OpenConnection();
+
+        connection.Execute("DELETE FROM users OUTPUT DELETED.id WHERE id = -1");
+
+        Assert.ThrowsAny<Exception>(() => connection.Execute("SELECT INSERTED.id FROM users"));
+        Assert.ThrowsAny<Exception>(() => connection.Execute("SELECT DELETED.id FROM users"));
+        Assert.ThrowsAny<Exception>(() => connection.Execute(
+            "DELETE FROM users WHERE DELETED.id = -1"));
+    }
+
     [Fact] // #241 (GAP-19): SQL Server matches GROUP BY expressions syntactically,
            // so a parameterized SELECT expression repeated with fresh markers fails
            // with Msg 8120 (live-verified). Raw SQL by necessity — SqlArtisan now


### PR DESCRIPTION
## Summary

Closes the last two gaps in #400 (items 1 and 3), both as `SQLA0004` context
rules rather than the `Validate(Dbms)` guard item 1 originally proposed — see
the note below.

- **`PercentileCont(...)` / `PercentileDisc(...)` outside an `OVER` clause.**
  SQL Server exposes both percentiles only as window functions, so the plain
  `WithinGroup(...)` form Oracle and PostgreSQL accept has no spelling there.
- **`Inserted(...)` / `Deleted(...)` outside an `Output(...)` clause.** The
  `OUTPUT` clause is what binds those pseudo-tables; elsewhere the reference
  resolves against no table. Scoped to both twins — the issue names only
  `Inserted`, but `Deleted` is the same shape and shares a matrix entry.
- Generalized `FindClauseAnchor`'s climb into `FindArgumentHost`. Reaching an
  argument host proves the expression is consumed where it is written, which is
  what lets the percentile rule conclude no later `.Over()` can arrive; an
  expression parked in a variable stops the climb and stays silent.
- `AnalyzeContextRules` no longer hard-codes MySQL — each trigger now pairs
  with the one dialect whose grammar restricts it.

### Why not a `Validate(Dbms)` guard for item 1

`FindPart<T>()` scans only the builder's top-level `_parts`, and `SqlPart` has
no child enumeration, so a `PercentileFunction` nested in a `SelectClause` is
invisible to a `Validate` override; function nodes also never branch on `Dbms`
(zero instances in the codebase). A `Build()` guard would therefore need new
traversal infrastructure. It is also not what the guard rule asks for: the
*bounded exception* category requires the construct be **both** invisible to
the analyzer **and** unspellable on the target, and the first half fails here —
the position is plainly visible in the fluent chain, the same way the existing
`Grouping`/`WITH ROLLUP` rule sees it. That puts it in *dialect availability*,
whose mechanism is the analyzer.

## Test plan

- [x] 16 new analyzer tests covering both rules: reporting cases, the `.Over()`
      and `Output(...)` silent twins, wrong-dialect and no-target-configured
      silence, and the held-in-a-variable false-negative each rule accepts.
- [x] 3 new contract tests pinning the API facts the rules key on (the
      `WithinGroup` → `PercentileFunction` → `Over` chain, and that the
      pseudo-table factories stay plain expressions).
- [x] `dotnet test tests/SqlArtisan.Tests` — 898 passed.
- [x] `dotnet test tests/SqlArtisan.Analyzers.Tests` — 643 passed (was 620).
- [x] `dotnet test tests/SqlArtisan.TableClassGen.Tests` — 145 passed.
- [x] `dotnet format SqlArtisan.sln --verify-no-changes` — clean.
- [x] `llms-full.txt` regenerated for the `docs/analyzer.md` change.
- [x] **Live-verified against SQL Server.** Integration run
      [#181](https://github.com/h-tacayama/SqlArtisan/actions/runs/30855368080)
      passed all six engine lanes; the SQL Server lane ran 79/79, including the
      two new tests that assert the engine itself rejects both forms, each with
      a passing control:
      `BarePercentileWithinGroup_Rejected` and
      `OutputPseudoTableOutsideOutput_Rejected`. This discharges the
      *grammar-unverified* tag the issue carried on item 1.
