### PR TITLE
docs: Draw the documentation precision boundary (ADR 0020)

### DIFF
--- a/.claude/rules/docs-style.md
+++ b/.claude/rules/docs-style.md
@@ -68,13 +68,21 @@ with availability left to the database"). ADR cross-references belong in
   the emitted SQL → (only when it differs by dialect) a dialect note that lists
   DBMS in enum order.
 - **Dialect caveat note** (a construct that is invalid or a trap on some
-  DBMS): one sentence naming the affected DBMS (enum order) and the working
-  alternative in the same breath — "On Oracle and SQL Server, recurse
-  with plain `With(...)` — `WithRecursive()` is rejected there." Never a bare
-  "not supported on X" with no way out.
-- **Version boundary note**: parenthesized after the DBMS name — "(SQL Server
-  2022+)", "(MySQL 8.0.20+)", "(SQLite 3.44+)" — inside the dialect note, not
-  in the entry's one-line description.
+  DBMS): one sentence naming the affected DBMS (enum order) and, where one
+  exists, the **sibling SqlArtisan API that emits that dialect's own
+  construct** — "On Oracle and SQL Server, recurse with plain `With(...)` —
+  `WithRecursive()` is rejected there." Where no sibling API exists, "not
+  available there" is the complete answer: never a hand-written SQL rewrite,
+  and never a claim that two constructs are interchangeable (ADR 0020 — that
+  is a portability claim, which ADR 0001 refuses in code).
+- **Result semantics are the engine's** — duplicate handling, `NULL` matching,
+  multiplicity, collation, precision. Link the engine's manual; do not restate
+  it. A hazard in *SqlArtisan's own emitted SQL* is a different thing and stays
+  (the callouts below).
+- **No version floor in a reference page.** A floor lives only where a test
+  keeps it tied to `DialectMatrix`: `docs/analyzer.md`'s version-bound register
+  and XML `<remarks>` (ADR 0020). Reference pages state which dialects support
+  a construct and link to the register for the version.
 - README→docs and docs↔docs links are absolute GitHub `blob/main` URLs;
   in-page anchors stay relative. In `llms.txt`, a page's URL form decides
   whether it joins the `llms-full.txt` deep bundle: pages meant for ingestion

--- a/.claude/skills/sa-diff-review/SKILL.md
+++ b/.claude/skills/sa-diff-review/SKILL.md
@@ -266,6 +266,12 @@ contributor) — plus `CLAUDE.md`, `docs/adr/**`, `.claude/skills/**`,
 - **Misleading ambiguity** — wording a reader could plausibly misread into an
   incorrect belief about behavior, not merely wording you'd have chosen
   differently.
+- **Out of boundary** (ADR 0020) — a claim the repo cannot verify: result
+  semantics (duplicate handling, `NULL` matching, multiplicity, collation), an
+  equivalence between two constructs, a hand-written SQL rewrite, or a version
+  floor in a reference page. Report it whether or not it is currently true —
+  the defect is that nothing keeps it true. A hazard in SqlArtisan's *own*
+  emitted SQL is in boundary and stays.
 
 **Not a defect — do not report:**
 - A rewording that changes nothing a reader could conclude — pure phrasing

--- a/.claude/skills/sa-docs-audit/SKILL.md
+++ b/.claude/skills/sa-docs-audit/SKILL.md
@@ -105,6 +105,14 @@ Score the docs against these. The scripts cover 2–5 and parts of 6/10.
     `<sub>` may be stripped). No trailing whitespace, double blank lines, or
     mojibake. (`check_terms.py` covers whitespace/blank lines.)
 
+11. **Precision boundary (ADR 0020).** Every claim has a source of truth in the
+    repo. Flag result semantics (duplicate handling, `NULL` matching,
+    multiplicity, collation), an equivalence between two constructs, a
+    hand-written SQL rewrite, and a version floor outside `docs/analyzer.md`'s
+    register — whether or not it currently reads as true, since nothing keeps it
+    true. A substitution names a sibling SqlArtisan API or nothing at all; a
+    hazard in SqlArtisan's own emitted SQL is in boundary and stays.
+
 ## Process safeguards (hard-won)
 
 - **Verify, don't recall.** Emitted SQL, dialect behaviour, and allocations come

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   MySQL 8.0.31+; `EXCEPT`, `EXCEPT ALL`, `INTERSECT ALL`, and `MINUS ALL` need
   Oracle 21+ (plain `MINUS`/`INTERSECT` run on any Oracle version); and
   `RIGHT JOIN`/`FULL JOIN` with their `NATURAL` forms need SQLite 3.39+. Each
