### PR TITLE
docs: Gate XML-remark version floors against DialectMatrix's VersionBounds

### DIFF
--- a/.claude/skills/sa-write-xml-docs/SKILL.md
+++ b/.claude/skills/sa-write-xml-docs/SKILL.md
@@ -87,6 +87,14 @@ separate, deliberate decision.
 - **Line breaks:** `<summary>` always three `///` lines;
   `<param>`/`<returns>`/`<typeparam>`/`<exception>` inline (wrap content only when
   long). This is the Visual Studio / Roslyn layout.
+- **Version floor**: parenthesized next to the dialect it bounds — `SQLite
+  (3.35+)` inside a dialect list, `(SQLite 3.44+)` as a standalone aside. Never
+  bare (`SQL Server 2022+`) and never in a relative clause: those read the same
+  to a human but parse to nothing, and
+  `XmlDocDialectParityTests.RemarksVersionFloor_MatchesMatrix` gates every floor
+  against `DialectMatrix`'s `VersionBounds` (#471). `docs/` puts the name inside
+  the parentheses instead — there the note stands alone, here it usually sits in
+  a list of dialect names.
 - **Document on the interface, not the implementation** — put `<inheritdoc/>` on
   the implementing method so shipped XML / DocFX inherit it. Never write it twice.
 - Runnable examples live in the **README**, not `<example>` blocks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Docs
