### PR TITLE
docs: State the full supported-dialect set on seven remarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Docs
+- Eight `<remarks>` that never stated their member's full supported-dialect set
+  now do: `Ceil`, `Ceiling`, `Concat(a, b, c, params object[])`, `Excluded`,
+  `MergeInto`, `Round(object)`, and `Separator` each named only a spelling
+  caveat or an *unsupported* dialect, and `CosineDistance` was missing its
+  Oracle 23ai+ floor entirely (docs/expressions.md already had it). Retiring
+  each from `XmlDocDialectParityTests`' `ExcludedMembers` catalog needed the
+  parity test itself to stop reading a version-gated dialect as unsupported —
+  `SupportedDialects` now agrees with any dialect carrying a
+  `DialectMatrix` version-bound row, mirroring the analyzer's own
+  `DialectSupportResolver.Evaluate` (a bound overrides the baseline bool in
+  both directions), so a remark naming a floored dialect like `Oracle (23ai+)`
+  parses to agreement instead of tripping the gate. `ExcludedMembers` shrinks
+  from 18 entries to 10, all four of the remaining non-version ones a matrix
+  key that unions two distinct APIs and so can never be retired by rewording;
+  the swept member count grows from 124 to 132. (#474)
 - `XmlDocDialectParityTests`' positive-list branch — "A, B, and C syntax." =
   exactly the named set — now scopes to its own clause the same way #469
   scoped the exclusion branch, and also recognizes "Not available on X"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Docs
 - Eight `<remarks>` that never stated their member's full supported-dialect set
-  now do: `Ceil`, `Ceiling`, `Concat(a, b, c, params object[])`, `Excluded`,
-  `MergeInto`, `Round(object)`, and `Separator` each named only a spelling
-  caveat or an *unsupported* dialect, and `CosineDistance` was missing its
-  Oracle 23ai+ floor entirely (docs/expressions.md already had it). Retiring
-  each from `XmlDocDialectParityTests`' `ExcludedMembers` catalog needed the
-  parity test itself to stop reading a version-gated dialect as unsupported —
-  `SupportedDialects` now agrees with any dialect carrying a
-  `DialectMatrix` version-bound row, mirroring the analyzer's own
-  `DialectSupportResolver.Evaluate` (a bound overrides the baseline bool in
-  both directions), so a remark naming a floored dialect like `Oracle (23ai+)`
-  parses to agreement instead of tripping the gate. `ExcludedMembers` shrinks
-  from 18 entries to 10, all four of the remaining non-version ones a matrix
-  key that unions two distinct APIs and so can never be retired by rewording;
-  the swept member count grows from 124 to 132. (#474)
+  now do: `Ceil`, `Ceiling`, `Concat(a, b, c, params object[])`,
+  `CosineDistance`, `Excluded`, `MergeInto`, `Round(object)`, and `Separator`.
+  Each named some mix of a spelling caveat, a dialect it is *not* supported on,
+  and part of its supported set, leaving a reader unable to tell from the
+  remark alone what runs where — `Ceil` never named Oracle, `Round(object)`
+  named only the SQL Server it is unsupported on, and `CosineDistance` omitted
+  the Oracle 23ai+ floor `docs/expressions.md` already carried. `CosineDistance`
+  also needed the parity test to stop reading a version-gated dialect as
+  unsupported: `SupportedDialects` now counts any dialect carrying a
+  `DialectMatrix` version-bound row, matching how the analyzer resolves one once
+  a target declares a version. The other seven retire under the unchanged
+  comparison. `XmlDocDialectParityTests`' `ExcludedMembers` catalog shrinks from
+  18 entries to 10 — four of them a matrix key that unions two distinct APIs,
+  which no single remark can represent — and the swept member count grows from
+  124 to 132. (#474)
 - `XmlDocDialectParityTests`' positive-list branch — "A, B, and C syntax." =
   exactly the named set — now scopes to its own clause the same way #469
   scoped the exclusion branch, and also recognizes "Not available on X"

--- a/src/SqlArtisan/Sql/Sql.C.cs
+++ b/src/SqlArtisan/Sql/Sql.C.cs
@@ -455,9 +455,10 @@ public static partial class Sql
     /// <paramref name="expr"/>).
     /// </summary>
     /// <remarks>
-    /// Emitted verbatim as <c>CEIL</c> on every DBMS. SQL Server spells this
-    /// function <c>CEILING</c>; use <see cref="Ceiling(object)"/> for that
-    /// target. MySQL, PostgreSQL, and SQLite accept both spellings.
+    /// MySQL, Oracle, PostgreSQL, and SQLite (3.35+) syntax — emitted verbatim
+    /// as <c>CEIL</c>. SQL Server spells this function <c>CEILING</c>; use
+    /// <see cref="Ceiling(object)"/> for that target. MySQL, PostgreSQL, and
+    /// SQLite accept both spellings.
     /// </remarks>
     public static CeilFunction Ceil(object expr) =>
         new(Resolve(expr));
@@ -467,9 +468,10 @@ public static partial class Sql
     /// <paramref name="expr"/>).
     /// </summary>
     /// <remarks>
-    /// Emitted verbatim as <c>CEILING</c> on every DBMS. Oracle spells this
-    /// function <c>CEIL</c>; use <see cref="Ceil(object)"/> for that target.
-    /// MySQL, PostgreSQL, and SQLite accept both spellings.
+    /// MySQL, PostgreSQL, SQLite (3.35+), and SQL Server syntax — emitted
+    /// verbatim as <c>CEILING</c>. Oracle spells this function <c>CEIL</c>; use
+    /// <see cref="Ceil(object)"/> for that target. MySQL, PostgreSQL, and
+    /// SQLite accept both spellings.
     /// </remarks>
     public static CeilingFunction Ceiling(object expr) =>
         new(Resolve(expr));
@@ -523,8 +525,9 @@ public static partial class Sql
     /// <param name="third">The third string expression.</param>
     /// <param name="others">Any further string expressions, appended in order.</param>
     /// <returns>A <see cref="ConcatFunction"/> emitting <c>CONCAT(a, b, c, ...)</c>.</returns>
-    /// <remarks>Requires SQLite 3.44+. Oracle's <c>CONCAT</c> takes exactly two arguments
-    /// and rejects this three-or-more form — nest two-argument calls there instead, or use
+    /// <remarks>MySQL, PostgreSQL, SQLite (3.44+), and SQL Server syntax. Oracle's
+    /// <c>CONCAT</c> takes exactly two arguments and rejects this three-or-more
+    /// form — nest two-argument calls there instead, or use
     /// <see cref="DoublePipe(object, object, object[])"/> to chain any number without
     /// nesting (also valid on PostgreSQL and SQLite).</remarks>
     public static ConcatFunction Concat(
@@ -623,8 +626,9 @@ public static partial class Sql
     /// <param name="rightVector">The second vector.</param>
     /// <returns>A <c>&lt;=&gt;</c> operator expression.</returns>
     /// <remarks>
-    /// On MySQL, <c>&lt;=&gt;</c> is the NULL-safe equality operator — valid SQL
-    /// with silently different semantics, an equality test rather than a distance.
+    /// Oracle (23ai+) and PostgreSQL syntax. On MySQL, <c>&lt;=&gt;</c> is the
+    /// NULL-safe equality operator — valid SQL with silently different
+    /// semantics, an equality test rather than a distance.
     /// </remarks>
     public static CosineDistanceOperator CosineDistance(object leftVector, object rightVector) =>
         new(Resolve(leftVector), Resolve(rightVector));

--- a/src/SqlArtisan/Sql/Sql.E.cs
+++ b/src/SqlArtisan/Sql/Sql.E.cs
@@ -21,9 +21,9 @@ public static partial class Sql
     /// <param name="column">The conflicting-insert column to reference.</param>
     /// <returns>An <see cref="ExcludedColumn"/> referencing the proposed row's
     /// value of <paramref name="column"/>.</returns>
-    /// <remarks>MySQL 8.0.19+ (SqlArtisan always emits the row-alias form).
-    /// Oracle and SQL Server have no UPSERT excluded row — use <c>MERGE</c>
-    /// there.</remarks>
+    /// <remarks>MySQL (8.0.19+), PostgreSQL, and SQLite syntax — SqlArtisan
+    /// always emits the row-alias form on MySQL. Oracle and SQL Server have no
+    /// UPSERT excluded row — use <c>MERGE</c> there.</remarks>
     public static ExcludedColumn Excluded(DbColumn column) => new(column);
 
     /// <summary>

--- a/src/SqlArtisan/Sql/Sql.M.cs
+++ b/src/SqlArtisan/Sql/Sql.M.cs
@@ -50,8 +50,9 @@ public static partial class Sql
     /// </summary>
     /// <param name="target">The table to merge rows into.</param>
     /// <returns>A merge builder positioned to accept <c>Using(...).On(...)</c>.</returns>
-    /// <remarks>The emitted SQL is per-dialect: SQL Server appends the required
-    /// terminating semicolon and supports <c>WHEN NOT MATCHED BY SOURCE</c>.</remarks>
+    /// <remarks>Oracle, PostgreSQL (15+), and SQL Server syntax. The emitted SQL
+    /// is per-dialect: SQL Server appends the required terminating semicolon and
+    /// supports <c>WHEN NOT MATCHED BY SOURCE</c>.</remarks>
     public static IMergeBuilderTarget MergeInto(DbTableBase target) =>
         new MergeBuilder(new MergeIntoClause(target));
 

--- a/src/SqlArtisan/Sql/Sql.R.cs
+++ b/src/SqlArtisan/Sql/Sql.R.cs
@@ -319,8 +319,9 @@ public static partial class Sql
     /// </summary>
     /// <param name="expr">The numeric expression to round.</param>
     /// <returns>A <c>ROUND</c> function expression.</returns>
-    /// <remarks>SQL Server's <c>ROUND</c> requires the decimal count — pass
-    /// <c>0</c> to <see cref="Round(object, object)"/> there.</remarks>
+    /// <remarks>Not supported by SQL Server — its <c>ROUND</c> requires the
+    /// decimal count; pass <c>0</c> to <see cref="Round(object, object)"/>
+    /// there.</remarks>
     public static RoundFunction Round(object expr) =>
         new(Resolve(expr));
 

--- a/src/SqlArtisan/Sql/Sql.S.cs
+++ b/src/SqlArtisan/Sql/Sql.S.cs
@@ -124,7 +124,7 @@ public static partial class Sql
     /// <param name="separator">The separator string placed between concatenated values.</param>
     /// <returns>A <c>SEPARATOR</c> clause for <c>GROUP_CONCAT</c>.</returns>
     /// <remarks>
-    /// Distinct from SQLite's positional separator argument.
+    /// MySQL syntax. Distinct from SQLite's positional separator argument.
     /// </remarks>
     public static SeparatorClause Separator(string separator) =>
         new(separator);

--- a/tests/SqlArtisan.Analyzers.Tests/XmlDocDialectParityTests.cs
+++ b/tests/SqlArtisan.Analyzers.Tests/XmlDocDialectParityTests.cs
@@ -45,20 +45,12 @@ public class XmlDocDialectParityTests
         ("Currval", 1),
         ("GroupConcat", 2),
 
-        ("Ceil", 1),
-        ("Ceiling", 1),
         ("Concat", 2),
-        ("Concat", 4),
-        ("CosineDistance", 2),
         ("Date", 1),
         ("Datediff", 3),
-        ("Excluded", 1),
         ("Exp", 1),
         ("If", 3),
         ("IntervalLiteral", 2),
-        ("MergeInto", 1),
-        ("Round", 1),
-        ("Separator", 1),
     };
 
     // Every member whose <remarks> names a dialect — i.e. contains one of
@@ -115,10 +107,9 @@ public class XmlDocDialectParityTests
     private static bool ParsesToMatrixSet((string Id, string Name, int? Arity) candidate)
     {
         ISet<TargetDbms> claimed = ParseDialects(ReadRemark(candidate.Id));
-        DialectMatrix.TryGetEntry(candidate.Name, candidate.Arity, out DbmsSupport support, out _);
+        ISet<TargetDbms> matrixSet = SupportedDialects(candidate.Name, candidate.Arity);
 
-        return claimed.Count > 0
-            && AllDbms.All(dbms => claimed.Contains(dbms) == support.IsSupported(dbms));
+        return claimed.Count > 0 && claimed.SetEquals(matrixSet);
     }
 
     [Theory]
@@ -133,17 +124,32 @@ public class XmlDocDialectParityTests
                 + "genuine claim of universal (non-)support. Add it to ExcludedMembers if the "
                 + "remark's shape is legitimately unparseable.");
 
-        bool found = DialectMatrix.TryGetEntry(name, arity, out DbmsSupport support, out _);
-        Assert.True(found, $"No DialectMatrix entry for {name}/{arity?.ToString() ?? "member"}.");
+        ISet<TargetDbms> support = SupportedDialects(name, arity);
 
         foreach (TargetDbms dbms in AllDbms)
         {
             Assert.True(
-                claimed.Contains(dbms) == support.IsSupported(dbms),
+                claimed.Contains(dbms) == support.Contains(dbms),
                 $"{memberId} remark \"{remark}\" disagrees with the matrix on {dbms} "
                     + $"(remark says {(claimed.Contains(dbms) ? "supported" : "unsupported")}, "
-                    + $"matrix says {(support.IsSupported(dbms) ? "supported" : "unsupported")}).");
+                    + $"matrix says {(support.Contains(dbms) ? "supported" : "unsupported")}).");
         }
+    }
+
+    // A dialect carrying a version bound is supported by some version of it — the
+    // analyzer's own DialectSupportResolver.Evaluate treats a bound as overriding
+    // DbmsSupport's plain bool in both directions, so a remark naming that dialect
+    // (with or without its floor, e.g. "Oracle (23ai+)") agrees with the matrix.
+    // TryGetMinVersion looks up the matched key exactly — an arity-specific bound
+    // never falls back to the member-wide row, so the matched key must match too.
+    private static ISet<TargetDbms> SupportedDialects(string name, int? arity)
+    {
+        bool found = DialectMatrix.TryGetEntry(name, arity, out DbmsSupport support, out bool wasArityMatch);
+        Assert.True(found, $"No DialectMatrix entry for {name}/{arity?.ToString() ?? "member"}.");
+
+        MatrixKey matchedKey = new(name, wasArityMatch ? arity : null);
+        return new HashSet<TargetDbms>(AllDbms.Where(
+            dbms => support.IsSupported(dbms) || DialectMatrix.TryGetMinVersion(matchedKey, dbms, out _)));
     }
 
     private static readonly TargetDbms[] AllDbms =

