### PR TITLE
docs: Retire the 44 version floors left in the reference pages (ADR 0020)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Docs
+- Retired the 44 version floors ADR 0020 left in `docs/functions.md`,
+  `docs/query-statements.md`, `docs/expressions.md`, and `docs/cookbook.md`.
+  Each floor either drops the version and keeps the dialect fact, or — where
+  the surrounding sentence already named the supported dialects — drops the
+  parenthetical entirely; the handful backed by `docs/analyzer.md`'s
+  version-bound register (MySQL's `WithRecursive`/`JsonValue`, Oracle's vector
+  operators, PostgreSQL's `MERGE`/`Log10`/`Regexp*`, SQLite's math functions
+  and `RETURNING`/`STRING_AGG`/`Substring`, SQL Server's `Trim`/`Greatest`/
+  `Least`/`Datetrunc`) now link it instead of restating a number nothing keeps
+  current. A few floors named no matrix row at all — Oracle's `LATERAL`/
+  `OFFSET`/`FETCH`, SQLite's `UPDATE … FROM`, SQL Server's multi-row `VALUES`,
+  and the window-function frame requirement — those simply drop the version,
+  the last dropping its now-vacuous "every dialect" bullet entirely. (#480)
 - **ADR 0020 draws a precision boundary for the documentation**: a page states
   what SqlArtisan emits and which dialects support a construct — both tied to
   tests — and delegates the rest to the engine. Result semantics (duplicate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Docs
-- Retired the 44 version floors ADR 0020 left in `docs/functions.md`,
+- Retired every version floor ADR 0020 left in `docs/functions.md`,
   `docs/query-statements.md`, `docs/expressions.md`, and `docs/cookbook.md`.
-  Each floor either drops the version and keeps the dialect fact, or — where
-  the surrounding sentence already named the supported dialects — drops the
-  parenthetical entirely; the handful backed by `docs/analyzer.md`'s
-  version-bound register (MySQL's `WithRecursive`/`JsonValue`, Oracle's vector
-  operators, PostgreSQL's `MERGE`/`Log10`/`Regexp*`, SQLite's math functions
-  and `RETURNING`/`STRING_AGG`/`Substring`, SQL Server's `Trim`/`Greatest`/
-  `Least`/`Datetrunc`) now link it instead of restating a number nothing keeps
-  current. A few floors named no matrix row at all — Oracle's `LATERAL`/
+  Where the parenthetical was a support list carrying a floor, it keeps the
+  dialects and drops the version; where it annotated one dialect's floor on a
+  construct every dialect accepts (`Exp`, `Floor`, `Power`, `Sqrt`, `Sign`,
+  1-argument `Trim`), the note goes entirely — on these pages an unqualified
+  dialect list means "only there", so keeping one would have stated a support
+  set the matrix contradicts. Floors backed by `docs/analyzer.md`'s
+  version-bound register (MySQL's `WithRecursive`/`JsonValue`/row-alias
+  UPSERT, Oracle's vector operators, PostgreSQL's `MERGE`, SQLite's
+  `RETURNING`/`STRING_AGG`) now link it instead of restating a number nothing
+  keeps current. Floors with no matrix row at all — Oracle's `LATERAL`/
   `OFFSET`/`FETCH`, SQLite's `UPDATE … FROM`, SQL Server's multi-row `VALUES`,
-  and the window-function frame requirement — those simply drop the version,
-  the last dropping its now-vacuous "every dialect" bullet entirely. (#480)
+  and the window-function frame requirement — simply drop the version, the
+  last dropping its now-vacuous "every dialect" bullet entirely. (#480)
 - **ADR 0020 draws a precision boundary for the documentation**: a page states
   what SqlArtisan emits and which dialects support a construct — both tied to
   tests — and delegates the rest to the engine. Result semantics (duplicate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Docs
-- Retired every version floor ADR 0020 left in `docs/functions.md`,
-  `docs/query-statements.md`, `docs/expressions.md`, and `docs/cookbook.md`.
+- Retired every version floor the documentation precision boundary left in
+  `docs/functions.md`, `docs/query-statements.md`, `docs/expressions.md`, and
+  `docs/cookbook.md`.
   Where the parenthetical was a support list carrying a floor, it keeps the
   dialects and drops the version; where it annotated one dialect's floor on a
   construct every dialect accepts (`Exp`, `Floor`, `Power`, `Sqrt`, `Sign`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `OFFSET`/`FETCH`, SQLite's `UPDATE … FROM`, SQL Server's multi-row `VALUES`,
   and the window-function frame requirement — simply drop the version, the
   last dropping its now-vacuous "every dialect" bullet entirely. (#480)
-- **ADR 0020 draws a precision boundary for the documentation**: a page states
+- **A precision boundary for the documentation**: a page states
   what SqlArtisan emits and which dialects support a construct — both tied to
   tests — and delegates the rest to the engine. Result semantics (duplicate
   handling, `NULL` matching, multiplicity), equivalence between two constructs,
@@ -38,7 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   of `EXCEPT`/`EXCEPT ALL` and run only there, `ExceptAll`/`IntersectAll` are
   MySQL, Oracle, and PostgreSQL only, and SQLite and SQL Server take `ALL` on
   `UNION` alone — and both it and the JOIN section link the register for the
-  versions. Two pre-existing claims retire under ADR 0020: the MySQL `FULL JOIN`
+  versions. Two pre-existing claims retire under that boundary: the MySQL `FULL JOIN`
   emulation recipe (a `UNION` of two one-sided joins, which drops duplicate rows
   the join keeps) and SQL Server's `JOIN ... USING` substitute, described as an
   "equivalent" `On(...)` predicate though `USING` collapses the join column.

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -244,7 +244,7 @@ SqlStatement sql =
 ```
 
 This shape runs on all five dialects (only markers and quoting differ). On
-MySQL, Oracle (12c+), PostgreSQL, and SQL Server, a
+MySQL, Oracle, PostgreSQL, and SQL Server, a
 [row-limited `LATERAL` / `APPLY` subquery](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/query-statements.md#row-limited-queries-as-subqueries)
 is the per-group top-N alternative.
 
@@ -420,7 +420,7 @@ InsertInto(u, u.ProductId, u.Price)
 // RETURNING product_id, price
 // (SQLite emits lowercase "excluded.price" — Build(Dbms.Sqlite) handles it)
 
-// MySQL — ON DUPLICATE KEY UPDATE (8.0.19+ row-alias form):
+// MySQL — ON DUPLICATE KEY UPDATE (row-alias form):
 InsertInto(u, u.ProductId, u.Price)
     .Values(1, 990)
     .OnDuplicateKeyUpdate(u.Price == Excluded(u.Price))

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -538,9 +538,9 @@ SqlStatement sql =
 // LIMIT :1
 ```
 
-`L2Distance` (`<->`), `CosineDistance` (`<=>`), and `NegativeInnerProduct` (`<#>`) work on Oracle (23ai+) and PostgreSQL; `L1Distance` (`<+>`), `HammingDistance` (`<~>`), and `JaccardDistance` (`<%>`) are PostgreSQL only (pgvector 0.7.0+). On PostgreSQL all six need the [pgvector](https://github.com/pgvector/pgvector) extension installed in the database (`CREATE EXTENSION vector`); on Oracle 23ai the three shared operators are built in.
+`L2Distance` (`<->`), `CosineDistance` (`<=>`), and `NegativeInnerProduct` (`<#>`) work on Oracle and PostgreSQL (Oracle gained the three shared operators in a specific release — see the [version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs)); `L1Distance` (`<+>`), `HammingDistance` (`<~>`), and `JaccardDistance` (`<%>`) are PostgreSQL only, via the pgvector extension. On PostgreSQL all six need the [pgvector](https://github.com/pgvector/pgvector) extension installed in the database (`CREATE EXTENSION vector`); on Oracle the three shared operators are built in.
 
-A bound vector literal reaches PostgreSQL as `text` — wrap it in `Cast(text, "vector")` (or `Cast(bits, "bit(n)")` for the bit operators) as above. On Oracle, drop the `Cast` — Oracle 23ai rejects `CAST(... AS vector)` outright (ORA-22849); pass the vector string bare (`L2Distance(u.Embedding, "[0.1,0.2,0.3]")`) and Oracle converts the bound string implicitly. `NegativeInnerProduct` returns the **negative** inner product, so the smallest value is still the most similar. On MySQL, `<=>` is the NULL-safe equality operator — the same glyph as `CosineDistance` with entirely different meaning — so keep cosine-distance queries off MySQL connections.
+A bound vector literal reaches PostgreSQL as `text` — wrap it in `Cast(text, "vector")` (or `Cast(bits, "bit(n)")` for the bit operators) as above. On Oracle, drop the `Cast` — Oracle rejects `CAST(... AS vector)` outright (ORA-22849); pass the vector string bare (`L2Distance(u.Embedding, "[0.1,0.2,0.3]")`) and Oracle converts the bound string implicitly. `NegativeInnerProduct` returns the **negative** inner product, so the smallest value is still the most similar. On MySQL, `<=>` is the NULL-safe equality operator — the same glyph as `CosineDistance` with entirely different meaning — so keep cosine-distance queries off MySQL connections.
 
 To bind a `Pgvector.Vector` instance instead of a cast string literal, construct the bind directly — `new BindValue(vector)` — and register pgvector's Dapper type handler (`VectorTypeHandler`, from the `Pgvector.Dapper` package) plus `UseVector()` on the Npgsql data source (from the `Pgvector` package); the held value then flows to the driver untouched.
 
@@ -938,7 +938,6 @@ SqlStatement sql =
 - A single bound uses `Rows(bound)` / `Range(bound)` (e.g. `Rows(UnboundedPreceding)`); `RowsBetween(start, end)` / `RangeBetween(start, end)` produce `ROWS/RANGE BETWEEN ... AND ...`.
 - A mis-ordered frame throws `ArgumentException` — no engine accepts a single bound past `CurrentRow` (use the `BETWEEN` form for `Following(n)` / `UnboundedFollowing`) or a `BETWEEN` start ranking later than its end.
 - A frame requires `ORDER BY`, so `Rows(...)` / `Range(...)` are available only after `OrderBy(...)` (optionally with `PartitionBy(...)`).
-- Requires MySQL 8.0+, Oracle, PostgreSQL, SQLite 3.25+, or SQL Server 2012+.
 
 ### Example using PERCENTILE_CONT / PERCENTILE_DISC
 
@@ -993,12 +992,12 @@ Chain `.Over(...)` afterwards for a filtered window function — `SUM(amount) FI
 
 ## String Aggregation
 
-String aggregation flattens the values of a group into one delimited string. This is the most syntactically divergent feature in scope, so SqlArtisan exposes it per dialect (no unified rewrite): you call the function your target DBMS supports, and the SQL you write is the SQL that runs.
+String aggregation flattens the values of a group into one delimited string. This is the most syntactically divergent feature in scope, so SqlArtisan exposes it per dialect (no unified rewrite): you call the function your target DBMS supports, and the SQL you write is the SQL that runs. SQLite gained `STRING_AGG` in a specific release — see the [version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs).
 
-### STRING_AGG (PostgreSQL / SQLite 3.44+ / SQL Server)
+### STRING_AGG (PostgreSQL / SQLite / SQL Server)
 
 ```csharp
-// PostgreSQL / SQLite (3.44+): ordering is inline inside the call, so pass OrderBy(...) as an argument
+// PostgreSQL / SQLite: ordering is inline inside the call, so pass OrderBy(...) as an argument
 Select(StringAgg(u.Name, ", ", OrderBy(u.Name)))
     .From(u)
     .Build(Dbms.PostgreSql);

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -6,6 +6,9 @@
 > **How to read this reference.** Each entry maps a C# API to the SQL token it emits.
 > Pick the API for your target DBMS; a single call is not rewritten per dialect.
 > Dialect notes list databases in the order **MySQL, Oracle, PostgreSQL, SQLite, SQL Server**.
+> Where a dialect note names a construct without saying since when, the
+> [version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs)
+> has the minimum engine version, kept in sync by a test.
 
 ## Contents
 
@@ -19,19 +22,19 @@ SqlArtisan provides C# APIs that map to various SQL functions, enabling you to u
 ## Numeric Functions
 
 - `Abs()` for `ABS`
-- `Ceil()` for `CEIL` (Oracle; MySQL/PostgreSQL/SQLite 3.35+ accept both spellings)
-- `Ceiling()` for `CEILING` (SQL Server; MySQL/PostgreSQL/SQLite 3.35+ accept both spellings)
-- `Exp()` for `EXP` (SQLite 3.35+)
-- `Floor()` for `FLOOR` (SQLite 3.35+)
-- `Ln()` for `LN` (SQLite 3.35+; not supported by SQL Server — its `LOG(x)` is the natural logarithm)
+- `Ceil()` for `CEIL` (Oracle; MySQL/PostgreSQL/SQLite accept both spellings)
+- `Ceiling()` for `CEILING` (SQL Server; MySQL/PostgreSQL/SQLite accept both spellings)
+- `Exp()` for `EXP` (SQLite)
+- `Floor()` for `FLOOR` (SQLite)
+- `Ln()` for `LN` (SQLite; not supported by SQL Server — its `LOG(x)` is the natural logarithm)
 - `Log(x)` for `LOG(x)`; `Log(base, x)` for `LOG(base, x)` — **the base differs per dialect, see below**
-- `Log10()` for `LOG10` (PostgreSQL 12+, SQLite 3.35+; not supported by Oracle — spell it `Log(10, x)` there)
-- `Mod()` for `MOD` (SQLite 3.35+; not supported by SQL Server — use the `%` operator there)
-- `Power()` for `POWER` (SQLite 3.35+)
+- `Log10()` for `LOG10` (PostgreSQL, SQLite; not supported by Oracle — spell it `Log(10, x)` there)
+- `Mod()` for `MOD` (SQLite; not supported by SQL Server — use the `%` operator there)
+- `Power()` for `POWER` (SQLite)
 - `Round()` for `ROUND` (single-argument `Round(expr)` is not supported by SQL Server — pass the scale explicitly there)
-- `Sign()` for `SIGN` (SQLite 3.35+)
-- `Sqrt()` for `SQRT` (SQLite 3.35+)
-- `Trunc()` for `TRUNC` (Numeric Overload; Oracle, PostgreSQL, SQLite 3.35+ — the two-argument scale form is Oracle/PostgreSQL only)
+- `Sign()` for `SIGN` (SQLite)
+- `Sqrt()` for `SQRT` (SQLite)
+- `Trunc()` for `TRUNC` (Numeric Overload; Oracle, PostgreSQL, SQLite — the two-argument scale form is Oracle/PostgreSQL only)
 
 > [!WARNING]
 > **`LOG` silently changes meaning with the target, in both forms.** `SQLA0100` catches Oracle's rejection of `Log(x)` and every 2-arg `Log` on SQL Server; every other cell below runs, right or silently wrong.
@@ -41,7 +44,7 @@ SqlArtisan provides C# APIs that map to various SQL functions, enabling you to u
 > | `Log(x)` → `LOG(x)` | base e | *(rejected)* | base 10 | base 10 | base e |
 > | `Log(b, x)` → `LOG(b, x)` | log<sub>b</sub>x | log<sub>b</sub>x | log<sub>b</sub>x | log<sub>b</sub>x | log<sub>x</sub>b |
 >
-> SQL Server's row inverts (value first, base second). For a base that does not vary: `Ln(x)` (MySQL, Oracle, PostgreSQL, SQLite 3.35+), `Log10(x)` (MySQL, PostgreSQL 12+, SQLite 3.35+, SQL Server), or `Log(base, x)` on the four base-first engines (SQLite 3.35+).
+> SQL Server's row inverts (value first, base second). For a base that does not vary: `Ln(x)` (MySQL, Oracle, PostgreSQL, SQLite), `Log10(x)` (MySQL, PostgreSQL, SQLite, SQL Server), or `Log(base, x)` on the four base-first engines (SQLite).
 
 `SQLA0100` also flags every two-argument `Log` call on SQL Server — blind to
 argument order — including the correct T-SQL spelling: call `Log(base, x)`
@@ -56,30 +59,30 @@ not at the SqlArtisan layer.
 
 ## Character Functions
 
-- `Concat(a, b)` for `CONCAT(a, b)`; `Concat(a, b, c, ...)` for `CONCAT(a, b, c, ...)` (SQLite 3.44+; Oracle takes only the two-argument form — see below)
-- `ConcatWs(sep, a, b, ...)` for `CONCAT_WS(sep, a, b, ...)` (MySQL, PostgreSQL, SQLite 3.44+, SQL Server 2017+)
+- `Concat(a, b)` for `CONCAT(a, b)`; `Concat(a, b, c, ...)` for `CONCAT(a, b, c, ...)` (SQLite; Oracle takes only the two-argument form — see below)
+- `ConcatWs(sep, a, b, ...)` for `CONCAT_WS(sep, a, b, ...)` (MySQL, PostgreSQL, SQLite, SQL Server)
 - `CharLength()` for `CHAR_LENGTH` (MySQL, PostgreSQL)
 - `Instr()` for `INSTR` (MySQL, Oracle, SQLite; the 3- and 4-argument forms are Oracle-only)
 - `Left()` for `LEFT` (MySQL, PostgreSQL, SQL Server)
 - `Lpad()` for `LPAD` (MySQL, Oracle, PostgreSQL; the 2-argument form is Oracle/PostgreSQL only)
-- `Ltrim()` for `LTRIM` (two-argument trim-set form: Oracle, PostgreSQL, SQLite, SQL Server 2022+)
+- `Ltrim()` for `LTRIM` (two-argument trim-set form: Oracle, PostgreSQL, SQLite, SQL Server)
 - `Length()` for `LENGTH` (MySQL, Oracle, PostgreSQL, SQLite)
 - `Lengthb()` for `LENGTHB` (Oracle)
 - `Lower()` for `LOWER`
 - `Position()` for `POSITION(substr IN str)`
 - `Right()` for `RIGHT` (MySQL, PostgreSQL, SQL Server)
 - `Rpad()` for `RPAD` (MySQL, Oracle, PostgreSQL; the 2-argument form is Oracle/PostgreSQL only)
-- `Rtrim()` for `RTRIM` (two-argument trim-set form: Oracle, PostgreSQL, SQLite, SQL Server 2022+)
-- `RegexpCount()` for `REGEXP_COUNT` (Oracle, PostgreSQL 15+)
-- `RegexpInstr()` for `REGEXP_INSTR` (MySQL, Oracle, PostgreSQL 15+; the 7-argument `subPatternPos` form is Oracle/PostgreSQL only)
-- `RegexpReplace()` for `REGEXP_REPLACE` (MySQL, Oracle, PostgreSQL 15+)
-- `RegexpSubstr()` for `REGEXP_SUBSTR` (MySQL, Oracle, PostgreSQL 15+; the 6-argument `subPatternPos` form is Oracle/PostgreSQL only)
+- `Rtrim()` for `RTRIM` (two-argument trim-set form: Oracle, PostgreSQL, SQLite, SQL Server)
+- `RegexpCount()` for `REGEXP_COUNT` (Oracle, PostgreSQL)
+- `RegexpInstr()` for `REGEXP_INSTR` (MySQL, Oracle, PostgreSQL; the 7-argument `subPatternPos` form is Oracle/PostgreSQL only)
+- `RegexpReplace()` for `REGEXP_REPLACE` (MySQL, Oracle, PostgreSQL)
+- `RegexpSubstr()` for `REGEXP_SUBSTR` (MySQL, Oracle, PostgreSQL; the 6-argument `subPatternPos` form is Oracle/PostgreSQL only)
 - `Replace()` for `REPLACE`
 - `Strpos()` for `STRPOS`
 - `Substr()` for `SUBSTR` (not supported by SQL Server — use `Substring()` there)
 - `Substrb()` for `SUBSTRB` (Oracle)
-- `Substring()` for `SUBSTRING` (MySQL, PostgreSQL, SQLite 3.34+, SQL Server; on Oracle use `Substr()`)
-- `Trim()` for `TRIM` (SQL Server 2017+; the two-argument trim-set form is SQL Server 2022+ and not supported by SQLite — nest `Ltrim()`/`Rtrim()` there)
+- `Substring()` for `SUBSTRING` (MySQL, PostgreSQL, SQLite, SQL Server; on Oracle use `Substr()`)
+- `Trim()` for `TRIM` (SQL Server; the two-argument trim-set form is not supported by SQLite — nest `Ltrim()`/`Rtrim()` there)
 - `Upper()` for `UPPER`
 
 On Oracle, chain two-argument `Concat(a, b)` calls (`Concat(Concat(a, b), c)`)
@@ -111,7 +114,7 @@ for the full per-dialect guide, including a MySQL semantics trap `||` has that
 - `DateSub()` for `DATE_SUB` (MySQL)
 - `DateTrunc()` for `DATE_TRUNC` (PostgreSQL)
 - `Datetime(timevalue[, modifier, ...])` for `DATETIME` (SQLite)
-- `Datetrunc()` for `DATETRUNC` (SQL Server 2022+; use `Format()` on earlier versions)
+- `Datetrunc()` for `DATETRUNC` (SQL Server)
 - `Extract()` for `EXTRACT` (Date/Time Overload; MySQL, Oracle, PostgreSQL)
 - `Julianday(timevalue[, modifier, ...])` for `JULIANDAY` (SQLite)
 - `LastDay()` for `LAST_DAY` (MySQL, Oracle)
@@ -141,9 +144,9 @@ expression; for Oracle/PostgreSQL date-shift arithmetic (and MySQL's own
 - `Coalesce()` for `COALESCE`
 - `Decode()` for `DECODE` (Oracle)
 - `Format(value, format[, culture])` for `FORMAT(value, format[, culture])` (SQL Server)
-- `If(condition, then, else)` for `IF(condition, then, else)` (MySQL; SQLite 3.48+ accepts it as a second name for `IIF`)
+- `If(condition, then, else)` for `IF(condition, then, else)` (MySQL; SQLite accepts it as a second name for `IIF`)
 - `Ifnull(expr, alt)` for `IFNULL(expr, alt)` (MySQL, SQLite)
-- `Iif(condition, then, else)` for `IIF(condition, then, else)` (SQLite 3.32+, SQL Server 2012+)
+- `Iif(condition, then, else)` for `IIF(condition, then, else)` (SQLite, SQL Server)
 - `Isnull(expr, alt)` for `ISNULL(expr, alt)` (SQL Server)
 - `Nullif()` for `NULLIF`
 - `Numtodsinterval()` for `NUMTODSINTERVAL` (Oracle)
@@ -156,7 +159,7 @@ expression; for Oracle/PostgreSQL date-shift arithmetic (and MySQL's own
 
 > [!NOTE]
 > MySQL and SQLite each have their own same-named but incompatible `FORMAT()`
-> (MySQL: fixed decimal count; SQLite 3.38+: a `printf()` alias). Neither
+> (MySQL: fixed decimal count; SQLite: a `printf()` alias). Neither
 > matches SQL Server's .NET-style format strings — a call executes on both
 > without erroring, but there is no MySQL/SQLite equivalent of this factory.
 
@@ -170,8 +173,8 @@ expression; for Oracle/PostgreSQL date-shift arithmetic (and MySQL's own
 
 ## Comparison Functions
 
-- `Greatest()` for `GREATEST` (MySQL, Oracle, PostgreSQL, SQL Server 2022+)
-- `Least()` for `LEAST` (MySQL, Oracle, PostgreSQL, SQL Server 2022+)
+- `Greatest()` for `GREATEST` (MySQL, Oracle, PostgreSQL, SQL Server)
+- `Least()` for `LEAST` (MySQL, Oracle, PostgreSQL, SQL Server)
 
 ---
 
@@ -180,7 +183,7 @@ expression; for Oracle/PostgreSQL date-shift arithmetic (and MySQL's own
 JSON paths are emitted as inline string literals (SQL Server and Oracle require the path to be a literal, not a bind parameter).
 
 - `JsonExtract(jsonDoc, path)` for `JSON_EXTRACT(jsonDoc, 'path')` (MySQL, SQLite)
-- `JsonValue(jsonDoc, path)` for `JSON_VALUE(jsonDoc, 'path')` (MySQL 8.0.21+, Oracle, SQL Server)
+- `JsonValue(jsonDoc, path)` for `JSON_VALUE(jsonDoc, 'path')` (MySQL, Oracle, SQL Server)
 - `JsonQuery(jsonDoc, path)` for `JSON_QUERY(jsonDoc, 'path')` (Oracle, SQL Server)
 
 JSON **operators** (`->`, `->>`, `#>`, `#>>`, and the JSONB predicates
@@ -254,7 +257,7 @@ Chain `.Over(...)` to turn any of them into a window function (see
 
 Exposed per dialect (no unified rewrite); each emits its dialect-native syntax verbatim.
 
-- `StringAgg(expr, sep)` for `STRING_AGG(expr, sep)` (PostgreSQL/SQLite 3.44+/SQL Server). Order with an `OrderBy(...)` argument — `StringAgg(expr, sep, OrderBy(...))` (PostgreSQL/SQLite 3.44+, inline) — or chain `.WithinGroup(OrderBy(...))` (SQL Server)
+- `StringAgg(expr, sep)` for `STRING_AGG(expr, sep)` (PostgreSQL/SQLite/SQL Server). Order with an `OrderBy(...)` argument — `StringAgg(expr, sep, OrderBy(...))` (PostgreSQL/SQLite, inline) — or chain `.WithinGroup(OrderBy(...))` (SQL Server)
 - `Listagg(expr, sep).WithinGroup(OrderBy(...))` for `LISTAGG(expr, sep) WITHIN GROUP (ORDER BY ...)` (Oracle)
 - `GroupConcat(expr)` for `GROUP_CONCAT(expr)` (MySQL/SQLite)
 - `GroupConcat(expr, sep)` for `GROUP_CONCAT(expr, sep)` (SQLite, positional separator)

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -6,9 +6,10 @@
 > **How to read this reference.** Each entry maps a C# API to the SQL token it emits.
 > Pick the API for your target DBMS; a single call is not rewritten per dialect.
 > Dialect notes list databases in the order **MySQL, Oracle, PostgreSQL, SQLite, SQL Server**.
-> Where a dialect note names a construct without saying since when, the
-> [version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs)
-> has the minimum engine version, kept in sync by a test.
+> Notes say which dialects accept a construct, never from which version; where
+> a minimum engine version is recorded, it lives in the
+> [version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs),
+> kept in sync by a test.
 
 ## Contents
 
@@ -24,16 +25,16 @@ SqlArtisan provides C# APIs that map to various SQL functions, enabling you to u
 - `Abs()` for `ABS`
 - `Ceil()` for `CEIL` (Oracle; MySQL/PostgreSQL/SQLite accept both spellings)
 - `Ceiling()` for `CEILING` (SQL Server; MySQL/PostgreSQL/SQLite accept both spellings)
-- `Exp()` for `EXP` (SQLite)
-- `Floor()` for `FLOOR` (SQLite)
-- `Ln()` for `LN` (SQLite; not supported by SQL Server — its `LOG(x)` is the natural logarithm)
+- `Exp()` for `EXP`
+- `Floor()` for `FLOOR`
+- `Ln()` for `LN` (not supported by SQL Server — its `LOG(x)` is the natural logarithm)
 - `Log(x)` for `LOG(x)`; `Log(base, x)` for `LOG(base, x)` — **the base differs per dialect, see below**
-- `Log10()` for `LOG10` (PostgreSQL, SQLite; not supported by Oracle — spell it `Log(10, x)` there)
-- `Mod()` for `MOD` (SQLite; not supported by SQL Server — use the `%` operator there)
-- `Power()` for `POWER` (SQLite)
+- `Log10()` for `LOG10` (not supported by Oracle — spell it `Log(10, x)` there)
+- `Mod()` for `MOD` (not supported by SQL Server — use the `%` operator there)
+- `Power()` for `POWER`
 - `Round()` for `ROUND` (single-argument `Round(expr)` is not supported by SQL Server — pass the scale explicitly there)
-- `Sign()` for `SIGN` (SQLite)
-- `Sqrt()` for `SQRT` (SQLite)
+- `Sign()` for `SIGN`
+- `Sqrt()` for `SQRT`
 - `Trunc()` for `TRUNC` (Numeric Overload; Oracle, PostgreSQL, SQLite — the two-argument scale form is Oracle/PostgreSQL only)
 
 > [!WARNING]
@@ -44,7 +45,7 @@ SqlArtisan provides C# APIs that map to various SQL functions, enabling you to u
 > | `Log(x)` → `LOG(x)` | base e | *(rejected)* | base 10 | base 10 | base e |
 > | `Log(b, x)` → `LOG(b, x)` | log<sub>b</sub>x | log<sub>b</sub>x | log<sub>b</sub>x | log<sub>b</sub>x | log<sub>x</sub>b |
 >
-> SQL Server's row inverts (value first, base second). For a base that does not vary: `Ln(x)` (MySQL, Oracle, PostgreSQL, SQLite), `Log10(x)` (MySQL, PostgreSQL, SQLite, SQL Server), or `Log(base, x)` on the four base-first engines (SQLite).
+> SQL Server's row inverts (value first, base second). For a base that does not vary: `Ln(x)` (MySQL, Oracle, PostgreSQL, SQLite), `Log10(x)` (MySQL, PostgreSQL, SQLite, SQL Server), or `Log(base, x)` on the four base-first engines.
 
 `SQLA0100` also flags every two-argument `Log` call on SQL Server — blind to
 argument order — including the correct T-SQL spelling: call `Log(base, x)`
@@ -59,7 +60,7 @@ not at the SqlArtisan layer.
 
 ## Character Functions
 
-- `Concat(a, b)` for `CONCAT(a, b)`; `Concat(a, b, c, ...)` for `CONCAT(a, b, c, ...)` (SQLite; Oracle takes only the two-argument form — see below)
+- `Concat(a, b)` for `CONCAT(a, b)`; `Concat(a, b, c, ...)` for `CONCAT(a, b, c, ...)` (Oracle takes only the two-argument form — see below)
 - `ConcatWs(sep, a, b, ...)` for `CONCAT_WS(sep, a, b, ...)` (MySQL, PostgreSQL, SQLite, SQL Server)
 - `CharLength()` for `CHAR_LENGTH` (MySQL, PostgreSQL)
 - `Instr()` for `INSTR` (MySQL, Oracle, SQLite; the 3- and 4-argument forms are Oracle-only)
@@ -82,7 +83,7 @@ not at the SqlArtisan layer.
 - `Substr()` for `SUBSTR` (not supported by SQL Server — use `Substring()` there)
 - `Substrb()` for `SUBSTRB` (Oracle)
 - `Substring()` for `SUBSTRING` (MySQL, PostgreSQL, SQLite, SQL Server; on Oracle use `Substr()`)
-- `Trim()` for `TRIM` (SQL Server; the two-argument trim-set form is not supported by SQLite — nest `Ltrim()`/`Rtrim()` there)
+- `Trim()` for `TRIM` (the two-argument trim-set form is not supported by SQLite — nest `Ltrim()`/`Rtrim()` there)
 - `Upper()` for `UPPER`
 
 On Oracle, chain two-argument `Concat(a, b)` calls (`Concat(Concat(a, b), c)`)

--- a/docs/query-statements.md
+++ b/docs/query-statements.md
@@ -316,7 +316,7 @@ The DBMS column lists where each form is idiomatic, not the limit of what is
 emitted: availability is the target database's concern (and the opt-in
 analyzer's). SQLite supports neither family, and `LATERAL` has no SQL Server
 form. Oracle accepts both families except `LeftJoinLateral` — its
-injected `ON TRUE` relies on a boolean literal Oracle lacks before 23c; use
+injected `ON TRUE` relies on a boolean literal Oracle lacks; use
 `OuterApply` there. SqlArtisan emits the construct faithfully rather than
 gating it at build time.
 
@@ -607,7 +607,7 @@ SqlStatement sql =
 
 - Use `OffsetRows(m)` alone for `OFFSET m ROWS`.
 - Use `FetchFirst(n)` for `FETCH FIRST n ROWS ONLY` (no offset). This standalone form is valid on **Oracle** (and PostgreSQL); **SQL Server requires an `OFFSET`**, so on SQL Server use `OffsetRows(0).FetchNext(n)` instead.
-- This clause requires `ORDER BY` on SQL Server, and is available on Oracle / SQL Server.
+- This clause requires `ORDER BY` on SQL Server.
 
 The row counts are parameterized like other literals, so the bind-parameter prefix follows the target dialect (`:` / `@` / `?`).
 
@@ -1011,8 +1011,9 @@ SqlStatement sql =
 ```
 
 MySQL keys off any unique index implicitly (no conflict target). SqlArtisan
-emits the 8.0.19+ row-alias form (`AS new` … `new.column`) to avoid the
-deprecated `VALUES()` function.
+emits the row-alias form (`AS new` … `new.column`) to avoid the deprecated
+`VALUES()` function; MySQL added the row alias in a specific release — see the
+[version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs).
 
 **Note:** `ON CONFLICT` is PostgreSQL/SQLite-only and `ON DUPLICATE KEY UPDATE`
 is MySQL-only. Oracle and SQL Server use [`MERGE`](#merge-statement) instead.

--- a/docs/query-statements.md
+++ b/docs/query-statements.md
@@ -302,9 +302,9 @@ pattern as a CTE's `CteBase`); pass that instance as the handle.
 |---|---|---|
 | `CrossApply(subquery, handle)` | `CROSS APPLY (...) alias` | SQL Server, Oracle |
 | `OuterApply(subquery, handle)` | `OUTER APPLY (...) alias` | SQL Server, Oracle |
-| `CrossJoinLateral(subquery, handle)` | `CROSS JOIN LATERAL (...) alias` | MySQL, Oracle 12c+, PostgreSQL |
+| `CrossJoinLateral(subquery, handle)` | `CROSS JOIN LATERAL (...) alias` | MySQL, Oracle, PostgreSQL |
 | `LeftJoinLateral(subquery, handle)` | `LEFT JOIN LATERAL (...) alias ON TRUE` | MySQL, PostgreSQL |
-| `JoinLateral(subquery, handle).On(cond)` | `JOIN LATERAL (...) alias ON cond` | MySQL, Oracle 12c+, PostgreSQL |
+| `JoinLateral(subquery, handle).On(cond)` | `JOIN LATERAL (...) alias ON cond` | MySQL, Oracle, PostgreSQL |
 
 The derived-table alias is alias-quoted at its definition (`... ) "x"`), matching
 both how a CTE name is written and the alias-quoted column references through the
@@ -315,7 +315,7 @@ quoted reference.
 The DBMS column lists where each form is idiomatic, not the limit of what is
 emitted: availability is the target database's concern (and the opt-in
 analyzer's). SQLite supports neither family, and `LATERAL` has no SQL Server
-form. Oracle (12c+) accepts both families except `LeftJoinLateral` — its
+form. Oracle accepts both families except `LeftJoinLateral` — its
 injected `ON TRUE` relies on a boolean literal Oracle lacks before 23c; use
 `OuterApply` there. SqlArtisan emits the construct faithfully rather than
 gating it at build time.
@@ -587,7 +587,7 @@ SqlStatement sql =
 
 `Limit()` and `Offset()` can be combined as `LIMIT n OFFSET m`. Note that a standalone `Offset()` (without `Limit()`) is only valid on PostgreSQL; MySQL and SQLite require `OFFSET` to be paired with `LIMIT`.
 
-#### OFFSET/FETCH family (Oracle 12c+ / PostgreSQL / SQL Server 2012+)
+#### OFFSET/FETCH family (Oracle / PostgreSQL / SQL Server)
 
 ```csharp
 TestTable t = new();
@@ -607,7 +607,7 @@ SqlStatement sql =
 
 - Use `OffsetRows(m)` alone for `OFFSET m ROWS`.
 - Use `FetchFirst(n)` for `FETCH FIRST n ROWS ONLY` (no offset). This standalone form is valid on **Oracle** (and PostgreSQL); **SQL Server requires an `OFFSET`**, so on SQL Server use `OffsetRows(0).FetchNext(n)` instead.
-- This clause requires `ORDER BY` on SQL Server, and is available on Oracle 12c+ / SQL Server 2012+.
+- This clause requires `ORDER BY` on SQL Server, and is available on Oracle / SQL Server.
 
 The row counts are parameterized like other literals, so the bind-parameter prefix follows the target dialect (`:` / `@` / `?`).
 
@@ -783,7 +783,7 @@ SqlStatement sql =
 Update or delete rows using columns from other tables. Each dialect has its own
 grammar for this — the SQL you write is the SQL that runs.
 
-**`UPDATE … FROM` (PostgreSQL, SQLite 3.33+):** the target stays in the
+**`UPDATE … FROM` (PostgreSQL, SQLite):** the target stays in the
 `UPDATE`, the other tables go in `FROM`, and the join predicate lives in
 `WHERE`:
 
@@ -884,7 +884,7 @@ SqlStatement sql =
 // (:0, :1), (:2, :3), (:4, :5)
 ```
 
-**Note:** Multi-row `VALUES` is supported by MySQL, PostgreSQL, SQLite, and SQL Server (2008+). Oracle does not support multi-row `VALUES`; it uses `INSERT ALL` instead.
+**Note:** Multi-row `VALUES` is supported by MySQL, PostgreSQL, SQLite, and SQL Server. Oracle does not support multi-row `VALUES`; it uses `INSERT ALL` instead.
 
 When the rows come from data rather than fixed literals, pass the whole collection to `Values(...)` in one call — a `List<object[]>`, an `object[][]` (e.g. from `.Select(...).ToArray()`), or any `IEnumerable<object[]>` — instead of a `Values(...)` call per row:
 
@@ -1047,7 +1047,9 @@ exposed separately.
 ### MERGE Statement
 
 `MERGE` is the native UPSERT path for **Oracle** and **SQL Server** (and
-**PostgreSQL 15+**), which have no `ON CONFLICT` / `ON DUPLICATE KEY UPDATE`.
+**PostgreSQL**), which have no `ON CONFLICT` / `ON DUPLICATE KEY UPDATE`.
+PostgreSQL gained `MERGE` in a specific release — see the
+[version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs).
 Start with `MergeInto(target)`, name the data source with `Using(...)`, match
 rows with `On(...)`, then add one or more `WhenMatched` / `WhenNotMatched`
 branches. As elsewhere, the SQL you write is the SQL that runs — the branches
@@ -1132,7 +1134,7 @@ subquery source (`… .AsTable("s")`) instead.
 // Oracle in-clause DELETE: WHEN MATCHED THEN UPDATE SET ... DELETE WHERE ...
 .WhenMatched().ThenUpdateSet(t.Name == s.Name).DeleteWhere(t.Name.IsNull)
 
-// PostgreSQL 15+ / SQL Server: WHEN MATCHED THEN DELETE
+// PostgreSQL / SQL Server: WHEN MATCHED THEN DELETE
 .WhenMatched().ThenDelete()
 
 // SQL Server only: WHEN NOT MATCHED BY SOURCE THEN UPDATE/DELETE
@@ -1232,7 +1234,7 @@ SqlStatement sql =
 
 SqlArtisan also supports more advanced WITH clause scenarios:
 
-- **Recursive CTEs** — `WithRecursive()` emits `WITH RECURSIVE`, required by MySQL (8.0+) and PostgreSQL and accepted by SQLite. Oracle — every version, 23ai included (live-verified) — and SQL Server reject the `RECURSIVE` keyword; there, recurse with plain `With(...)`. On Oracle a recursive body additionally requires the CTE column list — chain `.WithColumnList()` onto the CTE binding (`With(cte.As(...).WithColumnList())`) to emit it (`WITH "cte"(code) AS (...)`); SQL Server recurses with plain `With(...)` alone, and also accepts the list. The analyzer warns when `WithRecursive()` targets a dialect (or a declared version) that does not support it. `WithRecursive()` always includes the CTE column list, derived from the first query block — Oracle-style recursive `WITH` requires the list, and every engine accepts it; `.WithColumnList()` derives the same list under plain `With()`. Every select item of the CTE's first query block must therefore have a name: a plain column, or an expression aliased with `.As(...)` — an unnamed expression throws at the `WithRecursive()` or `.WithColumnList()` call. Plain `With()` emits a column list only for CTEs that opt in with `.WithColumnList()`.
+- **Recursive CTEs** — `WithRecursive()` emits `WITH RECURSIVE`, required by MySQL and PostgreSQL and accepted by SQLite (MySQL gained CTE support in a specific release — see the [version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs)). Oracle — every version, 23ai included (live-verified) — and SQL Server reject the `RECURSIVE` keyword; there, recurse with plain `With(...)`. On Oracle a recursive body additionally requires the CTE column list — chain `.WithColumnList()` onto the CTE binding (`With(cte.As(...).WithColumnList())`) to emit it (`WITH "cte"(code) AS (...)`); SQL Server recurses with plain `With(...)` alone, and also accepts the list. The analyzer warns when `WithRecursive()` targets a dialect (or a declared version) that does not support it. `WithRecursive()` always includes the CTE column list, derived from the first query block — Oracle-style recursive `WITH` requires the list, and every engine accepts it; `.WithColumnList()` derives the same list under plain `With()`. Every select item of the CTE's first query block must therefore have a name: a plain column, or an expression aliased with `.As(...)` — an unnamed expression throws at the `WithRecursive()` or `.WithColumnList()` call. Plain `With()` emits a column list only for CTEs that opt in with `.WithColumnList()`.
 - **CTEs with DML main statements** — `With(...)` before an `INSERT`, `UPDATE`, or `DELETE` main statement is supported. DML *inside* a CTE body (PostgreSQL data-modifying CTEs) is not supported.
 
 ---
@@ -1305,7 +1307,7 @@ int deletedId = outputs.Get<int>("outId");
 string deletedName = outputs.Get<string>("outName");
 ```
 
-**Note:** `RETURNING` is supported by Oracle, PostgreSQL, and SQLite (3.35+). It is not supported by SQL Server (which uses [`OUTPUT`](#output-clause-sql-server)) or MySQL. The `RETURNING ... INTO` form is Oracle-specific. SqlArtisan does not validate database feature support, so ensure the clause is valid for your target DBMS.
+**Note:** `RETURNING` is supported by Oracle, PostgreSQL, and SQLite (SQLite gained it in a specific release — see the [version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs)). It is not supported by SQL Server (which uses [`OUTPUT`](#output-clause-sql-server)) or MySQL. The `RETURNING ... INTO` form is Oracle-specific. SqlArtisan does not validate database feature support, so ensure the clause is valid for your target DBMS.
 
 ## OUTPUT Clause (SQL Server)
 

--- a/docs/query-statements.md
+++ b/docs/query-statements.md
@@ -315,8 +315,8 @@ quoted reference.
 The DBMS column lists where each form is idiomatic, not the limit of what is
 emitted: availability is the target database's concern (and the opt-in
 analyzer's). SQLite supports neither family, and `LATERAL` has no SQL Server
-form. Oracle accepts both families except `LeftJoinLateral` — Oracle rejects
-its injected `ON TRUE`; use `OuterApply` there. SqlArtisan emits the construct faithfully rather than
+form. Oracle accepts both families except `LeftJoinLateral`; use `OuterApply`
+there. SqlArtisan emits the construct faithfully rather than
 gating it at build time.
 
 ---

--- a/docs/query-statements.md
+++ b/docs/query-statements.md
@@ -315,9 +315,8 @@ quoted reference.
 The DBMS column lists where each form is idiomatic, not the limit of what is
 emitted: availability is the target database's concern (and the opt-in
 analyzer's). SQLite supports neither family, and `LATERAL` has no SQL Server
-form. Oracle accepts both families except `LeftJoinLateral` — its
-injected `ON TRUE` relies on a boolean literal Oracle lacks; use
-`OuterApply` there. SqlArtisan emits the construct faithfully rather than
+form. Oracle accepts both families except `LeftJoinLateral` — Oracle rejects
+its injected `ON TRUE`; use `OuterApply` there. SqlArtisan emits the construct faithfully rather than
 gating it at build time.
 
 ---

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -751,9 +751,8 @@ quoted reference.
 The DBMS column lists where each form is idiomatic, not the limit of what is
 emitted: availability is the target database's concern (and the opt-in
 analyzer's). SQLite supports neither family, and `LATERAL` has no SQL Server
-form. Oracle accepts both families except `LeftJoinLateral` — its
-injected `ON TRUE` relies on a boolean literal Oracle lacks; use
-`OuterApply` there. SqlArtisan emits the construct faithfully rather than
+form. Oracle accepts both families except `LeftJoinLateral` — Oracle rejects
+its injected `ON TRUE`; use `OuterApply` there. SqlArtisan emits the construct faithfully rather than
 gating it at build time.
 
 ---

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -738,9 +738,9 @@ pattern as a CTE's `CteBase`); pass that instance as the handle.
 |---|---|---|
 | `CrossApply(subquery, handle)` | `CROSS APPLY (...) alias` | SQL Server, Oracle |
 | `OuterApply(subquery, handle)` | `OUTER APPLY (...) alias` | SQL Server, Oracle |
-| `CrossJoinLateral(subquery, handle)` | `CROSS JOIN LATERAL (...) alias` | MySQL, Oracle 12c+, PostgreSQL |
+| `CrossJoinLateral(subquery, handle)` | `CROSS JOIN LATERAL (...) alias` | MySQL, Oracle, PostgreSQL |
 | `LeftJoinLateral(subquery, handle)` | `LEFT JOIN LATERAL (...) alias ON TRUE` | MySQL, PostgreSQL |
-| `JoinLateral(subquery, handle).On(cond)` | `JOIN LATERAL (...) alias ON cond` | MySQL, Oracle 12c+, PostgreSQL |
+| `JoinLateral(subquery, handle).On(cond)` | `JOIN LATERAL (...) alias ON cond` | MySQL, Oracle, PostgreSQL |
 
 The derived-table alias is alias-quoted at its definition (`... ) "x"`), matching
 both how a CTE name is written and the alias-quoted column references through the
@@ -751,7 +751,7 @@ quoted reference.
 The DBMS column lists where each form is idiomatic, not the limit of what is
 emitted: availability is the target database's concern (and the opt-in
 analyzer's). SQLite supports neither family, and `LATERAL` has no SQL Server
-form. Oracle (12c+) accepts both families except `LeftJoinLateral` — its
+form. Oracle accepts both families except `LeftJoinLateral` — its
 injected `ON TRUE` relies on a boolean literal Oracle lacks before 23c; use
 `OuterApply` there. SqlArtisan emits the construct faithfully rather than
 gating it at build time.
@@ -1023,7 +1023,7 @@ SqlStatement sql =
 
 `Limit()` and `Offset()` can be combined as `LIMIT n OFFSET m`. Note that a standalone `Offset()` (without `Limit()`) is only valid on PostgreSQL; MySQL and SQLite require `OFFSET` to be paired with `LIMIT`.
 
-#### OFFSET/FETCH family (Oracle 12c+ / PostgreSQL / SQL Server 2012+)
+#### OFFSET/FETCH family (Oracle / PostgreSQL / SQL Server)
 
 ```csharp
 TestTable t = new();
@@ -1043,7 +1043,7 @@ SqlStatement sql =
 
 - Use `OffsetRows(m)` alone for `OFFSET m ROWS`.
 - Use `FetchFirst(n)` for `FETCH FIRST n ROWS ONLY` (no offset). This standalone form is valid on **Oracle** (and PostgreSQL); **SQL Server requires an `OFFSET`**, so on SQL Server use `OffsetRows(0).FetchNext(n)` instead.
-- This clause requires `ORDER BY` on SQL Server, and is available on Oracle 12c+ / SQL Server 2012+.
+- This clause requires `ORDER BY` on SQL Server, and is available on Oracle / SQL Server.
 
 The row counts are parameterized like other literals, so the bind-parameter prefix follows the target dialect (`:` / `@` / `?`).
 
@@ -1219,7 +1219,7 @@ SqlStatement sql =
 Update or delete rows using columns from other tables. Each dialect has its own
 grammar for this — the SQL you write is the SQL that runs.
 
-**`UPDATE … FROM` (PostgreSQL, SQLite 3.33+):** the target stays in the
+**`UPDATE … FROM` (PostgreSQL, SQLite):** the target stays in the
 `UPDATE`, the other tables go in `FROM`, and the join predicate lives in
 `WHERE`:
 
@@ -1320,7 +1320,7 @@ SqlStatement sql =
 // (:0, :1), (:2, :3), (:4, :5)
 ```
 
-**Note:** Multi-row `VALUES` is supported by MySQL, PostgreSQL, SQLite, and SQL Server (2008+). Oracle does not support multi-row `VALUES`; it uses `INSERT ALL` instead.
+**Note:** Multi-row `VALUES` is supported by MySQL, PostgreSQL, SQLite, and SQL Server. Oracle does not support multi-row `VALUES`; it uses `INSERT ALL` instead.
 
 When the rows come from data rather than fixed literals, pass the whole collection to `Values(...)` in one call — a `List<object[]>`, an `object[][]` (e.g. from `.Select(...).ToArray()`), or any `IEnumerable<object[]>` — instead of a `Values(...)` call per row:
 
@@ -1483,7 +1483,9 @@ exposed separately.
 ### MERGE Statement
 
 `MERGE` is the native UPSERT path for **Oracle** and **SQL Server** (and
-**PostgreSQL 15+**), which have no `ON CONFLICT` / `ON DUPLICATE KEY UPDATE`.
+**PostgreSQL**), which have no `ON CONFLICT` / `ON DUPLICATE KEY UPDATE`.
+PostgreSQL gained `MERGE` in a specific release — see the
+[version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs).
 Start with `MergeInto(target)`, name the data source with `Using(...)`, match
 rows with `On(...)`, then add one or more `WhenMatched` / `WhenNotMatched`
 branches. As elsewhere, the SQL you write is the SQL that runs — the branches
@@ -1568,7 +1570,7 @@ subquery source (`… .AsTable("s")`) instead.
 // Oracle in-clause DELETE: WHEN MATCHED THEN UPDATE SET ... DELETE WHERE ...
 .WhenMatched().ThenUpdateSet(t.Name == s.Name).DeleteWhere(t.Name.IsNull)
 
-// PostgreSQL 15+ / SQL Server: WHEN MATCHED THEN DELETE
+// PostgreSQL / SQL Server: WHEN MATCHED THEN DELETE
 .WhenMatched().ThenDelete()
 
 // SQL Server only: WHEN NOT MATCHED BY SOURCE THEN UPDATE/DELETE
@@ -1668,7 +1670,7 @@ SqlStatement sql =
 
 SqlArtisan also supports more advanced WITH clause scenarios:
 
-- **Recursive CTEs** — `WithRecursive()` emits `WITH RECURSIVE`, required by MySQL (8.0+) and PostgreSQL and accepted by SQLite. Oracle — every version, 23ai included (live-verified) — and SQL Server reject the `RECURSIVE` keyword; there, recurse with plain `With(...)`. On Oracle a recursive body additionally requires the CTE column list — chain `.WithColumnList()` onto the CTE binding (`With(cte.As(...).WithColumnList())`) to emit it (`WITH "cte"(code) AS (...)`); SQL Server recurses with plain `With(...)` alone, and also accepts the list. The analyzer warns when `WithRecursive()` targets a dialect (or a declared version) that does not support it. `WithRecursive()` always includes the CTE column list, derived from the first query block — Oracle-style recursive `WITH` requires the list, and every engine accepts it; `.WithColumnList()` derives the same list under plain `With()`. Every select item of the CTE's first query block must therefore have a name: a plain column, or an expression aliased with `.As(...)` — an unnamed expression throws at the `WithRecursive()` or `.WithColumnList()` call. Plain `With()` emits a column list only for CTEs that opt in with `.WithColumnList()`.
+- **Recursive CTEs** — `WithRecursive()` emits `WITH RECURSIVE`, required by MySQL and PostgreSQL and accepted by SQLite (MySQL gained CTE support in a specific release — see the [version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs)). Oracle — every version, 23ai included (live-verified) — and SQL Server reject the `RECURSIVE` keyword; there, recurse with plain `With(...)`. On Oracle a recursive body additionally requires the CTE column list — chain `.WithColumnList()` onto the CTE binding (`With(cte.As(...).WithColumnList())`) to emit it (`WITH "cte"(code) AS (...)`); SQL Server recurses with plain `With(...)` alone, and also accepts the list. The analyzer warns when `WithRecursive()` targets a dialect (or a declared version) that does not support it. `WithRecursive()` always includes the CTE column list, derived from the first query block — Oracle-style recursive `WITH` requires the list, and every engine accepts it; `.WithColumnList()` derives the same list under plain `With()`. Every select item of the CTE's first query block must therefore have a name: a plain column, or an expression aliased with `.As(...)` — an unnamed expression throws at the `WithRecursive()` or `.WithColumnList()` call. Plain `With()` emits a column list only for CTEs that opt in with `.WithColumnList()`.
 - **CTEs with DML main statements** — `With(...)` before an `INSERT`, `UPDATE`, or `DELETE` main statement is supported. DML *inside* a CTE body (PostgreSQL data-modifying CTEs) is not supported.
 
 ---
@@ -1741,7 +1743,7 @@ int deletedId = outputs.Get<int>("outId");
 string deletedName = outputs.Get<string>("outName");
 ```
 
-**Note:** `RETURNING` is supported by Oracle, PostgreSQL, and SQLite (3.35+). It is not supported by SQL Server (which uses [`OUTPUT`](#output-clause-sql-server)) or MySQL. The `RETURNING ... INTO` form is Oracle-specific. SqlArtisan does not validate database feature support, so ensure the clause is valid for your target DBMS.
+**Note:** `RETURNING` is supported by Oracle, PostgreSQL, and SQLite (SQLite gained it in a specific release — see the [version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs)). It is not supported by SQL Server (which uses [`OUTPUT`](#output-clause-sql-server)) or MySQL. The `RETURNING ... INTO` form is Oracle-specific. SqlArtisan does not validate database feature support, so ensure the clause is valid for your target DBMS.
 
 ## OUTPUT Clause (SQL Server)
 
@@ -2330,9 +2332,9 @@ SqlStatement sql =
 // LIMIT :1
 ```
 
-`L2Distance` (`<->`), `CosineDistance` (`<=>`), and `NegativeInnerProduct` (`<#>`) work on Oracle (23ai+) and PostgreSQL; `L1Distance` (`<+>`), `HammingDistance` (`<~>`), and `JaccardDistance` (`<%>`) are PostgreSQL only (pgvector 0.7.0+). On PostgreSQL all six need the [pgvector](https://github.com/pgvector/pgvector) extension installed in the database (`CREATE EXTENSION vector`); on Oracle 23ai the three shared operators are built in.
+`L2Distance` (`<->`), `CosineDistance` (`<=>`), and `NegativeInnerProduct` (`<#>`) work on Oracle and PostgreSQL (Oracle gained the three shared operators in a specific release — see the [version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs)); `L1Distance` (`<+>`), `HammingDistance` (`<~>`), and `JaccardDistance` (`<%>`) are PostgreSQL only, via the pgvector extension. On PostgreSQL all six need the [pgvector](https://github.com/pgvector/pgvector) extension installed in the database (`CREATE EXTENSION vector`); on Oracle the three shared operators are built in.
 
-A bound vector literal reaches PostgreSQL as `text` — wrap it in `Cast(text, "vector")` (or `Cast(bits, "bit(n)")` for the bit operators) as above. On Oracle, drop the `Cast` — Oracle 23ai rejects `CAST(... AS vector)` outright (ORA-22849); pass the vector string bare (`L2Distance(u.Embedding, "[0.1,0.2,0.3]")`) and Oracle converts the bound string implicitly. `NegativeInnerProduct` returns the **negative** inner product, so the smallest value is still the most similar. On MySQL, `<=>` is the NULL-safe equality operator — the same glyph as `CosineDistance` with entirely different meaning — so keep cosine-distance queries off MySQL connections.
+A bound vector literal reaches PostgreSQL as `text` — wrap it in `Cast(text, "vector")` (or `Cast(bits, "bit(n)")` for the bit operators) as above. On Oracle, drop the `Cast` — Oracle rejects `CAST(... AS vector)` outright (ORA-22849); pass the vector string bare (`L2Distance(u.Embedding, "[0.1,0.2,0.3]")`) and Oracle converts the bound string implicitly. `NegativeInnerProduct` returns the **negative** inner product, so the smallest value is still the most similar. On MySQL, `<=>` is the NULL-safe equality operator — the same glyph as `CosineDistance` with entirely different meaning — so keep cosine-distance queries off MySQL connections.
 
 To bind a `Pgvector.Vector` instance instead of a cast string literal, construct the bind directly — `new BindValue(vector)` — and register pgvector's Dapper type handler (`VectorTypeHandler`, from the `Pgvector.Dapper` package) plus `UseVector()` on the Npgsql data source (from the `Pgvector` package); the held value then flows to the driver untouched.
 
@@ -2730,7 +2732,6 @@ SqlStatement sql =
 - A single bound uses `Rows(bound)` / `Range(bound)` (e.g. `Rows(UnboundedPreceding)`); `RowsBetween(start, end)` / `RangeBetween(start, end)` produce `ROWS/RANGE BETWEEN ... AND ...`.
 - A mis-ordered frame throws `ArgumentException` — no engine accepts a single bound past `CurrentRow` (use the `BETWEEN` form for `Following(n)` / `UnboundedFollowing`) or a `BETWEEN` start ranking later than its end.
 - A frame requires `ORDER BY`, so `Rows(...)` / `Range(...)` are available only after `OrderBy(...)` (optionally with `PartitionBy(...)`).
-- Requires MySQL 8.0+, Oracle, PostgreSQL, SQLite 3.25+, or SQL Server 2012+.
 
 ### Example using PERCENTILE_CONT / PERCENTILE_DISC
 
@@ -2785,12 +2786,12 @@ Chain `.Over(...)` afterwards for a filtered window function — `SUM(amount) FI
 
 ## String Aggregation
 
-String aggregation flattens the values of a group into one delimited string. This is the most syntactically divergent feature in scope, so SqlArtisan exposes it per dialect (no unified rewrite): you call the function your target DBMS supports, and the SQL you write is the SQL that runs.
+String aggregation flattens the values of a group into one delimited string. This is the most syntactically divergent feature in scope, so SqlArtisan exposes it per dialect (no unified rewrite): you call the function your target DBMS supports, and the SQL you write is the SQL that runs. SQLite gained `STRING_AGG` in a specific release — see the [version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs).
 
-### STRING_AGG (PostgreSQL / SQLite 3.44+ / SQL Server)
+### STRING_AGG (PostgreSQL / SQLite / SQL Server)
 
 ```csharp
-// PostgreSQL / SQLite (3.44+): ordering is inline inside the call, so pass OrderBy(...) as an argument
+// PostgreSQL / SQLite: ordering is inline inside the call, so pass OrderBy(...) as an argument
 Select(StringAgg(u.Name, ", ", OrderBy(u.Name)))
     .From(u)
     .Build(Dbms.PostgreSql);
@@ -2892,6 +2893,9 @@ SqlStatement sql =
 > **How to read this reference.** Each entry maps a C# API to the SQL token it emits.
 > Pick the API for your target DBMS; a single call is not rewritten per dialect.
 > Dialect notes list databases in the order **MySQL, Oracle, PostgreSQL, SQLite, SQL Server**.
+> Where a dialect note names a construct without saying since when, the
+> [version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs)
+> has the minimum engine version, kept in sync by a test.
 
 ## Contents
 
@@ -2905,19 +2909,19 @@ SqlArtisan provides C# APIs that map to various SQL functions, enabling you to u
 ## Numeric Functions
 
 - `Abs()` for `ABS`
-- `Ceil()` for `CEIL` (Oracle; MySQL/PostgreSQL/SQLite 3.35+ accept both spellings)
-- `Ceiling()` for `CEILING` (SQL Server; MySQL/PostgreSQL/SQLite 3.35+ accept both spellings)
-- `Exp()` for `EXP` (SQLite 3.35+)
-- `Floor()` for `FLOOR` (SQLite 3.35+)
-- `Ln()` for `LN` (SQLite 3.35+; not supported by SQL Server — its `LOG(x)` is the natural logarithm)
+- `Ceil()` for `CEIL` (Oracle; MySQL/PostgreSQL/SQLite accept both spellings)
+- `Ceiling()` for `CEILING` (SQL Server; MySQL/PostgreSQL/SQLite accept both spellings)
+- `Exp()` for `EXP` (SQLite)
+- `Floor()` for `FLOOR` (SQLite)
+- `Ln()` for `LN` (SQLite; not supported by SQL Server — its `LOG(x)` is the natural logarithm)
 - `Log(x)` for `LOG(x)`; `Log(base, x)` for `LOG(base, x)` — **the base differs per dialect, see below**
-- `Log10()` for `LOG10` (PostgreSQL 12+, SQLite 3.35+; not supported by Oracle — spell it `Log(10, x)` there)
-- `Mod()` for `MOD` (SQLite 3.35+; not supported by SQL Server — use the `%` operator there)
-- `Power()` for `POWER` (SQLite 3.35+)
+- `Log10()` for `LOG10` (PostgreSQL, SQLite; not supported by Oracle — spell it `Log(10, x)` there)
+- `Mod()` for `MOD` (SQLite; not supported by SQL Server — use the `%` operator there)
+- `Power()` for `POWER` (SQLite)
 - `Round()` for `ROUND` (single-argument `Round(expr)` is not supported by SQL Server — pass the scale explicitly there)
-- `Sign()` for `SIGN` (SQLite 3.35+)
-- `Sqrt()` for `SQRT` (SQLite 3.35+)
-- `Trunc()` for `TRUNC` (Numeric Overload; Oracle, PostgreSQL, SQLite 3.35+ — the two-argument scale form is Oracle/PostgreSQL only)
+- `Sign()` for `SIGN` (SQLite)
+- `Sqrt()` for `SQRT` (SQLite)
+- `Trunc()` for `TRUNC` (Numeric Overload; Oracle, PostgreSQL, SQLite — the two-argument scale form is Oracle/PostgreSQL only)
 
 > [!WARNING]
 > **`LOG` silently changes meaning with the target, in both forms.** `SQLA0100` catches Oracle's rejection of `Log(x)` and every 2-arg `Log` on SQL Server; every other cell below runs, right or silently wrong.
@@ -2927,7 +2931,7 @@ SqlArtisan provides C# APIs that map to various SQL functions, enabling you to u
 > | `Log(x)` → `LOG(x)` | base e | *(rejected)* | base 10 | base 10 | base e |
 > | `Log(b, x)` → `LOG(b, x)` | log<sub>b</sub>x | log<sub>b</sub>x | log<sub>b</sub>x | log<sub>b</sub>x | log<sub>x</sub>b |
 >
-> SQL Server's row inverts (value first, base second). For a base that does not vary: `Ln(x)` (MySQL, Oracle, PostgreSQL, SQLite 3.35+), `Log10(x)` (MySQL, PostgreSQL 12+, SQLite 3.35+, SQL Server), or `Log(base, x)` on the four base-first engines (SQLite 3.35+).
+> SQL Server's row inverts (value first, base second). For a base that does not vary: `Ln(x)` (MySQL, Oracle, PostgreSQL, SQLite), `Log10(x)` (MySQL, PostgreSQL, SQLite, SQL Server), or `Log(base, x)` on the four base-first engines (SQLite).
 
 `SQLA0100` also flags every two-argument `Log` call on SQL Server — blind to
 argument order — including the correct T-SQL spelling: call `Log(base, x)`
@@ -2942,30 +2946,30 @@ not at the SqlArtisan layer.
 
 ## Character Functions
 
-- `Concat(a, b)` for `CONCAT(a, b)`; `Concat(a, b, c, ...)` for `CONCAT(a, b, c, ...)` (SQLite 3.44+; Oracle takes only the two-argument form — see below)
-- `ConcatWs(sep, a, b, ...)` for `CONCAT_WS(sep, a, b, ...)` (MySQL, PostgreSQL, SQLite 3.44+, SQL Server 2017+)
+- `Concat(a, b)` for `CONCAT(a, b)`; `Concat(a, b, c, ...)` for `CONCAT(a, b, c, ...)` (SQLite; Oracle takes only the two-argument form — see below)
+- `ConcatWs(sep, a, b, ...)` for `CONCAT_WS(sep, a, b, ...)` (MySQL, PostgreSQL, SQLite, SQL Server)
 - `CharLength()` for `CHAR_LENGTH` (MySQL, PostgreSQL)
 - `Instr()` for `INSTR` (MySQL, Oracle, SQLite; the 3- and 4-argument forms are Oracle-only)
 - `Left()` for `LEFT` (MySQL, PostgreSQL, SQL Server)
 - `Lpad()` for `LPAD` (MySQL, Oracle, PostgreSQL; the 2-argument form is Oracle/PostgreSQL only)
-- `Ltrim()` for `LTRIM` (two-argument trim-set form: Oracle, PostgreSQL, SQLite, SQL Server 2022+)
+- `Ltrim()` for `LTRIM` (two-argument trim-set form: Oracle, PostgreSQL, SQLite, SQL Server)
 - `Length()` for `LENGTH` (MySQL, Oracle, PostgreSQL, SQLite)
 - `Lengthb()` for `LENGTHB` (Oracle)
 - `Lower()` for `LOWER`
 - `Position()` for `POSITION(substr IN str)`
 - `Right()` for `RIGHT` (MySQL, PostgreSQL, SQL Server)
 - `Rpad()` for `RPAD` (MySQL, Oracle, PostgreSQL; the 2-argument form is Oracle/PostgreSQL only)
-- `Rtrim()` for `RTRIM` (two-argument trim-set form: Oracle, PostgreSQL, SQLite, SQL Server 2022+)
-- `RegexpCount()` for `REGEXP_COUNT` (Oracle, PostgreSQL 15+)
-- `RegexpInstr()` for `REGEXP_INSTR` (MySQL, Oracle, PostgreSQL 15+; the 7-argument `subPatternPos` form is Oracle/PostgreSQL only)
-- `RegexpReplace()` for `REGEXP_REPLACE` (MySQL, Oracle, PostgreSQL 15+)
-- `RegexpSubstr()` for `REGEXP_SUBSTR` (MySQL, Oracle, PostgreSQL 15+; the 6-argument `subPatternPos` form is Oracle/PostgreSQL only)
+- `Rtrim()` for `RTRIM` (two-argument trim-set form: Oracle, PostgreSQL, SQLite, SQL Server)
+- `RegexpCount()` for `REGEXP_COUNT` (Oracle, PostgreSQL)
+- `RegexpInstr()` for `REGEXP_INSTR` (MySQL, Oracle, PostgreSQL; the 7-argument `subPatternPos` form is Oracle/PostgreSQL only)
+- `RegexpReplace()` for `REGEXP_REPLACE` (MySQL, Oracle, PostgreSQL)
+- `RegexpSubstr()` for `REGEXP_SUBSTR` (MySQL, Oracle, PostgreSQL; the 6-argument `subPatternPos` form is Oracle/PostgreSQL only)
 - `Replace()` for `REPLACE`
 - `Strpos()` for `STRPOS`
 - `Substr()` for `SUBSTR` (not supported by SQL Server — use `Substring()` there)
 - `Substrb()` for `SUBSTRB` (Oracle)
-- `Substring()` for `SUBSTRING` (MySQL, PostgreSQL, SQLite 3.34+, SQL Server; on Oracle use `Substr()`)
-- `Trim()` for `TRIM` (SQL Server 2017+; the two-argument trim-set form is SQL Server 2022+ and not supported by SQLite — nest `Ltrim()`/`Rtrim()` there)
+- `Substring()` for `SUBSTRING` (MySQL, PostgreSQL, SQLite, SQL Server; on Oracle use `Substr()`)
+- `Trim()` for `TRIM` (SQL Server; the two-argument trim-set form is not supported by SQLite — nest `Ltrim()`/`Rtrim()` there)
 - `Upper()` for `UPPER`
 
 On Oracle, chain two-argument `Concat(a, b)` calls (`Concat(Concat(a, b), c)`)
@@ -2997,7 +3001,7 @@ for the full per-dialect guide, including a MySQL semantics trap `||` has that
 - `DateSub()` for `DATE_SUB` (MySQL)
 - `DateTrunc()` for `DATE_TRUNC` (PostgreSQL)
 - `Datetime(timevalue[, modifier, ...])` for `DATETIME` (SQLite)
-- `Datetrunc()` for `DATETRUNC` (SQL Server 2022+; use `Format()` on earlier versions)
+- `Datetrunc()` for `DATETRUNC` (SQL Server)
 - `Extract()` for `EXTRACT` (Date/Time Overload; MySQL, Oracle, PostgreSQL)
 - `Julianday(timevalue[, modifier, ...])` for `JULIANDAY` (SQLite)
 - `LastDay()` for `LAST_DAY` (MySQL, Oracle)
@@ -3027,9 +3031,9 @@ expression; for Oracle/PostgreSQL date-shift arithmetic (and MySQL's own
 - `Coalesce()` for `COALESCE`
 - `Decode()` for `DECODE` (Oracle)
 - `Format(value, format[, culture])` for `FORMAT(value, format[, culture])` (SQL Server)
-- `If(condition, then, else)` for `IF(condition, then, else)` (MySQL; SQLite 3.48+ accepts it as a second name for `IIF`)
+- `If(condition, then, else)` for `IF(condition, then, else)` (MySQL; SQLite accepts it as a second name for `IIF`)
 - `Ifnull(expr, alt)` for `IFNULL(expr, alt)` (MySQL, SQLite)
-- `Iif(condition, then, else)` for `IIF(condition, then, else)` (SQLite 3.32+, SQL Server 2012+)
+- `Iif(condition, then, else)` for `IIF(condition, then, else)` (SQLite, SQL Server)
 - `Isnull(expr, alt)` for `ISNULL(expr, alt)` (SQL Server)
 - `Nullif()` for `NULLIF`
 - `Numtodsinterval()` for `NUMTODSINTERVAL` (Oracle)
@@ -3042,7 +3046,7 @@ expression; for Oracle/PostgreSQL date-shift arithmetic (and MySQL's own
 
 > [!NOTE]
 > MySQL and SQLite each have their own same-named but incompatible `FORMAT()`
-> (MySQL: fixed decimal count; SQLite 3.38+: a `printf()` alias). Neither
+> (MySQL: fixed decimal count; SQLite: a `printf()` alias). Neither
 > matches SQL Server's .NET-style format strings — a call executes on both
 > without erroring, but there is no MySQL/SQLite equivalent of this factory.
 
@@ -3056,8 +3060,8 @@ expression; for Oracle/PostgreSQL date-shift arithmetic (and MySQL's own
 
 ## Comparison Functions
 
-- `Greatest()` for `GREATEST` (MySQL, Oracle, PostgreSQL, SQL Server 2022+)
-- `Least()` for `LEAST` (MySQL, Oracle, PostgreSQL, SQL Server 2022+)
+- `Greatest()` for `GREATEST` (MySQL, Oracle, PostgreSQL, SQL Server)
+- `Least()` for `LEAST` (MySQL, Oracle, PostgreSQL, SQL Server)
 
 ---
 
@@ -3066,7 +3070,7 @@ expression; for Oracle/PostgreSQL date-shift arithmetic (and MySQL's own
 JSON paths are emitted as inline string literals (SQL Server and Oracle require the path to be a literal, not a bind parameter).
 
 - `JsonExtract(jsonDoc, path)` for `JSON_EXTRACT(jsonDoc, 'path')` (MySQL, SQLite)
-- `JsonValue(jsonDoc, path)` for `JSON_VALUE(jsonDoc, 'path')` (MySQL 8.0.21+, Oracle, SQL Server)
+- `JsonValue(jsonDoc, path)` for `JSON_VALUE(jsonDoc, 'path')` (MySQL, Oracle, SQL Server)
 - `JsonQuery(jsonDoc, path)` for `JSON_QUERY(jsonDoc, 'path')` (Oracle, SQL Server)
 
 JSON **operators** (`->`, `->>`, `#>`, `#>>`, and the JSONB predicates
@@ -3140,7 +3144,7 @@ Chain `.Over(...)` to turn any of them into a window function (see
 
 Exposed per dialect (no unified rewrite); each emits its dialect-native syntax verbatim.
 
-- `StringAgg(expr, sep)` for `STRING_AGG(expr, sep)` (PostgreSQL/SQLite 3.44+/SQL Server). Order with an `OrderBy(...)` argument — `StringAgg(expr, sep, OrderBy(...))` (PostgreSQL/SQLite 3.44+, inline) — or chain `.WithinGroup(OrderBy(...))` (SQL Server)
+- `StringAgg(expr, sep)` for `STRING_AGG(expr, sep)` (PostgreSQL/SQLite/SQL Server). Order with an `OrderBy(...)` argument — `StringAgg(expr, sep, OrderBy(...))` (PostgreSQL/SQLite, inline) — or chain `.WithinGroup(OrderBy(...))` (SQL Server)
 - `Listagg(expr, sep).WithinGroup(OrderBy(...))` for `LISTAGG(expr, sep) WITHIN GROUP (ORDER BY ...)` (Oracle)
 - `GroupConcat(expr)` for `GROUP_CONCAT(expr)` (MySQL/SQLite)
 - `GroupConcat(expr, sep)` for `GROUP_CONCAT(expr, sep)` (SQLite, positional separator)
@@ -4557,7 +4561,7 @@ SqlStatement sql =
 ```
 
 This shape runs on all five dialects (only markers and quoting differ). On
-MySQL, Oracle (12c+), PostgreSQL, and SQL Server, a
+MySQL, Oracle, PostgreSQL, and SQL Server, a
 [row-limited `LATERAL` / `APPLY` subquery](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/query-statements.md#row-limited-queries-as-subqueries)
 is the per-group top-N alternative.
 
@@ -4733,7 +4737,7 @@ InsertInto(u, u.ProductId, u.Price)
 // RETURNING product_id, price
 // (SQLite emits lowercase "excluded.price" — Build(Dbms.Sqlite) handles it)
 
-// MySQL — ON DUPLICATE KEY UPDATE (8.0.19+ row-alias form):
+// MySQL — ON DUPLICATE KEY UPDATE (row-alias form):
 InsertInto(u, u.ProductId, u.Price)
     .Values(1, 990)
     .OnDuplicateKeyUpdate(u.Price == Excluded(u.Price))

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -751,8 +751,8 @@ quoted reference.
 The DBMS column lists where each form is idiomatic, not the limit of what is
 emitted: availability is the target database's concern (and the opt-in
 analyzer's). SQLite supports neither family, and `LATERAL` has no SQL Server
-form. Oracle accepts both families except `LeftJoinLateral` — Oracle rejects
-its injected `ON TRUE`; use `OuterApply` there. SqlArtisan emits the construct faithfully rather than
+form. Oracle accepts both families except `LeftJoinLateral`; use `OuterApply`
+there. SqlArtisan emits the construct faithfully rather than
 gating it at build time.
 
 ---

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -752,7 +752,7 @@ The DBMS column lists where each form is idiomatic, not the limit of what is
 emitted: availability is the target database's concern (and the opt-in
 analyzer's). SQLite supports neither family, and `LATERAL` has no SQL Server
 form. Oracle accepts both families except `LeftJoinLateral` — its
-injected `ON TRUE` relies on a boolean literal Oracle lacks before 23c; use
+injected `ON TRUE` relies on a boolean literal Oracle lacks; use
 `OuterApply` there. SqlArtisan emits the construct faithfully rather than
 gating it at build time.
 
@@ -1043,7 +1043,7 @@ SqlStatement sql =
 
 - Use `OffsetRows(m)` alone for `OFFSET m ROWS`.
 - Use `FetchFirst(n)` for `FETCH FIRST n ROWS ONLY` (no offset). This standalone form is valid on **Oracle** (and PostgreSQL); **SQL Server requires an `OFFSET`**, so on SQL Server use `OffsetRows(0).FetchNext(n)` instead.
-- This clause requires `ORDER BY` on SQL Server, and is available on Oracle / SQL Server.
+- This clause requires `ORDER BY` on SQL Server.
 
 The row counts are parameterized like other literals, so the bind-parameter prefix follows the target dialect (`:` / `@` / `?`).
 
@@ -1447,8 +1447,9 @@ SqlStatement sql =
 ```
 
 MySQL keys off any unique index implicitly (no conflict target). SqlArtisan
-emits the 8.0.19+ row-alias form (`AS new` … `new.column`) to avoid the
-deprecated `VALUES()` function.
+emits the row-alias form (`AS new` … `new.column`) to avoid the deprecated
+`VALUES()` function; MySQL added the row alias in a specific release — see the
+[version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs).
 
 **Note:** `ON CONFLICT` is PostgreSQL/SQLite-only and `ON DUPLICATE KEY UPDATE`
 is MySQL-only. Oracle and SQL Server use [`MERGE`](#merge-statement) instead.
@@ -2893,9 +2894,10 @@ SqlStatement sql =
 > **How to read this reference.** Each entry maps a C# API to the SQL token it emits.
 > Pick the API for your target DBMS; a single call is not rewritten per dialect.
 > Dialect notes list databases in the order **MySQL, Oracle, PostgreSQL, SQLite, SQL Server**.
-> Where a dialect note names a construct without saying since when, the
-> [version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs)
-> has the minimum engine version, kept in sync by a test.
+> Notes say which dialects accept a construct, never from which version; where
+> a minimum engine version is recorded, it lives in the
+> [version-bound register](https://github.com/h-tacayama/SqlArtisan/blob/main/docs/analyzer.md#version-bound-constructs),
+> kept in sync by a test.
 
 ## Contents
 
@@ -2911,16 +2913,16 @@ SqlArtisan provides C# APIs that map to various SQL functions, enabling you to u
 - `Abs()` for `ABS`
 - `Ceil()` for `CEIL` (Oracle; MySQL/PostgreSQL/SQLite accept both spellings)
 - `Ceiling()` for `CEILING` (SQL Server; MySQL/PostgreSQL/SQLite accept both spellings)
-- `Exp()` for `EXP` (SQLite)
-- `Floor()` for `FLOOR` (SQLite)
-- `Ln()` for `LN` (SQLite; not supported by SQL Server — its `LOG(x)` is the natural logarithm)
+- `Exp()` for `EXP`
+- `Floor()` for `FLOOR`
+- `Ln()` for `LN` (not supported by SQL Server — its `LOG(x)` is the natural logarithm)
 - `Log(x)` for `LOG(x)`; `Log(base, x)` for `LOG(base, x)` — **the base differs per dialect, see below**
-- `Log10()` for `LOG10` (PostgreSQL, SQLite; not supported by Oracle — spell it `Log(10, x)` there)
-- `Mod()` for `MOD` (SQLite; not supported by SQL Server — use the `%` operator there)
-- `Power()` for `POWER` (SQLite)
+- `Log10()` for `LOG10` (not supported by Oracle — spell it `Log(10, x)` there)
+- `Mod()` for `MOD` (not supported by SQL Server — use the `%` operator there)
+- `Power()` for `POWER`
 - `Round()` for `ROUND` (single-argument `Round(expr)` is not supported by SQL Server — pass the scale explicitly there)
-- `Sign()` for `SIGN` (SQLite)
-- `Sqrt()` for `SQRT` (SQLite)
+- `Sign()` for `SIGN`
+- `Sqrt()` for `SQRT`
 - `Trunc()` for `TRUNC` (Numeric Overload; Oracle, PostgreSQL, SQLite — the two-argument scale form is Oracle/PostgreSQL only)
 
 > [!WARNING]
@@ -2931,7 +2933,7 @@ SqlArtisan provides C# APIs that map to various SQL functions, enabling you to u
 > | `Log(x)` → `LOG(x)` | base e | *(rejected)* | base 10 | base 10 | base e |
 > | `Log(b, x)` → `LOG(b, x)` | log<sub>b</sub>x | log<sub>b</sub>x | log<sub>b</sub>x | log<sub>b</sub>x | log<sub>x</sub>b |
 >
-> SQL Server's row inverts (value first, base second). For a base that does not vary: `Ln(x)` (MySQL, Oracle, PostgreSQL, SQLite), `Log10(x)` (MySQL, PostgreSQL, SQLite, SQL Server), or `Log(base, x)` on the four base-first engines (SQLite).
+> SQL Server's row inverts (value first, base second). For a base that does not vary: `Ln(x)` (MySQL, Oracle, PostgreSQL, SQLite), `Log10(x)` (MySQL, PostgreSQL, SQLite, SQL Server), or `Log(base, x)` on the four base-first engines.
 
 `SQLA0100` also flags every two-argument `Log` call on SQL Server — blind to
 argument order — including the correct T-SQL spelling: call `Log(base, x)`
@@ -2946,7 +2948,7 @@ not at the SqlArtisan layer.
 
 ## Character Functions
 
-- `Concat(a, b)` for `CONCAT(a, b)`; `Concat(a, b, c, ...)` for `CONCAT(a, b, c, ...)` (SQLite; Oracle takes only the two-argument form — see below)
+- `Concat(a, b)` for `CONCAT(a, b)`; `Concat(a, b, c, ...)` for `CONCAT(a, b, c, ...)` (Oracle takes only the two-argument form — see below)
 - `ConcatWs(sep, a, b, ...)` for `CONCAT_WS(sep, a, b, ...)` (MySQL, PostgreSQL, SQLite, SQL Server)
 - `CharLength()` for `CHAR_LENGTH` (MySQL, PostgreSQL)
 - `Instr()` for `INSTR` (MySQL, Oracle, SQLite; the 3- and 4-argument forms are Oracle-only)
@@ -2969,7 +2971,7 @@ not at the SqlArtisan layer.
 - `Substr()` for `SUBSTR` (not supported by SQL Server — use `Substring()` there)
 - `Substrb()` for `SUBSTRB` (Oracle)
 - `Substring()` for `SUBSTRING` (MySQL, PostgreSQL, SQLite, SQL Server; on Oracle use `Substr()`)
-- `Trim()` for `TRIM` (SQL Server; the two-argument trim-set form is not supported by SQLite — nest `Ltrim()`/`Rtrim()` there)
+- `Trim()` for `TRIM` (the two-argument trim-set form is not supported by SQLite — nest `Ltrim()`/`Rtrim()` there)
 - `Upper()` for `UPPER`
 
 On Oracle, chain two-argument `Concat(a, b)` calls (`Concat(Concat(a, b), c)`)


### PR DESCRIPTION
## Summary

Follow-up to #479 (ADR 0020), which adopted the documentation precision
boundary and applied it to the sections that PR touched. This closes #480 by
applying it to the rest of the corpus.

### 1ec16d9 — retire the floors

- Retired every version-floor mention across `docs/functions.md`,
  `docs/query-statements.md`, `docs/expressions.md`, and `docs/cookbook.md`.
- Where a floor is backed by `docs/analyzer.md`'s version-bound register
  (MySQL's `WithRecursive`/`JsonValue`/row-alias UPSERT, Oracle's vector
  operators, PostgreSQL's `MERGE`, SQLite's `RETURNING`/`STRING_AGG`), the
  section now links the register instead of restating a number nothing keeps
  current.
- Where a floor named no matrix row at all — Oracle's `LATERAL`/`OFFSET`/
  `FETCH`, SQLite's `UPDATE … FROM`, SQL Server's multi-row `VALUES`, the
  window-function frame requirement — the version is simply dropped; the
  frame bullet's "requires MySQL, Oracle, PostgreSQL, SQLite, or SQL Server"
  became vacuous with no version left, so that line is removed rather than
  kept as a no-op.
- Two section headings lost their version suffix (`OFFSET/FETCH family`,
  `STRING_AGG`), moving their anchors; `check_links.py` confirms nothing
  linked to the old anchors.

### f0bbda5 — fix the dialect claims the sweep inverted

Review of the first commit found its mechanical rule — drop the version token,
keep the parenthetical — correct only where the parenthetical was a *support
list carrying a floor*. On these pages an unqualified dialect list means "only
there" (`Lengthb()` … (Oracle), `Datetrunc()` … (SQL Server)), so where the
parenthetical had annotated **one dialect's floor on a construct every dialect
accepts**, stripping the version stated a support set `DialectMatrix`
contradicts:

| Entry | Was | Sweep produced | `DialectMatrix.Entries` |
|---|---|---|---|
| `Exp`/`Floor`/`Power`/`Sqrt`/`Sign` | `(SQLite 3.35+)` | `(SQLite)` | `DbmsSupport.All` |
| `Trim` (1-arg) | `(SQL Server 2017+; …)` | `(SQL Server; …)` | `DbmsSupport.All` |
| `Concat` (variadic) | `(SQLite 3.44+; …)` | `(SQLite; …)` | arity-2 `All` |
| `Ln` | `(SQLite 3.35+; …)` | `(SQLite; …)` | all but SQL Server |
| `Log10` | `(PostgreSQL 12+, SQLite 3.35+; …)` | `(PostgreSQL, SQLite; …)` | all but Oracle |

Those notes now go entirely — which is what the page already does for `Abs`,
`Coalesce` and `Replace`. The `LOG` warning table had also drifted out of
agreement with the entries above it, and its "four base-first engines (SQLite)"
clause had become self-contradictory once the version left.

Four more, found in the same pass:

- The OFFSET/FETCH bullet's "available on Oracle 12c+ / SQL Server 2012+" had
  listed the two engines with floors; with the versions gone it read as an
  availability claim that dropped PostgreSQL, contradicting its own heading
  and the bullet above it.
- The MySQL row-alias UPSERT floor survived the sweep in
  `docs/query-statements.md` though its twin in `docs/cookbook.md` was
  stripped; it is register-backed, so it links the register now.
- The `LATERAL` sentence kept "a boolean literal Oracle lacks before 23c"
  after losing its other floor. `DialectMatrix` deliberately records no bound
  for `LeftJoinLateral`, so the register cannot host that boundary.
- `docs/functions.md`'s new preamble promised the register has a minimum
  version for every construct whose note omits one; most carry no bound at all.

`llms-full.txt` regenerated per the header comment in
`tests/SqlArtisan.Tests/LlmsFullTests.cs`.

## Test plan

- [x] `dotnet build src/SqlArtisan/SqlArtisan.csproj -c Release` — 0 warnings,
      0 errors
- [x] `dotnet test tests/SqlArtisan.Tests` — 1045 passed
- [x] `dotnet test tests/SqlArtisan.Analyzers.Tests` — 1082 passed
- [x] `dotnet format SqlArtisan.sln --verify-no-changes` — exit 0
- [x] `python3 .claude/skills/sa-docs-audit/scripts/check_links.py` — all
      intra-doc anchor links resolve
- [x] `python3 .claude/skills/sa-docs-audit/scripts/check_terms.py` — no
      terminology/formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzYTnhkQsYiN6jRvpj1UP2