### PR TITLE
docs: Record why Interval/Timestampadd/Timestampdiff stay permissive under ADR 0012

### DIFF
--- a/docs/adr/0012-value-domain-guards.md
+++ b/docs/adr/0012-value-domain-guards.md
@@ -53,7 +53,12 @@ all three of the following hold:
 3. **Dialect-independent.** The guard fires before any `Dbms` is chosen and
    behaves identically for every target — it encodes no per-engine knowledge. A
    domain any engine widens or narrows disqualifies the guard; divergent domains
-   stay permissive (analyzer / database).
+   stay permissive (analyzer / database). This turns on the domain's *source*,
+   not on how many dialects the construct supports: a single-dialect function
+   still fails this condition if its accepted set is copied from that vendor's
+   own grammar table rather than fixed by the construct's own definition — a
+   later revision to that table could turn a rejection into a false positive,
+   which condition 1 requires to be structurally impossible (#454).
 
 The message follows the guard grammar (names the construct, states the
 requirement) and is exact-message tested:
@@ -83,6 +88,20 @@ other value is invalid everywhere (#448).
 
 ## Consequences
 
+- **`Interval`/`Timestampadd`/`Timestampdiff`'s `unit` deliberately stays
+  permissive (`SQLA0104`-only), unlike `Numtoyminterval`'s/`Numtodsinterval`'s
+  eager guard above, and this is not scheduled for unification (#454).**
+  `Numtoyminterval`'s `YEAR`/`MONTH` restriction is the function's own
+  definition — no Oracle revision can widen it without changing what the
+  function means. MySQL's unit sets in `DatepartValidity` are copied from a
+  vendor grammar table that has itself changed across releases (`MICROSECOND`
+  was added, `FRAC_SECOND` deprecated), so the same value could become valid
+  on a newer engine — condition 1's false positive is not structurally
+  impossible there, only currently absent. An eager guard has no version dial
+  to express that; `SQLA0104`'s per-(member, dialect) table already is one. The
+  two functions' argument sets look identical in shape (a literal
+  `DateTimePart`) but differ in this one respect, which is why they take
+  different routes.
 - **ADR 0007's dividing test is unchanged; its rationale now covers both ways
   to land on "no".** A construct can be valid nowhere because a mandatory
   element is missing (incomplete — ADR 0007) or because an embedded value lies

--- a/docs/adr/0012-value-domain-guards.md
+++ b/docs/adr/0012-value-domain-guards.md
@@ -53,12 +53,12 @@ all three of the following hold:
 3. **Dialect-independent.** The guard fires before any `Dbms` is chosen and
    behaves identically for every target — it encodes no per-engine knowledge. A
    domain any engine widens or narrows disqualifies the guard; divergent domains
-   stay permissive (analyzer / database). This turns on the domain's *source*,
-   not on how many dialects the construct supports: a single-dialect function
-   still fails this condition if its accepted set is copied from that vendor's
-   own grammar table rather than fixed by the construct's own definition — a
-   later revision to that table could turn a rejection into a false positive,
-   which condition 1 requires to be structurally impossible (#454).
+   stay permissive (analyzer / database). Dialect *count* does not decide this:
+   the dividing question is whether the domain is closed — fixed by the
+   construct's own definition or by a standard grammar unlikely to grow — or
+   open, a vendor's own accepted-value list that has changed, or could still
+   change, release to release. A domain attributed to "a vendor's grammar" can
+   still be closed in this sense (#454).
 
 The message follows the guard grammar (names the construct, states the
 requirement) and is exact-message tested:
@@ -97,11 +97,14 @@ other value is invalid everywhere (#448).
   vendor grammar table that has itself changed across releases (`MICROSECOND`
   was added, `FRAC_SECOND` deprecated), so the same value could become valid
   on a newer engine — condition 1's false positive is not structurally
-  impossible there, only currently absent. An eager guard has no version dial
-  to express that; `SQLA0104`'s per-(member, dialect) table already is one. The
-  two functions' argument sets look identical in shape (a literal
-  `DateTimePart`) but differ in this one respect, which is why they take
-  different routes.
+  impossible there, only currently absent. An eager guard, fixed before any
+  `Dbms` or version is known, would have to commit to one accepted set forever
+  and either over-reject a newer engine or under-reject an older one;
+  `SQLA0104`'s per-(member, dialect) table is a plain data set an analyzer
+  release can revise without touching the shipped throw behavior at all — the
+  reason this one stays a diagnostic rather than an exception. The two
+  functions' argument sets look identical in shape (a literal `DateTimePart`)
+  but differ in this one respect, which is why they take different routes.
 - **ADR 0007's dividing test is unchanged; its rationale now covers both ways
   to land on "no".** A construct can be valid nowhere because a mandatory
   element is missing (incomplete — ADR 0007) or because an embedded value lies


### PR DESCRIPTION
## Summary

- Closes #454. Records why `Interval`/`Timestampadd`/`Timestampdiff`'s `unit` argument stays on the permissive/`SQLA0104` side rather than getting an eager `ArgumentException` guard like `Numtoyminterval`/`Numtodsinterval`'s `interval_unit`.
- Clarifies ADR 0012's condition 3 (dialect-independent): the dividing question is the accepted set's *source* (the construct's own definition vs. a vendor grammar table), not how many dialects support the construct.
- Adds a Consequences entry explaining the two functions' argument sets look identical in shape (a literal `DateTimePart`) but differ in this respect: `Numtoyminterval`'s `YEAR`/`MONTH` restriction is fixed by the function's own definition, while MySQL's unit sets are copied from a vendor grammar table that has itself changed release to release (`MICROSECOND` added, `FRAC_SECOND` deprecated) — an eager guard there risks turning a future-valid unit into a false positive, which condition 1 rules out. `SQLA0104`'s per-(member, dialect) table is the mechanism that can absorb such a revision.
- States explicitly that unification of the two mechanisms is not scheduled — this closes the open question rather than deferring it to a follow-up issue.

## Test plan

- [x] `dotnet build SqlArtisan.sln`
- [x] `dotnet test tests/SqlArtisan.Tests` (1013 passed)
- [x] `dotnet test tests/SqlArtisan.Analyzers.Tests` (821 passed)
- Docs-only change (`docs/adr/0012-value-domain-guards.md`); no source files touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_0135KrZuGz9NcX6a1nXmLA22)_