+- A version floor stated in a `<remarks>` is now gated against
+  `DialectMatrix`'s `VersionBounds` in both directions — a stated floor must be
+  the matrix's, and a bound the matrix records must be stated — resolving the
+  same key the support check resolves, so `Trim`'s arity-2 SQL Server 2022 floor
+  is checked against the arity-2 bound rather than the member key's 2017. A
+  dialect the matrix supports at no version is skipped: a version named against
+  one bounds a same-named foreign function, as `Format`'s remark does for
+  SQLite's `printf()` alias. Floors now have one spelling — parenthesized beside
+  the dialect (`SQLite (3.35+)`, or `(SQLite 3.44+)` as a standalone aside) —
+  and a second gate fails any bare or clause-embedded floor, which reads the
+  same to a human but parses to nothing. Twelve remarks are normalized to it,
+  `Datetrunc`'s nested parenthetical and `Trim(object, object)`'s relative
+  clause are rewritten, and five floors the matrix recorded but no remark stated
+  are now written down: `Iif` (SQLite 3.32+, SQL Server 2012+), `Mod` (SQLite
+  3.35+), `RegexpReplace(source, pattern, replacement)` and
+  `Values(alias, columnNames, rows)` (PostgreSQL 15+). (#471)
 - Eight `<remarks>` that never stated their member's full supported-dialect set
   now do: `Ceil`, `Ceiling`, `Concat(a, b, c, params object[])`,
   `CosineDistance`, `Excluded`, `MergeInto`, `Round(object)`, and `Separator`.

--- a/src/SqlArtisan/Sql/Sql.D.cs
+++ b/src/SqlArtisan/Sql/Sql.D.cs
@@ -197,8 +197,8 @@ public static partial class Sql
     /// <param name="date">The date/time value to truncate.</param>
     /// <returns>The <c>DATETRUNC</c> function expression.</returns>
     /// <remarks>
-    /// SQL Server syntax (SQL Server 2022+; use <see cref="Format(object, object)"/>
-    /// on earlier versions).
+    /// SQL Server (2022+) syntax; use <see cref="Format(object, object)"/> on
+    /// earlier versions.
     /// </remarks>
     public static DatetruncFunction Datetrunc(DateTimePart datepart, object date) =>
         new(datepart, Resolve(date));

--- a/src/SqlArtisan/Sql/Sql.G.cs
+++ b/src/SqlArtisan/Sql/Sql.G.cs
@@ -12,7 +12,7 @@ public static partial class Sql
     /// <param name="expressions">The values to compare.</param>
     /// <returns>The <c>GREATEST</c> function expression.</returns>
     /// <remarks>Not supported by SQLite — its multi-argument
-    /// <c>MAX(a, b, ...)</c> is the equivalent; SQL Server 2022+.</remarks>
+    /// <c>MAX(a, b, ...)</c> is the equivalent; SQL Server (2022+).</remarks>
     public static GreatestFunction Greatest(params object[] expressions) =>
         new(Resolve(expressions));
 

--- a/src/SqlArtisan/Sql/Sql.I.cs
+++ b/src/SqlArtisan/Sql/Sql.I.cs
@@ -16,7 +16,7 @@ public static partial class Sql
     /// <returns>An <c>IF</c> function expression.</returns>
     /// <exception cref="ArgumentException"><paramref name="condition"/> is empty
     /// (every operand excluded).</exception>
-    /// <remarks>MySQL syntax; SQLite 3.48+ accepts it as a second name for
+    /// <remarks>MySQL syntax; SQLite (3.48+) accepts it as a second name for
     /// <c>IIF</c>. Not <see cref="ConditionIf(bool, SqlCondition)"/>, the C#-side
     /// helper that drops a <c>WHERE</c> condition and emits no SQL.</remarks>
     public static IfFunction If(SqlCondition condition, object then, object @else) =>
@@ -46,7 +46,7 @@ public static partial class Sql
     /// <returns>An <c>IIF</c> function expression.</returns>
     /// <exception cref="ArgumentException"><paramref name="condition"/> is empty
     /// (every operand excluded).</exception>
-    /// <remarks>SQLite/SQL Server syntax; on MySQL use
+    /// <remarks>SQLite (3.32+) and SQL Server (2012+) syntax; on MySQL use
     /// <see cref="If(SqlCondition, object, object)"/>.</remarks>
     public static IifFunction Iif(SqlCondition condition, object then, object @else) =>
         new(condition, Resolve(then), Resolve(@else));

--- a/src/SqlArtisan/Sql/Sql.L.cs
+++ b/src/SqlArtisan/Sql/Sql.L.cs
@@ -128,7 +128,7 @@ public static partial class Sql
     /// <param name="expressions">The values to compare.</param>
     /// <returns>The LEAST construct.</returns>
     /// <remarks>Not supported by SQLite — its multi-argument
-    /// <c>MIN(a, b, ...)</c> is the equivalent; SQL Server 2022+.</remarks>
+    /// <c>MIN(a, b, ...)</c> is the equivalent; SQL Server (2022+).</remarks>
     public static LeastFunction Least(params object[] expressions) =>
         new(Resolve(expressions));
 

--- a/src/SqlArtisan/Sql/Sql.M.cs
+++ b/src/SqlArtisan/Sql/Sql.M.cs
@@ -83,7 +83,8 @@ public static partial class Sql
     /// <param name="dividend">The number being divided.</param>
     /// <param name="divisor">The number to divide by.</param>
     /// <returns>The MOD construct.</returns>
-    /// <remarks>Not supported by SQL Server — use the <c>%</c> operator there.</remarks>
+    /// <remarks>Not supported by SQL Server — use the <c>%</c> operator there;
+    /// SQLite (3.35+).</remarks>
     public static ModFunction Mod(object dividend, object divisor) =>
         new(Resolve(dividend), Resolve(divisor));
 

--- a/src/SqlArtisan/Sql/Sql.N.cs
+++ b/src/SqlArtisan/Sql/Sql.N.cs
@@ -65,7 +65,7 @@ public static partial class Sql
     /// The <c>NOWAIT</c> lock behavior for a <c>FOR UPDATE</c> clause: fail
     /// immediately rather than block when a row is already locked.
     /// </summary>
-    /// <remarks>MySQL 8.0+, Oracle, and PostgreSQL syntax.</remarks>
+    /// <remarks>MySQL (8.0+), Oracle, and PostgreSQL syntax.</remarks>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public static NowaitBehavior Nowait => new();
 

--- a/src/SqlArtisan/Sql/Sql.R.cs
+++ b/src/SqlArtisan/Sql/Sql.R.cs
@@ -202,7 +202,7 @@ public static partial class Sql
     /// <param name="pattern">The regular-expression pattern.</param>
     /// <param name="replacement">The replacement text (may reference capture groups).</param>
     /// <returns>A <c>REGEXP_REPLACE</c> function expression.</returns>
-    /// <remarks>MySQL, Oracle, and PostgreSQL syntax.</remarks>
+    /// <remarks>MySQL, Oracle, and PostgreSQL (15+) syntax.</remarks>
     public static RegexpReplaceFunction RegexpReplace(
         object source,
         object pattern,

--- a/src/SqlArtisan/Sql/Sql.S.cs
+++ b/src/SqlArtisan/Sql/Sql.S.cs
@@ -154,7 +154,7 @@ public static partial class Sql
     /// The <c>SKIP LOCKED</c> behavior for a <c>FOR UPDATE</c> clause: skip rows that
     /// are already locked instead of blocking on them.
     /// </summary>
-    /// <remarks>MySQL 8.0+, Oracle, and PostgreSQL syntax.</remarks>
+    /// <remarks>MySQL (8.0+), Oracle, and PostgreSQL syntax.</remarks>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public static SkipLockedBehavior SkipLocked => new();
 

--- a/src/SqlArtisan/Sql/Sql.T.cs
+++ b/src/SqlArtisan/Sql/Sql.T.cs
@@ -202,7 +202,7 @@ public static partial class Sql
     /// <returns>A <c>TRIM</c> function expression.</returns>
     /// <remarks>
     /// Emits the ANSI <c>TRIM(BOTH trimChar FROM source)</c> form, which SQL Server
-    /// accepts only on 2022+ (compatibility level 160). Not supported by SQLite,
+    /// (2022+) accepts only at compatibility level 160. Not supported by SQLite,
     /// whose grammar has no <c>BOTH ... FROM</c> clause; its positional
     /// <c>trim(source, trimChar)</c> is a separate function this does not emit.
     /// </remarks>

--- a/src/SqlArtisan/Sql/Sql.V.cs
+++ b/src/SqlArtisan/Sql/Sql.V.cs
@@ -14,7 +14,7 @@ public static partial class Sql
     /// <param name="columnNames">The source column names, in row-value order.</param>
     /// <param name="rows">The literal rows; each supplies one value per column.</param>
     /// <returns>A <see cref="ValuesDerivedTable"/> usable as a MERGE <c>USING</c> source.</returns>
-    /// <remarks>PostgreSQL and SQL Server. Oracle has no <c>VALUES</c> row
+    /// <remarks>PostgreSQL (15+) and SQL Server. Oracle has no <c>VALUES</c> row
     /// constructor in <c>USING</c> — wrap the rows in a subquery source instead.</remarks>
     public static ValuesDerivedTable Values(
         string alias, string[] columnNames, object[][] rows)

--- a/src/SqlArtisan/SqlPart/Expression/ExpressionAlias.cs
+++ b/src/SqlArtisan/SqlPart/Expression/ExpressionAlias.cs
@@ -46,7 +46,7 @@ public sealed class ExpressionAlias : SqlPart, ISortable
     /// Gets the <c>ORDER BY</c> sort key that puts <see langword="null"/>
     /// values first (<c>"alias" NULLS FIRST</c>).
     /// </summary>
-    /// <remarks>Not available on MySQL or SQL Server; SQLite 3.30+.</remarks>
+    /// <remarks>Not available on MySQL or SQL Server; SQLite (3.30+).</remarks>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public SortOrder NullsFirst => new(this, NullOrdering.NullsFirst);
 
@@ -54,7 +54,7 @@ public sealed class ExpressionAlias : SqlPart, ISortable
     /// Gets the <c>ORDER BY</c> sort key that puts <see langword="null"/>
     /// values last (<c>"alias" NULLS LAST</c>).
     /// </summary>
-    /// <remarks>Not available on MySQL or SQL Server; SQLite 3.30+.</remarks>
+    /// <remarks>Not available on MySQL or SQL Server; SQLite (3.30+).</remarks>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public SortOrder NullsLast => new(this, NullOrdering.NullsLast);
 

--- a/src/SqlArtisan/SqlPart/Expression/SqlExpression.cs
+++ b/src/SqlArtisan/SqlPart/Expression/SqlExpression.cs
@@ -44,7 +44,7 @@ public abstract class SqlExpression : SqlPart
     /// Gets the <c>ORDER BY</c> suffix that sorts this expression's <see
     /// langword="null"/> values first (<c>expr NULLS FIRST</c>).
     /// </summary>
-    /// <remarks>Not available on MySQL or SQL Server; SQLite 3.30+.</remarks>
+    /// <remarks>Not available on MySQL or SQL Server; SQLite (3.30+).</remarks>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public SortOrder NullsFirst => new(this, NullOrdering.NullsFirst);
 
@@ -52,7 +52,7 @@ public abstract class SqlExpression : SqlPart
     /// Gets the <c>ORDER BY</c> suffix that sorts this expression's <see
     /// langword="null"/> values last (<c>expr NULLS LAST</c>).
     /// </summary>
-    /// <remarks>Not available on MySQL or SQL Server; SQLite 3.30+.</remarks>
+    /// <remarks>Not available on MySQL or SQL Server; SQLite (3.30+).</remarks>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public SortOrder NullsLast => new(this, NullOrdering.NullsLast);
 

--- a/src/SqlArtisan/SqlPart/SortOrder.cs
+++ b/src/SqlArtisan/SqlPart/SortOrder.cs
@@ -41,7 +41,7 @@ public sealed class SortOrder : SqlPart
     /// Gets this sort key with its <see langword="null"/> values sorted first
     /// (<c>... NULLS FIRST</c>).
     /// </summary>
-    /// <remarks>Not available on MySQL or SQL Server; SQLite 3.30+.</remarks>
+    /// <remarks>Not available on MySQL or SQL Server; SQLite (3.30+).</remarks>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public SortOrder NullsFirst => new(_exprOrAlias, _direction, NullOrdering.NullsFirst);
 
@@ -49,7 +49,7 @@ public sealed class SortOrder : SqlPart
     /// Gets this sort key with its <see langword="null"/> values sorted last
     /// (<c>... NULLS LAST</c>).
     /// </summary>
-    /// <remarks>Not available on MySQL or SQL Server; SQLite 3.30+.</remarks>
+    /// <remarks>Not available on MySQL or SQL Server; SQLite (3.30+).</remarks>
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public SortOrder NullsLast => new(_exprOrAlias, _direction, NullOrdering.NullsLast);
 

--- a/tests/SqlArtisan.Analyzers.Tests/XmlDocDialectParityTests.cs
+++ b/tests/SqlArtisan.Analyzers.Tests/XmlDocDialectParityTests.cs
@@ -136,6 +136,119 @@ public class XmlDocDialectParityTests
         }
     }
 