-  note names what to reach for instead, and says where the substitute is not
-  equivalent — swapping an `ALL` form for its plain one eliminates duplicate
-  rows, an `Exists`/`NotExists` rewrite keeps duplicates `EXCEPT`/`INTERSECT`
-  would drop, never matches two `NULL`s, and cannot reproduce the `ALL` forms'
-  copy counts at all, and the SQLite/MySQL `FULL JOIN`
-  emulations are a `UNION` that eliminates duplicate rows a real `FULL JOIN`
-  keeps. The set-operator note also states the support facts around them —
-  that `Minus`/`MinusAll` are Oracle's spelling of `EXCEPT`/`EXCEPT ALL` and
-  run only there, and that SQLite and SQL Server take `ALL` on `UNION` alone —
-  which the section carried nowhere before. (#478)
+  note names the constructs that run at any version alongside the bounded ones
+  (`LeftJoin`/`NaturalLeftJoin`; plain `MINUS`/`INTERSECT` on Oracle), and
+  neither offers a rewrite for a construct the engine cannot run: an `ALL`
+  form is not interchangeable with its plain one, and how many copies it
+  returns is the engine's own rule to look up. The set-operator note also
+  states the support facts around them — that `Minus`/`MinusAll` are Oracle's
+  spelling of `EXCEPT`/`EXCEPT ALL` and run only there, and that SQLite and
+  SQL Server take `ALL` on `UNION` alone — which the section carried nowhere
+  before. (#478)
 - A version floor stated in a `<remarks>` is now gated against
   `DialectMatrix`'s `VersionBounds` in both directions — a stated floor must be
   the matrix's, and a bound the matrix records must be stated — resolving the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Docs
+- `docs/query-statements.md`'s set-operator and JOIN sections now state the
+  version floors that previously appeared only in `docs/analyzer.md`'s
+  version-bound register: `EXCEPT`/`INTERSECT` and their `ALL` forms need
+  MySQL 8.0.31+ and Oracle 21+ (plain `MINUS`/`INTERSECT` run on any Oracle
+  version), and `RIGHT JOIN`/`FULL JOIN` with their `NATURAL` forms need
+  SQLite 3.39+. Both notes name the working alternative on an engine below the
+  floor. The set-operator note also states the support facts around them — that
+  `Minus`/`MinusAll` are Oracle-only and that SQLite and SQL Server accept `ALL`
+  on `UNION` alone — which the section carried nowhere before. (#478)
 - A version floor stated in a `<remarks>` is now gated against
   `DialectMatrix`'s `VersionBounds` in both directions — a stated floor must be
   the matrix's, and a bound the matrix records must be stated — resolving the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Docs
-- `docs/query-statements.md`'s set-operator and JOIN sections now state the
-  version floors that previously appeared only in `docs/analyzer.md`'s
-  version-bound register: `EXCEPT`, `INTERSECT`, and both `ALL` forms need
-  MySQL 8.0.31+; `EXCEPT`, `EXCEPT ALL`, `INTERSECT ALL`, and `MINUS ALL` need
-  Oracle 21+ (plain `MINUS`/`INTERSECT` run on any Oracle version); and
-  `RIGHT JOIN`/`FULL JOIN` with their `NATURAL` forms need SQLite 3.39+. Each
-  note names the constructs that run at any version alongside the bounded ones
-  (`LeftJoin`/`NaturalLeftJoin`; plain `MINUS`/`INTERSECT` on Oracle), and
-  neither offers a rewrite for a construct the engine cannot run: an `ALL`
-  form is not interchangeable with its plain one, and how many copies it
-  returns is the engine's own rule to look up. The set-operator note also
-  states the support facts around them — that `Minus`/`MinusAll` are Oracle's
-  spelling of `EXCEPT`/`EXCEPT ALL` and run only there, and that SQLite and
-  SQL Server take `ALL` on `UNION` alone — which the section carried nowhere
-  before. (#478)
+- **ADR 0020 draws a precision boundary for the documentation**: a page states
+  what SqlArtisan emits and which dialects support a construct — both tied to
+  tests — and delegates the rest to the engine. Result semantics (duplicate
+  handling, `NULL` matching, multiplicity), equivalence between two constructs,
+  and hand-written SQL rewrites are no longer asserted: offering one construct
+  as a stand-in for another is a portability claim, which this project refuses
+  in code and now refuses in prose. A minimum engine version stays only where a
+  test keeps it tied to `DialectMatrix` — `docs/analyzer.md`'s version-bound
+  register, XML `<remarks>`, and the analyzer's own `SQLA0101` — so reference
+  pages link to the register instead of restating floors that nothing keeps
+  current. `.claude/rules/docs-style.md` and the two review skills move with it.
+- `docs/query-statements.md`'s set-operator section now states the dialect
+  support its API list never carried — `Minus`/`MinusAll` are Oracle's spelling
+  of `EXCEPT`/`EXCEPT ALL` and run only there, `ExceptAll`/`IntersectAll` are
+  MySQL, Oracle, and PostgreSQL only, and SQLite and SQL Server take `ALL` on
+  `UNION` alone — and both it and the JOIN section link the register for the
+  versions. Two pre-existing claims retire under ADR 0020: the MySQL `FULL JOIN`
+  emulation recipe (a `UNION` of two one-sided joins, which drops duplicate rows
+  the join keeps) and SQL Server's `JOIN ... USING` substitute, described as an
+  "equivalent" `On(...)` predicate though `USING` collapses the join column.
+  (#478)
 - A version floor stated in a `<remarks>` is now gated against
   `DialectMatrix`'s `VersionBounds` in both directions — a stated floor must be
   the matrix's, and a bound the matrix records must be stated — resolving the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Docs
 - `docs/query-statements.md`'s set-operator and JOIN sections now state the
   version floors that previously appeared only in `docs/analyzer.md`'s
-  version-bound register: `EXCEPT`/`INTERSECT` and their `ALL` forms need
-  MySQL 8.0.31+ and Oracle 21+ (plain `MINUS`/`INTERSECT` run on any Oracle
-  version), and `RIGHT JOIN`/`FULL JOIN` with their `NATURAL` forms need
-  SQLite 3.39+. Both notes name the working alternative on an engine below the
-  floor. The set-operator note also states the support facts around them — that
-  `Minus`/`MinusAll` are Oracle-only and that SQLite and SQL Server accept `ALL`
-  on `UNION` alone — which the section carried nowhere before. (#478)
+  version-bound register: `EXCEPT`, `INTERSECT`, and both `ALL` forms need
+  MySQL 8.0.31+; `EXCEPT`, `EXCEPT ALL`, `INTERSECT ALL`, and `MINUS ALL` need
+  Oracle 21+ (plain `MINUS`/`INTERSECT` run on any Oracle version); and
+  `RIGHT JOIN`/`FULL JOIN` with their `NATURAL` forms need SQLite 3.39+. Each
+  note names what to reach for instead, and says where the substitute is not
+  equivalent — swapping an `ALL` form for its plain one eliminates duplicate
+  rows, and an `Exists`/`NotExists` rewrite does not reproduce `ALL` semantics
+  at all. The set-operator note also states the support facts around them —
+  that `Minus`/`MinusAll` are Oracle's spelling of `EXCEPT`/`EXCEPT ALL` and
+  run only there, and that SQLite and SQL Server take `ALL` on `UNION` alone —
+  which the section carried nowhere before. (#478)
 - A version floor stated in a `<remarks>` is now gated against
   `DialectMatrix`'s `VersionBounds` in both directions — a stated floor must be
   the matrix's, and a bound the matrix records must be stated — resolving the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `RIGHT JOIN`/`FULL JOIN` with their `NATURAL` forms need SQLite 3.39+. Each
   note names what to reach for instead, and says where the substitute is not
   equivalent — swapping an `ALL` form for its plain one eliminates duplicate
-  rows, and an `Exists`/`NotExists` rewrite does not reproduce `ALL` semantics
-  at all. The set-operator note also states the support facts around them —
+  rows, an `Exists`/`NotExists` rewrite keeps duplicates `EXCEPT`/`INTERSECT`
+  would drop and never matches two `NULL`s, and the SQLite/MySQL `FULL JOIN`
+  emulations are a `UNION` that eliminates duplicate rows a real `FULL JOIN`
+  keeps. The set-operator note also states the support facts around them —
   that `Minus`/`MinusAll` are Oracle's spelling of `EXCEPT`/`EXCEPT ALL` and
   run only there, and that SQLite and SQL Server take `ALL` on `UNION` alone —
   which the section carried nowhere before. (#478)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   note names what to reach for instead, and says where the substitute is not
   equivalent — swapping an `ALL` form for its plain one eliminates duplicate
   rows, an `Exists`/`NotExists` rewrite keeps duplicates `EXCEPT`/`INTERSECT`
-  would drop and never matches two `NULL`s, and the SQLite/MySQL `FULL JOIN`
+  would drop, never matches two `NULL`s, and cannot reproduce the `ALL` forms'
+  copy counts at all, and the SQLite/MySQL `FULL JOIN`
   emulations are a `UNION` that eliminates duplicate rows a real `FULL JOIN`
   keeps. The set-operator note also states the support facts around them —
   that `Minus`/`MinusAll` are Oracle's spelling of `EXCEPT`/`EXCEPT ALL` and

--- a/docs/adr/0020-documentation-precision-boundary.md
+++ b/docs/adr/0020-documentation-precision-boundary.md
@@ -1,0 +1,139 @@
+# ADR 0020 — Documentation precision boundary: what the docs assert, and what they delegate to the engine
+
+**Status:** Accepted
+
+## Context
+
+One documentation change (#478's follow-up, four commits) went through four
+independent review rounds. Each round found a real defect; each defect sat in
+the same layer. The pattern is sharper than any individual finding:
+
+| Claim | Rounds survived | In-repo source of truth |
+|---|---|---|
+| What SqlArtisan emits | all | unit tests, asserting the exact SQL string |
+| Which dialects support a construct | all | `DialectMatrix.Entries`, live-verified by `MatrixSweepTests` |
+| From which engine version | all | `DialectMatrix.Bounds`, gated by `EveryBound_HasDocsProvenance` |
+| **Result semantics** (duplicates, `NULL` matching, multiplicity) | none | **none** |
+| **Equivalence between constructs; hand-written SQL rewrites** | none | **none** |
+
+Everything that held had a source of truth in the repository and a gate
+keeping the prose tied to it. Everything that broke had neither. The four
+defects were not carelessness on any one reviewer's part — the claims were
+unfalsifiable from inside the repo, so review could only trade one plausible
+assertion for another. Three of the four defects were introduced *by a fix for
+the previous round's defect*.
+
+There is a second, deeper reason those sentences kept failing. "Construct X is
+unavailable here, so write Y instead" is a **portability claim** — precisely
+what ADR 0001 refuses to do in code, and ADR 0010 names as a non-goal. The
+prose was offering what the library deliberately withholds, and inherited every
+correctness problem that comes with it: `EXCEPT` is not `EXCEPT ALL` minus its
+duplicates, a `UNION` of two one-sided joins is not a `FULL JOIN`, and a
+`NOT EXISTS` predicate is neither.
+
+`.claude/rules/docs-style.md` actively drove this: its dialect-caveat clause
+required "the working alternative in the same breath" and forbade "a bare 'not
+supported on X' with no way out." Each review round, the fix obeyed that rule
+by inventing another unverified equivalence.
+
+Version floors in the reference pages are the same class of liability without
+the same defence. `docs/` carries 44 of them; #477 measured every one as
+currently correct, and closed as not planned after finding they cannot be gated:
+a doc entry writes `` `Ltrim()` `` with no arity, so it cannot resolve the
+matrix's arity-specific keys, and several floors (Oracle 12c `OFFSET/FETCH`,
+SQLite 3.25 window functions, pgvector 0.7.0) lie outside the matrix's domain
+entirely. Their accuracy today rests on review alone, and every future engine
+release is a chance for them to drift silently.
+
+## Decision
+
+**A user-facing document asserts only what this repository can verify.**
+Everything else is the engine's contract, and the docs link to the engine's
+manual rather than restating it.
+
+### The three tiers
+
+| Tier | Stated in reference docs | Kept true by |
+|---|---|---|
+| What SqlArtisan emits | yes | unit tests (exact SQL strings) |
+| Which dialects support a construct | yes | `DialectMatrix.Entries` + `MatrixSweepTests` |
+| Minimum engine version | **no** — see below | — |
+| Result semantics; construct equivalence; SQL rewrites | **no** | — |
+
+### A version floor appears only where a gate keeps it synced
+
+Floors are not banned from the repository — they are banned from surfaces where
+nothing ties them to `DialectMatrix`:
+
+- **`docs/analyzer.md`'s version-bound register** — every bound, with its
+  primary source, gated by `DialectMatrixVersionBoundsTests.EveryBound_HasDocsProvenance`.
+  This is the reference-side home for floors.
+- **XML `<remarks>`** — gated in both directions by
+  `XmlDocDialectParityTests.RemarksVersionFloor_MatchesMatrix` (#471), so a
+  bound correction cannot ship without the remark moving with it.
+- **The analyzer itself** — `SQLA0101` reports the floor at the call site once
+  a target version is declared, which is the mechanism ADR 0003 designed for
+  this.
+
+Reference pages state *which dialects*, not *from which version*, and link to
+the register for the latter.
+
+### Substitution: point at an API, never at a rewrite
+
+When a construct is unavailable on a dialect, name the **sibling SqlArtisan
+API that emits that dialect's own construct** — `Minus` for Oracle's spelling
+of `EXCEPT`, the `LIMIT` / `OFFSET-FETCH` family for SQL Server's `TOP`. That
+is a fact about this library's surface, and the tests cover it.
+
+Never supply a hand-written SQL recipe, and never claim two constructs are
+interchangeable. Where no sibling API exists, **"not available there" is a
+complete answer** — the reader is better served by a correct full stop than by
+a rewrite whose limits the docs cannot state reliably.
+
+### What this does not touch
+
+Hazards about **SqlArtisan's own emitted SQL** stay, in full, under the
+existing callout taxonomy: MySQL parsing `||` as logical OR, `NATURAL JOIN`
+matching on shared column names as the schema drifts, `Log`'s dialect-defined
+base. These describe what our output does on a target engine — ADR 0010's guard
+rail, the reason this project exists. They are not claims about how to
+substitute one construct for another.
+
+## Rejected alternatives
+
+- **Gate the reference pages' floors against the matrix (#477).** Measured
+  infeasible: doc entries carry no arity, so a name-keyed lookup misfires on
+  exactly the entries where the docs are most precise (`Trim` states both the
+  member floor and the arity-2 floor on one line); 27 of the 44 floors sit in
+  prose, headings, or table cells with no entry name to key on; and several
+  floors have no matrix row at all, so the gate would pressure prose into
+  driving `VersionBounds` — whose bar is live, primary-source provenance.
+- **Keep the substitutes and write them more carefully.** Four rounds is the
+  evidence against. Each round's author had the previous round's finding in
+  hand and still shipped a fresh unverifiable claim; the layer's defect rate is
+  a property of it having no source of truth, not of who wrote it.
+- **Delegate the emitted-SQL hazards too.** Those are not DBMS-evolution
+  tracking — they describe this library's own output, and dropping them would
+  cut the guard rail ADR 0010 makes the mission.
+- **Keep floors in reference pages, accept review as the gate.** This is the
+  status quo that #477 documented and closed. It holds only as long as every
+  future reviewer re-derives 44 facts against five engines' release histories.
+
+## Consequences
+
+- `.claude/rules/docs-style.md` changes in two clauses: the dialect-caveat
+  note's "working alternative" requirement narrows to a sibling API, and the
+  version-boundary note is removed from reference-page prose and redirected to
+  the register.
+- The 44 existing floor mentions leave `docs/functions.md`,
+  `docs/query-statements.md`, `docs/expressions.md`, and `docs/cookbook.md`.
+  The register in `docs/analyzer.md` becomes the single reference-side home.
+- **Accepted cost:** a reader on a reference page no longer sees a construct's
+  floor inline and follows a link for it. In exchange the floor exists once,
+  where a test keeps it honest, and the analyzer surfaces it at the call site
+  where the reader is actually writing the query.
+- `sa-diff-review` and `sa-docs-audit` gain the classification question: does
+  this sentence claim an equivalence, supply a rewrite, or state result
+  semantics? If so it does not belong in the docs.
+- This boundary is what makes documentation review converge: a claim either has
+  a source of truth in the repo, or it is not made.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -43,6 +43,7 @@ only part of a cluster produces incomplete (and potentially wrong) conclusions.
 | [0017](0017-join-predicate-completeness.md) | Join predicate completeness: rejecting an omitted `ON`/`USING` that some dialects silently reinterpret as `CROSS JOIN` | Boundary | Accepted |
 | [0018](0018-analyzer-diagnostic-id-bands.md) | Analyzer diagnostic ID bands: one numbered range per category | Analyzer | Accepted |
 | [0019](0019-analyzer-multi-dialect-syntax-set.md) | Analyzer multi-dialect syntax set: `sqlartisan_syntax_*`, one key per DBMS | Analyzer | Accepted |
+| [0020](0020-documentation-precision-boundary.md) | Documentation precision boundary: what the docs assert, and what they delegate to the engine | | Accepted |
 
 ### Clusters
 

--- a/docs/query-statements.md
+++ b/docs/query-statements.md
@@ -236,14 +236,8 @@ On SQL Server, which has no `NATURAL JOIN`, write the match explicitly with
 unsupported too — emulate it with `LeftJoin(...).On(...)` unioned with
 `RightJoin(...).On(...)` there.
 
-`RIGHT JOIN` and `FULL JOIN`, and their `NATURAL` forms, need SQLite 3.39+. On
-an older build, swap the two tables and use `LeftJoin(...)` — or
-`NaturalLeftJoin(...)` for the natural form — and union two such swapped
-queries for the full form, since `RightJoin()` is missing there too.
-
-Both `FULL JOIN` emulations above are a `UNION` of two one-sided joins, which
-eliminates duplicate rows a real `FULL JOIN` keeps — they stand in only if
-duplicate rows don't matter.
+`RIGHT JOIN` and `FULL JOIN`, and their `NATURAL` forms, need SQLite 3.39+.
+`LeftJoin()` and `NaturalLeftJoin()` run on any version.
 
 #### JOIN ... USING
 
@@ -517,22 +511,14 @@ SqlStatement sql =
 
 `Minus` / `MinusAll` are Oracle's own spelling of `EXCEPT` / `EXCEPT ALL` and
 run only there. `ExceptAll` / `IntersectAll` are MySQL, Oracle, and PostgreSQL
-only — SQLite and SQL Server take `ALL` on `UNION` alone, where `Except` /
-`Intersect` stands in only if duplicates don't matter: the plain form
-eliminates duplicate rows, the `ALL` form keeps them.
+only — SQLite and SQL Server take `ALL` on `UNION` alone.
 
 `EXCEPT`, `INTERSECT`, and both `ALL` forms need MySQL 8.0.31+, and `EXCEPT`,
 `EXCEPT ALL`, `INTERSECT ALL`, and `MINUS ALL` need Oracle 21+ — plain `MINUS`
-and `INTERSECT` run on any Oracle version, so an Oracle below 21 takes the
-difference with `Minus`. Where no set operator reaches (MySQL below 8.0.31, and
-the `ALL` forms on Oracle below 21), write the test as an `Exists` /
-`NotExists` predicate instead. It stands in for the plain forms with two
-differences — its `=` join condition keeps duplicate rows (wrap it in
-`Select(Distinct, ...)` where that matters) and never matches two `NULL`s —
-but not for the `ALL` forms, which count copies: for a row present `m` times
-on the left and `n` times on the right, `EXCEPT ALL` returns it `max(m - n, 0)`
-times and `INTERSECT ALL` `min(m, n)` times, where the predicate can only keep
-or drop all `m`.
+and `INTERSECT` run on any Oracle version. An `ALL` form is not interchangeable
+with its plain one: the plain form eliminates duplicate rows, and how many
+copies the `ALL` form returns is the target engine's own rule — read its manual
+rather than swapping one for the other.
 
 ---
 

--- a/docs/query-statements.md
+++ b/docs/query-statements.md
@@ -236,9 +236,10 @@ On SQL Server, which has no `NATURAL JOIN`, write the match explicitly with
 unsupported too — emulate it with `LeftJoin(...).On(...)` unioned with
 `RightJoin(...).On(...)` there.
 
-`RIGHT JOIN` and `FULL JOIN`, and their `NATURAL` forms, are newer than SQLite
-itself (SQLite 3.39+); on an older build, swap the two tables and use
-`LeftJoin(...)`, or union the two one-sided joins for the full form.
+`RIGHT JOIN` and `FULL JOIN`, and their `NATURAL` forms, need SQLite 3.39+. On
+an older build, swap the two tables and use `LeftJoin(...)` — or
+`NaturalLeftJoin(...)` for the natural form — and union two such swapped
+queries for the full form, since `RightJoin()` is missing there too.
 
 #### JOIN ... USING
 
@@ -510,12 +511,19 @@ SqlStatement sql =
 - `Intersect` for `INTERSECT`
 - `IntersectAll` for `INTERSECT ALL`
 
-`Minus` / `MinusAll` are Oracle's spelling and exist only there, and
-`ExceptAll` / `IntersectAll` are MySQL, Oracle, and PostgreSQL only — SQLite
-and SQL Server accept `ALL` on `UNION` alone, so take the difference with
-`Except` / `Intersect` there. `EXCEPT`, `INTERSECT`, and their `ALL` forms are
-also newer than the engines themselves on two dialects (MySQL 8.0.31+, Oracle
-21+) — plain `MINUS` and `INTERSECT` run on any Oracle version.
+`Minus` / `MinusAll` are Oracle's own spelling of `EXCEPT` / `EXCEPT ALL` and
+run only there. `ExceptAll` / `IntersectAll` are MySQL, Oracle, and PostgreSQL
+only — SQLite and SQL Server take `ALL` on `UNION` alone, where `Except` /
+`Intersect` stands in only if duplicates don't matter: the plain form
+eliminates duplicate rows, the `ALL` form keeps them.
+
+`EXCEPT`, `INTERSECT`, and both `ALL` forms need MySQL 8.0.31+, and `EXCEPT`,
+`EXCEPT ALL`, `INTERSECT ALL`, and `MINUS ALL` need Oracle 21+ — plain `MINUS`
+and `INTERSECT` run on any Oracle version, so an Oracle below 21 takes the
+difference with `Minus`. Where no set operator reaches (MySQL below 8.0.31, and
+the `ALL` forms on Oracle below 21), write the test as an `Exists` /
+`NotExists` predicate instead, which matches `EXCEPT` / `INTERSECT` but not the
+duplicate-preserving `ALL` forms.
 
 ---
 

--- a/docs/query-statements.md
+++ b/docs/query-statements.md
@@ -526,9 +526,13 @@ eliminates duplicate rows, the `ALL` form keeps them.
 and `INTERSECT` run on any Oracle version, so an Oracle below 21 takes the
 difference with `Minus`. Where no set operator reaches (MySQL below 8.0.31, and
 the `ALL` forms on Oracle below 21), write the test as an `Exists` /
-`NotExists` predicate instead — but unlike `EXCEPT` / `INTERSECT`, its `=`
-join condition keeps duplicate rows (wrap it in `Select(Distinct, ...)` where
-that matters) and never matches two `NULL`s.
+`NotExists` predicate instead. It stands in for the plain forms with two
+differences — its `=` join condition keeps duplicate rows (wrap it in
+`Select(Distinct, ...)` where that matters) and never matches two `NULL`s —
+but not for the `ALL` forms, which count copies: for a row present `m` times
+on the left and `n` times on the right, `EXCEPT ALL` returns it `max(m - n, 0)`
+times and `INTERSECT ALL` `min(m, n)` times, where the predicate can only keep
+or drop all `m`.
 
 ---
 

--- a/docs/query-statements.md
+++ b/docs/query-statements.md
@@ -233,11 +233,9 @@ SqlStatement sql =
 
 On SQL Server, which has no `NATURAL JOIN`, write the match explicitly with
 `On(...)`; on MySQL, which has no `FULL JOIN` at all, `NaturalFullJoin()` is
-unsupported too — emulate it with `LeftJoin(...).On(...)` unioned with
-`RightJoin(...).On(...)` there.
-
-`RIGHT JOIN` and `FULL JOIN`, and their `NATURAL` forms, need SQLite 3.39+.
-`LeftJoin()` and `NaturalLeftJoin()` run on any version.
+unsupported too. SQLite gained `RIGHT JOIN` / `FULL JOIN` and their `NATURAL`
+forms in a specific release — see the
+[version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs).
 
 #### JOIN ... USING
 
@@ -263,7 +261,7 @@ SqlStatement sql =
 ```
 
 MySQL, Oracle, PostgreSQL, and SQLite support this (standard SQL); on SQL Server,
-which has no `JOIN ... USING`, write the equivalent `On(...)` predicate.
+which has no `JOIN ... USING`, write the match explicitly with `On(...)`.
 
 #### Correlated joins: APPLY / LATERAL
 
@@ -511,14 +509,10 @@ SqlStatement sql =
 
 `Minus` / `MinusAll` are Oracle's own spelling of `EXCEPT` / `EXCEPT ALL` and
 run only there. `ExceptAll` / `IntersectAll` are MySQL, Oracle, and PostgreSQL
-only — SQLite and SQL Server take `ALL` on `UNION` alone.
-
-`EXCEPT`, `INTERSECT`, and both `ALL` forms need MySQL 8.0.31+, and `EXCEPT`,
-`EXCEPT ALL`, `INTERSECT ALL`, and `MINUS ALL` need Oracle 21+ — plain `MINUS`
-and `INTERSECT` run on any Oracle version. An `ALL` form is not interchangeable
-with its plain one: the plain form eliminates duplicate rows, and how many
-copies the `ALL` form returns is the target engine's own rule — read its manual
-rather than swapping one for the other.
+only — SQLite and SQL Server take `ALL` on `UNION` alone. Several of these
+arrived in a specific engine release; the
+[version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs)
+lists each one, and the analyzer reports it against a declared target version.
 
 ---
 

--- a/docs/query-statements.md
+++ b/docs/query-statements.md
@@ -241,6 +241,10 @@ an older build, swap the two tables and use `LeftJoin(...)` — or
 `NaturalLeftJoin(...)` for the natural form — and union two such swapped
 queries for the full form, since `RightJoin()` is missing there too.
 
+Both `FULL JOIN` emulations above are a `UNION` of two one-sided joins, which
+eliminates duplicate rows a real `FULL JOIN` keeps — they stand in only if
+duplicate rows don't matter.
+
 #### JOIN ... USING
 
 `.Using(column, ...)` follows `InnerJoin()` / `LeftJoin()` / `RightJoin()` /
@@ -522,8 +526,9 @@ eliminates duplicate rows, the `ALL` form keeps them.
 and `INTERSECT` run on any Oracle version, so an Oracle below 21 takes the
 difference with `Minus`. Where no set operator reaches (MySQL below 8.0.31, and
 the `ALL` forms on Oracle below 21), write the test as an `Exists` /
-`NotExists` predicate instead, which matches `EXCEPT` / `INTERSECT` but not the
-duplicate-preserving `ALL` forms.
+`NotExists` predicate instead — but unlike `EXCEPT` / `INTERSECT`, its `=`
+join condition keeps duplicate rows (wrap it in `Select(Distinct, ...)` where
+that matters) and never matches two `NULL`s.
 
 ---
 

--- a/docs/query-statements.md
+++ b/docs/query-statements.md
@@ -236,6 +236,10 @@ On SQL Server, which has no `NATURAL JOIN`, write the match explicitly with
 unsupported too — emulate it with `LeftJoin(...).On(...)` unioned with
 `RightJoin(...).On(...)` there.
 
+`RIGHT JOIN` and `FULL JOIN`, and their `NATURAL` forms, are newer than SQLite
+itself (SQLite 3.39+); on an older build, swap the two tables and use
+`LeftJoin(...)`, or union the two one-sided joins for the full form.
+
 #### JOIN ... USING
 
 `.Using(column, ...)` follows `InnerJoin()` / `LeftJoin()` / `RightJoin()` /
@@ -505,6 +509,13 @@ SqlStatement sql =
 - `MinusAll` for `MINUS ALL`
 - `Intersect` for `INTERSECT`
 - `IntersectAll` for `INTERSECT ALL`
+
+`Minus` / `MinusAll` are Oracle's spelling and exist only there, and
+`ExceptAll` / `IntersectAll` are MySQL, Oracle, and PostgreSQL only — SQLite
+and SQL Server accept `ALL` on `UNION` alone, so take the difference with
+`Except` / `Intersect` there. `EXCEPT`, `INTERSECT`, and their `ALL` forms are
+also newer than the engines themselves on two dialects (MySQL 8.0.31+, Oracle
+21+) — plain `MINUS` and `INTERSECT` run on any Oracle version.
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -962,9 +962,13 @@ eliminates duplicate rows, the `ALL` form keeps them.
 and `INTERSECT` run on any Oracle version, so an Oracle below 21 takes the
 difference with `Minus`. Where no set operator reaches (MySQL below 8.0.31, and
 the `ALL` forms on Oracle below 21), write the test as an `Exists` /
-`NotExists` predicate instead — but unlike `EXCEPT` / `INTERSECT`, its `=`
-join condition keeps duplicate rows (wrap it in `Select(Distinct, ...)` where
-that matters) and never matches two `NULL`s.
+`NotExists` predicate instead. It stands in for the plain forms with two
+differences — its `=` join condition keeps duplicate rows (wrap it in
+`Select(Distinct, ...)` where that matters) and never matches two `NULL`s —
+but not for the `ALL` forms, which count copies: for a row present `m` times
+on the left and `n` times on the right, `EXCEPT ALL` returns it `max(m - n, 0)`
+times and `INTERSECT ALL` `min(m, n)` times, where the predicate can only keep
+or drop all `m`.
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -677,6 +677,10 @@ an older build, swap the two tables and use `LeftJoin(...)` — or
 `NaturalLeftJoin(...)` for the natural form — and union two such swapped
 queries for the full form, since `RightJoin()` is missing there too.
 
+Both `FULL JOIN` emulations above are a `UNION` of two one-sided joins, which
+eliminates duplicate rows a real `FULL JOIN` keeps — they stand in only if
+duplicate rows don't matter.
+
 #### JOIN ... USING
 
 `.Using(column, ...)` follows `InnerJoin()` / `LeftJoin()` / `RightJoin()` /
@@ -958,8 +962,9 @@ eliminates duplicate rows, the `ALL` form keeps them.
 and `INTERSECT` run on any Oracle version, so an Oracle below 21 takes the
 difference with `Minus`. Where no set operator reaches (MySQL below 8.0.31, and
 the `ALL` forms on Oracle below 21), write the test as an `Exists` /
-`NotExists` predicate instead, which matches `EXCEPT` / `INTERSECT` but not the
-duplicate-preserving `ALL` forms.
+`NotExists` predicate instead — but unlike `EXCEPT` / `INTERSECT`, its `=`
+join condition keeps duplicate rows (wrap it in `Select(Distinct, ...)` where
+that matters) and never matches two `NULL`s.
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -672,14 +672,8 @@ On SQL Server, which has no `NATURAL JOIN`, write the match explicitly with
 unsupported too — emulate it with `LeftJoin(...).On(...)` unioned with
 `RightJoin(...).On(...)` there.
 
-`RIGHT JOIN` and `FULL JOIN`, and their `NATURAL` forms, need SQLite 3.39+. On
-an older build, swap the two tables and use `LeftJoin(...)` — or
-`NaturalLeftJoin(...)` for the natural form — and union two such swapped
-queries for the full form, since `RightJoin()` is missing there too.
-
-Both `FULL JOIN` emulations above are a `UNION` of two one-sided joins, which
-eliminates duplicate rows a real `FULL JOIN` keeps — they stand in only if
-duplicate rows don't matter.
+`RIGHT JOIN` and `FULL JOIN`, and their `NATURAL` forms, need SQLite 3.39+.
+`LeftJoin()` and `NaturalLeftJoin()` run on any version.
 
 #### JOIN ... USING
 
@@ -953,22 +947,14 @@ SqlStatement sql =
 
 `Minus` / `MinusAll` are Oracle's own spelling of `EXCEPT` / `EXCEPT ALL` and
 run only there. `ExceptAll` / `IntersectAll` are MySQL, Oracle, and PostgreSQL
-only — SQLite and SQL Server take `ALL` on `UNION` alone, where `Except` /
-`Intersect` stands in only if duplicates don't matter: the plain form
-eliminates duplicate rows, the `ALL` form keeps them.
+only — SQLite and SQL Server take `ALL` on `UNION` alone.
 
 `EXCEPT`, `INTERSECT`, and both `ALL` forms need MySQL 8.0.31+, and `EXCEPT`,
 `EXCEPT ALL`, `INTERSECT ALL`, and `MINUS ALL` need Oracle 21+ — plain `MINUS`
-and `INTERSECT` run on any Oracle version, so an Oracle below 21 takes the
-difference with `Minus`. Where no set operator reaches (MySQL below 8.0.31, and
-the `ALL` forms on Oracle below 21), write the test as an `Exists` /
-`NotExists` predicate instead. It stands in for the plain forms with two
-differences — its `=` join condition keeps duplicate rows (wrap it in
-`Select(Distinct, ...)` where that matters) and never matches two `NULL`s —
-but not for the `ALL` forms, which count copies: for a row present `m` times
-on the left and `n` times on the right, `EXCEPT ALL` returns it `max(m - n, 0)`
-times and `INTERSECT ALL` `min(m, n)` times, where the predicate can only keep
-or drop all `m`.
+and `INTERSECT` run on any Oracle version. An `ALL` form is not interchangeable
+with its plain one: the plain form eliminates duplicate rows, and how many
+copies the `ALL` form returns is the target engine's own rule — read its manual
+rather than swapping one for the other.
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -672,9 +672,10 @@ On SQL Server, which has no `NATURAL JOIN`, write the match explicitly with
 unsupported too — emulate it with `LeftJoin(...).On(...)` unioned with
 `RightJoin(...).On(...)` there.
 
-`RIGHT JOIN` and `FULL JOIN`, and their `NATURAL` forms, are newer than SQLite
-itself (SQLite 3.39+); on an older build, swap the two tables and use
-`LeftJoin(...)`, or union the two one-sided joins for the full form.
+`RIGHT JOIN` and `FULL JOIN`, and their `NATURAL` forms, need SQLite 3.39+. On
+an older build, swap the two tables and use `LeftJoin(...)` — or
+`NaturalLeftJoin(...)` for the natural form — and union two such swapped
+queries for the full form, since `RightJoin()` is missing there too.
 
 #### JOIN ... USING
 
@@ -946,12 +947,19 @@ SqlStatement sql =
 - `Intersect` for `INTERSECT`
 - `IntersectAll` for `INTERSECT ALL`
 
-`Minus` / `MinusAll` are Oracle's spelling and exist only there, and
-`ExceptAll` / `IntersectAll` are MySQL, Oracle, and PostgreSQL only — SQLite
-and SQL Server accept `ALL` on `UNION` alone, so take the difference with
-`Except` / `Intersect` there. `EXCEPT`, `INTERSECT`, and their `ALL` forms are
-also newer than the engines themselves on two dialects (MySQL 8.0.31+, Oracle
-21+) — plain `MINUS` and `INTERSECT` run on any Oracle version.
+`Minus` / `MinusAll` are Oracle's own spelling of `EXCEPT` / `EXCEPT ALL` and
+run only there. `ExceptAll` / `IntersectAll` are MySQL, Oracle, and PostgreSQL
+only — SQLite and SQL Server take `ALL` on `UNION` alone, where `Except` /
+`Intersect` stands in only if duplicates don't matter: the plain form
+eliminates duplicate rows, the `ALL` form keeps them.
+
+`EXCEPT`, `INTERSECT`, and both `ALL` forms need MySQL 8.0.31+, and `EXCEPT`,
+`EXCEPT ALL`, `INTERSECT ALL`, and `MINUS ALL` need Oracle 21+ — plain `MINUS`
+and `INTERSECT` run on any Oracle version, so an Oracle below 21 takes the
+difference with `Minus`. Where no set operator reaches (MySQL below 8.0.31, and
+the `ALL` forms on Oracle below 21), write the test as an `Exists` /
+`NotExists` predicate instead, which matches `EXCEPT` / `INTERSECT` but not the
+duplicate-preserving `ALL` forms.
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -672,6 +672,10 @@ On SQL Server, which has no `NATURAL JOIN`, write the match explicitly with
 unsupported too — emulate it with `LeftJoin(...).On(...)` unioned with
 `RightJoin(...).On(...)` there.
 
+`RIGHT JOIN` and `FULL JOIN`, and their `NATURAL` forms, are newer than SQLite
+itself (SQLite 3.39+); on an older build, swap the two tables and use
+`LeftJoin(...)`, or union the two one-sided joins for the full form.
+
 #### JOIN ... USING
 
 `.Using(column, ...)` follows `InnerJoin()` / `LeftJoin()` / `RightJoin()` /
@@ -941,6 +945,13 @@ SqlStatement sql =
 - `MinusAll` for `MINUS ALL`
 - `Intersect` for `INTERSECT`
 - `IntersectAll` for `INTERSECT ALL`
+
+`Minus` / `MinusAll` are Oracle's spelling and exist only there, and
+`ExceptAll` / `IntersectAll` are MySQL, Oracle, and PostgreSQL only — SQLite
+and SQL Server accept `ALL` on `UNION` alone, so take the difference with
+`Except` / `Intersect` there. `EXCEPT`, `INTERSECT`, and their `ALL` forms are
+also newer than the engines themselves on two dialects (MySQL 8.0.31+, Oracle
+21+) — plain `MINUS` and `INTERSECT` run on any Oracle version.
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -669,11 +669,9 @@ SqlStatement sql =
 
 On SQL Server, which has no `NATURAL JOIN`, write the match explicitly with
 `On(...)`; on MySQL, which has no `FULL JOIN` at all, `NaturalFullJoin()` is
-unsupported too — emulate it with `LeftJoin(...).On(...)` unioned with
-`RightJoin(...).On(...)` there.
-
-`RIGHT JOIN` and `FULL JOIN`, and their `NATURAL` forms, need SQLite 3.39+.
-`LeftJoin()` and `NaturalLeftJoin()` run on any version.
+unsupported too. SQLite gained `RIGHT JOIN` / `FULL JOIN` and their `NATURAL`
+forms in a specific release — see the
+[version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs).
 
 #### JOIN ... USING
 
@@ -699,7 +697,7 @@ SqlStatement sql =
 ```
 
 MySQL, Oracle, PostgreSQL, and SQLite support this (standard SQL); on SQL Server,
-which has no `JOIN ... USING`, write the equivalent `On(...)` predicate.
+which has no `JOIN ... USING`, write the match explicitly with `On(...)`.
 
 #### Correlated joins: APPLY / LATERAL
 
@@ -947,14 +945,10 @@ SqlStatement sql =
 
 `Minus` / `MinusAll` are Oracle's own spelling of `EXCEPT` / `EXCEPT ALL` and
 run only there. `ExceptAll` / `IntersectAll` are MySQL, Oracle, and PostgreSQL
-only — SQLite and SQL Server take `ALL` on `UNION` alone.
-
-`EXCEPT`, `INTERSECT`, and both `ALL` forms need MySQL 8.0.31+, and `EXCEPT`,
-`EXCEPT ALL`, `INTERSECT ALL`, and `MINUS ALL` need Oracle 21+ — plain `MINUS`
-and `INTERSECT` run on any Oracle version. An `ALL` form is not interchangeable
-with its plain one: the plain form eliminates duplicate rows, and how many
-copies the `ALL` form returns is the target engine's own rule — read its manual
-rather than swapping one for the other.
+only — SQLite and SQL Server take `ALL` on `UNION` alone. Several of these
+arrived in a specific engine release; the
+[version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs)
+lists each one, and the analyzer reports it against a declared target version.
 
 ---
 


### PR DESCRIPTION
This PR started as "state nine version floors where their constructs are documented" (the salvageable part of #478). Four review rounds later it is a policy change, because the reviews found the same thing four times and the fourth time it was worth asking why.

## What the four rounds showed

Every defect sat in one layer, and the layer is identifiable by a property that has nothing to do with who wrote it:

| Claim | Rounds survived | Source of truth in repo |
|---|---|---|
| What SqlArtisan emits | all | unit tests (exact SQL) |
| Which dialects support a construct | all | `DialectMatrix.Entries` + `MatrixSweepTests` |
| From which engine version | all | `DialectMatrix.Bounds` + `EveryBound_HasDocsProvenance` |
| Result semantics (duplicates, `NULL`, multiplicity) | none | none |
| Construct equivalence; hand-written SQL rewrites | none | none |

Three of the four defects were introduced by the fix for the previous round. The claims were unfalsifiable from inside the repo, so each review could only trade one plausible assertion for another.

There was also a charter problem: "construct X is unavailable here, write Y instead" is a portability claim — what ADR 0001 refuses in code and ADR 0010 names a non-goal. `.claude/rules/docs-style.md` was mandating it ("the working alternative in the same breath … never a bare 'not supported on X' with no way out"), so each round's fix dutifully invented another unverified equivalence.

## ADR 0020

A user-facing document asserts only what this repository can verify:

- **States**: what SqlArtisan emits; which dialects support a construct.
- **Delegates**: result semantics, construct equivalence, SQL rewrites — with a link to the engine's manual instead.
- **Version floors** live only where a test ties them to `DialectMatrix` — `docs/analyzer.md`'s register, XML `<remarks>` (gated by #471's parity test), and `SQLA0101` at the call site. Reference pages link to the register.
- **Substitution** names a sibling SqlArtisan API that emits that dialect's own construct (`Minus` for Oracle's `EXCEPT`), or nothing at all. "Not available there" is a complete answer.
- **Unchanged**: hazards about SqlArtisan's *own* emitted SQL (MySQL's `||`, `NATURAL JOIN` schema drift, `Log`'s dialect-defined base). Those are ADR 0010's guard rail, not DBMS-evolution tracking.

The ADR records the rejected alternatives too — gating the docs' floors (measured infeasible in #477), writing the substitutes more carefully (four rounds is the evidence), and dropping the emitted-SQL hazards.

## Applied here

- `.claude/rules/docs-style.md`: dialect-caveat clause narrowed to a sibling API; version-boundary clause removed from reference prose; result semantics called out as the engine's.
- `sa-diff-review` gains an **out of boundary** defect shape; `sa-docs-audit` gains dimension 11.
- `docs/query-statements.md`'s set-operator section states the dialect support its API list never carried — `Minus`/`MinusAll` Oracle-only, `ExceptAll`/`IntersectAll` on MySQL/Oracle/PostgreSQL, SQLite and SQL Server taking `ALL` on `UNION` alone — and links the register for versions, as does the JOIN section.
- Two pre-existing claims retire: the MySQL `FULL JOIN` emulation recipe (a `UNION` of two one-sided joins drops duplicate rows the join keeps — probe: 6 rows vs 3) and SQL Server's `JOIN ... USING` substitute described as an "equivalent" `On(...)` predicate (`USING` collapses the join column).

## Verification

`SqlArtisan.Tests` 1045 green (+1 versus main: `DocsCalloutTests` enumerates `docs/**/*.md`, so the new ADR is one more case); `dotnet format --verify-no-changes` clean; `check_links.py` resolves all anchors; `llms-full.txt` regenerated per `LlmsFullTests`' header.

## Follow-up

44 version-floor mentions remain in `docs/functions.md` (30), `docs/query-statements.md` (9), `docs/expressions.md` (4), and `docs/cookbook.md` (1). All are currently accurate — #477 verified each — so removing them is maintenance-surface reduction, not error correction. Tracked separately so this PR stays reviewable as a policy change.