--- a/tests/SqlArtisan.Analyzers.Tests/XmlDocDialectParityTests.cs
+++ b/tests/SqlArtisan.Analyzers.Tests/XmlDocDialectParityTests.cs
@@ -136,12 +136,11 @@ public class XmlDocDialectParityTests
         }
     }
 
-    // A dialect carrying a version bound is supported by some version of it — the
-    // analyzer's own DialectSupportResolver.Evaluate treats a bound as overriding
-    // DbmsSupport's plain bool in both directions, so a remark naming that dialect
-    // (with or without its floor, e.g. "Oracle (23ai+)") agrees with the matrix.
-    // TryGetMinVersion looks up the matched key exactly — an arity-specific bound
-    // never falls back to the member-wide row, so the matched key must match too.
+    // A dialect carrying a version bound is supported by some version of it, so a
+    // remark naming it — floor or not — agrees with the matrix. The analyzer only
+    // reaches that verdict once a target declares a version
+    // (DialectSupportResolver.Evaluate); under `any` it falls back to the plain
+    // bool. TryGetMinVersion is an exact key lookup, so the matched key must match.
     private static ISet<TargetDbms> SupportedDialects(string name, int? arity)
     {
         bool found = DialectMatrix.TryGetEntry(name, arity, out DbmsSupport support, out bool wasArityMatch);


### PR DESCRIPTION
Closes #474.

## Problem

#470 widened `XmlDocDialectParityTests`' sweep to every member with a dialect-naming `<remarks>`, against a documented `ExcludedMembers` catalog for the members a single-clause parser can't resolve. Several of those catalog entries are excluded for a reason distinct from "the parser can't read this": **the remark never states the member's supported dialects at all**, so a reader relying on `<remarks>` alone can't tell what runs where.

Two shapes, all confirmed against `DialectMatrix`:

- **Never names a dialect the matrix supports** — reads as a spelling note or caveat with the supported set implicit or omitted: `Ceil` (never names Oracle), `Ceiling` (never names SQL Server), `Excluded` (never names PostgreSQL or SQLite).
- **Names only a dialect the matrix *excludes*** — the one dialect mentioned is a caveat about an unsupported engine, not the supported set: `Round(object)` (only SQL Server, which is excluded), `Separator` (only SQLite, excluded), `CosineDistance` (only MySQL, excluded — and missing its Oracle 23ai+ floor entirely, which `docs/expressions.md` already states).

`MergeInto` belongs to neither shape exactly: its remark named SQL Server, which *is* supported, but never Oracle or PostgreSQL 15+ — an incomplete set rather than an unsupported-only mention. While auditing the catalog I found an eighth case #474 didn't name, with that same incomplete-set shape: `Concat(a, b, c, params object[])`'s remark never mentions MySQL or SQL Server, both of which the matrix supports.

## Change

**Reworded all eight remarks** to state the full supported set in the house `A, B, and C syntax.` / `Not supported by X.` form, keeping each caveat.

**One parity-test fix was required, and only for `CosineDistance`.** `DialectMatrix` keys it `oracle: false` in `DbmsSupport` but carries a `VersionBounds` row of `oracle: V("23")`. `DialectSupportResolver.Evaluate` applies that bound — in both directions — **once the target declares a version**; under `any` it falls back to the plain bool, as `docs/analyzer.md` states. So Oracle 23ai+ is genuinely supported, but the parity test compared only against `DbmsSupport`: the truthful remark (`"Oracle (23ai+) and PostgreSQL syntax."`) failed the gate, and the only way to pass was to omit Oracle — the opposite of what #474 asked for.

`SupportedDialects` now counts any dialect carrying a version-bound row. The other seven remarks retire under the unchanged comparison — the only `false` + version-bound cells in the whole matrix are the three pgvector operators sharing `CosineDistance`'s shape, and the other two carry no `<remarks>` at all. Verified before touching any remark that this doesn't loosen the existing sweep: rechecked all 124 then-swept members under the new rule — 0 breaks.

## Verification

For each of the eight, confirmed `ExcludedMembers_AreAllLoadBearing` actually flags the entry as inert (parses to the matrix set) *before* removing it from the catalog — a gate that can't fail is worse than none. One rewording (`Separator`) initially used a comma where a period was needed, which let "SQLite" leak into the same clause as "MySQL"; caught because the gate didn't flag it, fixed, reconfirmed.

- `ExcludedMembers`: 18 → 10 entries. Four of the ten are a matrix key that unions two distinct APIs (`Match`, `Nextval`, `Currval`, `GroupConcat`) — no single remark can represent a union, so rewording can never retire those. The other six carry phrasings the first-clause parse can't resolve (a prose quantifier, a set spread across clauses, a caveat-led opening) and remain retirable by the same treatment.
- Swept members: 124 → 132.
- Gates: build 0 warnings, `dotnet format` clean, unit 1044, analyzer 937, TableClassGen 158, and all six integration lanes (Sqlite, PostgreSql, MySql, SqlServer, Oracle, Oracle23ai) green against this head.

## Notes for the reviewer

- **No behavior change.** This is XML-doc prose plus a test-comparison fix; no `DialectMatrix` entry, builder, or `Format` path changed.
- **Scope check on `Concat/4`.** Not in #474's list — found by auditing the full catalog against `DialectMatrix` rather than only the seven named members, since the same defect shape (remark omits a supported dialect) isn't specific to the seven the issue happened to sample.
- **Vendor floors not independently checked.** The version floors the new remarks quote (SQLite 3.35/3.44, MySQL 8.0.19, PostgreSQL 15, Oracle 23ai) are copied verbatim from `DialectMatrix.Bounds`, which this change does not alter; they are matrix-consistent but were not re-verified against vendor documentation here.