+    // The version check is orthogonal to the dialect-set parse, so it sweeps every
+    // candidate — ExcludedMembers' remarks defeat that parse, not this one.
+    public static IEnumerable<object[]> VersionCases() =>
+        from candidate in Candidates()
+        select new object[] { candidate.Id, candidate.Name, candidate.Arity! };
+
+    // #471: a floor stated in prose was checked by nothing, free to drift from
+    // VersionBounds the way the dialect note could once drift from DbmsSupport.
+    // Both directions are gated — a stated floor must be the matrix's, and a bound
+    // the matrix records must be stated.
+    [Theory]
+    [MemberData(nameof(VersionCases))]
+    public void RemarksVersionFloor_MatchesMatrix(string memberId, string name, int? arity)
+    {
+        string remark = ReadRemark(memberId);
+        IReadOnlyDictionary<TargetDbms, EngineVersion> claimed = ParseFloors(remark);
+        MatrixKey matchedKey = MatchedKey(name, arity);
+
+        // A dialect the matrix supports at no version has no floor to state: a
+        // version named against it bounds a same-named foreign function (Format's
+        // SQLite printf() alias), not this construct.
+        foreach (TargetDbms dbms in SupportedDialects(name, arity))
+        {
+            bool bounded = DialectMatrix.TryGetMinVersion(matchedKey, dbms, out EngineVersion min);
+            bool stated = claimed.TryGetValue(dbms, out EngineVersion floor);
+
+            Assert.True(
+                bounded == stated && (!bounded || min.Equals(floor)),
+                $"{memberId} remark \"{remark}\" disagrees with the matrix on {dbms}'s version "
+                    + $"floor (remark says {(stated ? floor.ToString() : "none")}, matrix says "
+                    + $"{(bounded ? min.ToString() : "none")}).");
+        }
+    }
+
+    // The convention ParseFloors reads: a floor is parenthesized next to the
+    // dialect it bounds — "SQLite (3.35+)" inside a dialect list, "(SQLite 3.44+)"
+    // as a standalone aside. A bare "SQL Server 2022+" reads the same to a human
+    // but parses to nothing, so it fails here rather than satisfying the parity
+    // theory vacuously. Swept over every remark, not just the candidates: the
+    // spelling is a house convention, not a matrix claim.
+    [Fact]
+    public void RemarksVersionFloor_IsParenthesizedBesideItsDialect()
+    {
+        List<string> offenders = [];
+        foreach (XElement member in LoadXmlDoc().Descendants("member"))
+        {
+            if (member.Element("remarks") is not { } remark)
+            {
+                continue;
+            }
+
+            string text = WhitespaceRun.Replace(remark.Value, " ").Trim();
+            offenders.AddRange(FreeFormFloors(text)
+                .Select(floor => $"{(string)member.Attribute("name")!}: \"{floor}\" in \"{text}\""));
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            $"{offenders.Count} version floors are not parenthesized beside their dialect — "
+                + $"write \"SQLite (3.35+)\" or \"(SQLite 3.35+)\":\n  "
+                + string.Join("\n  ", offenders));
+    }
+
+    private static IEnumerable<string> FreeFormFloors(string text)
+    {
+        IEnumerable<Range> asides = [.. ParenthesizedAside.Matches(text)
+            .Select(aside => new Range(aside.Index, aside.Index + aside.Length))];
+        TargetDbms? named = null;
+
+        foreach (Match token in DialectOrFloor.Matches(text))
+        {
+            if (token.Groups[1].Success)
+            {
+                named = DisplayNames[token.Groups[1].Value];
+            }
+            else if (named is null
+                || !asides.Any(aside => token.Index >= aside.Start.Value && token.Index < aside.End.Value))
+            {
+                yield return token.Value;
+            }
+        }
+    }
+
+    // First floor wins per dialect: a remark restating one (Ltrim's compatibility
+    // level, Log's per-base split) repeats the same number, never a second one.
+    private static IReadOnlyDictionary<TargetDbms, EngineVersion> ParseFloors(string remark)
+    {
+        Dictionary<TargetDbms, EngineVersion> floors = [];
+        TargetDbms? named = null;
+
+        foreach (Match token in DialectOrFloor.Matches(WhitespaceRun.Replace(remark, " ")))
+        {
+            if (token.Groups[1].Success)
+            {
+                named = DisplayNames[token.Groups[1].Value];
+            }
+            else if (named is { } dbms)
+            {
+                floors.TryAdd(dbms, EngineVersion.Parse(token.Groups[2].Value));
+            }
+        }
+
+        return floors;
+    }
+
+    // A floor binds to the nearest dialect named before it, which is what makes
+    // both spellings of the convention parse. EngineVersion drops the release-name
+    // suffix itself, so "23ai+" reads as Oracle 23.
+    private static readonly Regex DialectOrFloor =
+        new(@"(MySQL|Oracle|PostgreSQL|SQLite|SQL Server)|(\d+(?:\.\d+)*[A-Za-z]*)\+");
+
+    private static readonly Regex ParenthesizedAside = new(@"\([^()]*\)");
+
     // A dialect carrying a version bound is supported by some version of it, so a
     // remark naming it — floor or not — agrees with the matrix. The analyzer only
     // reaches that verdict once a target declares a version
@@ -143,12 +256,23 @@ public class XmlDocDialectParityTests
     // bool. TryGetMinVersion is an exact key lookup, so the matched key must match.
     private static ISet<TargetDbms> SupportedDialects(string name, int? arity)
     {
-        bool found = DialectMatrix.TryGetEntry(name, arity, out DbmsSupport support, out bool wasArityMatch);
+        bool found = DialectMatrix.TryGetEntry(name, arity, out DbmsSupport support, out _);
         Assert.True(found, $"No DialectMatrix entry for {name}/{arity?.ToString() ?? "member"}.");
 
-        MatrixKey matchedKey = new(name, wasArityMatch ? arity : null);
+        MatrixKey matchedKey = MatchedKey(name, arity);
         return new HashSet<TargetDbms>(AllDbms.Where(
             dbms => support.IsSupported(dbms) || DialectMatrix.TryGetMinVersion(matchedKey, dbms, out _)));
+    }
+
+    // A bound attaches to the exact key the entry lookup matched, never falling
+    // back from the arity key to the member key (Trim carries 2022 at the arity-2
+    // key and 2017 at the member key).
+    private static MatrixKey MatchedKey(string name, int? arity)
+    {
+        bool found = DialectMatrix.TryGetEntry(name, arity, out _, out bool wasArityMatch);
+        Assert.True(found, $"No DialectMatrix entry for {name}/{arity?.ToString() ?? "member"}.");
+
+        return new MatrixKey(name, wasArityMatch ? arity : null);
     }
 
     private static readonly TargetDbms[] AllDbms =


### PR DESCRIPTION
Closes #471.

A version floor written in a `<remarks>` was checked by nothing:
`RemarksDialectNote_MatchesMatrix` read the dialect note against `DbmsSupport`
and discarded the bounds, so prose could drift from `VersionBounds` the same way
the note could once drift from the support set — and #469 made such a floor
easier to introduce.

## Gates

- **`RemarksVersionFloor_MatchesMatrix`** — both directions: a stated floor must
  be the matrix's, and a bound the matrix records must be stated. It resolves the
  same arity-priority key the support check resolves, so `Trim`'s arity-2 SQL
  Server 2022 floor is checked against the arity-2 bound rather than the member
  key's 2017. A dialect the matrix supports at no version is skipped — a version
  named against one bounds a same-named foreign function, as `Format`'s remark
  does for SQLite's `printf()` alias, so that case needs no exclusion entry.
- **`RemarksVersionFloor_IsParenthesizedBesideItsDialect`** — the spelling the
  parse depends on. A bare `SQL Server 2022+` reads the same to a human but
  parses to nothing, so it fails here rather than satisfying the parity theory
  vacuously. Swept over every remark, since the spelling is a house convention
  rather than a matrix claim.

Both share the existing candidate enumeration and member-id parse; the version
check sweeps all candidates, since `ExcludedMembers`' remarks defeat the
dialect-set parse, not this one.

## Spelling

Settled on **parenthesized beside the dialect it bounds** — `SQLite (3.35+)`
inside a dialect list, `(SQLite 3.44+)` as a standalone aside — with the
rationale recorded in the `sa-write-xml-docs` skill. The `docs/` rule puts the
name inside the parentheses instead, because there the note stands alone; in a
remark the floor usually sits in a list of dialect names, where that form would
break the enumeration.

Twelve remarks are normalized to it (`Nowait`, `SkipLocked`, `Greatest`,
`Least`, `If`, and the six `NullsFirst`/`NullsLast` properties), and
`Datetrunc`'s nested parenthetical and `Trim(object, object)`'s relative clause
are rewritten. `Oracle (23ai+)` needs no change: `EngineVersion` drops the
release-name suffix itself.

## Floors written down

Five the matrix recorded but no remark stated: `Iif` (SQLite 3.32+, SQL Server
2012+ — matching what `docs/functions.md` already said), `Mod` (SQLite 3.35+),
`RegexpReplace(source, pattern, replacement)` and
`Values(alias, columnNames, rows)` (PostgreSQL 15+).

## Verification

`SqlArtisan.Tests` 1044, `Analyzers.Tests` 1082, `TableClassGen.Tests` 158 —
all green; `dotnet format --verify-no-changes` clean. The gate was verified to
bite by mutation on `Ceil`'s remark: changing 3.35 to 3.36, dropping the
parentheses, and deleting the floor each fail exactly one test, and reverting
restores green.

## Not in scope

- `docs/functions.md`'s version notes — gating those needs an entry-to-matrix-key
  mapping, a separate problem.
- 26 bound keys whose member's remark names no dialect at all (`Except`,
  `Returning`, `RightJoin`, the MERGE steps, `Floor`/`Power`/`Sqrt`/`Sign`,
  `Trim`'s member key, …) — they never reach the sweep, so closing that hole is a
  remarks-writing task in the shape of #475.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCXMGMDRtLcjMVVRQLuWEq)_